### PR TITLE
CSVReader handles double quotes correctly

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
         <version>2.0.2</version>
     </parent>
     <artifactId>sirius-kernel</artifactId>
-    <version>2.4</version>
+    <version>2.4.1</version>
     <name>Sirius Kernel</name>
     <description>Provides common core classes and the microkernel powering all Sirius applications</description>
 

--- a/src/main/java/sirius/kernel/commons/CSVReader.java
+++ b/src/main/java/sirius/kernel/commons/CSVReader.java
@@ -197,6 +197,7 @@ public class CSVReader {
                 result = new StringBuilder();
             }
         }
+
         while (shouldContinueField(inQuote)) {
             if (buffer == escape) {
                 read();
@@ -208,8 +209,7 @@ public class CSVReader {
             }
             read();
         }
-        if (inQuote && buffer == quotation) {
-            read();
+        if (inQuote) {
             while (buffer == ' ' || buffer == '\t') {
                 read();
             }
@@ -221,12 +221,16 @@ public class CSVReader {
     /*
      * Determines if the current buffer value should be added to the field (column) content.
      */
-    private boolean shouldContinueField(boolean inQuote) {
+    private boolean shouldContinueField(boolean inQuote) throws IOException {
         if (isEOF()) {
             return false;
         }
 
         if (inQuote) {
+            if (buffer == quotation) {
+                read();
+                return buffer == quotation;
+            }
             return buffer != quotation;
         } else {
             return buffer != separator && !isAtNewline();

--- a/src/test/java/sirius/kernel/commons/CSVReaderSpec.groovy
+++ b/src/test/java/sirius/kernel/commons/CSVReaderSpec.groovy
@@ -182,4 +182,22 @@ class CSVReaderSpec extends BaseSpecification {
         output.get(0).at("C") == ":c"
     }
 
+    def "quoted strings treat double quotes as escaped quote"() {
+        given:
+        def data = '"test""X""";"a";b""';
+        when:
+        List<Values> output = [];
+        and:
+        new CSVReader(new StringReader(data))
+                .execute(({ row -> output.add(row) } as Consumer<Values>))
+        then:
+        output.size() == 1
+        and:
+        output.get(0).at("A") == 'test"X"'
+        and:
+        output.get(0).at("B") == "a"
+        and:
+        output.get(0).at("C") == 'b""'
+    }
+
 }


### PR DESCRIPTION
Some csv generators use a doulbe quote ("") in a quoted string to
escape a single quote. (PROFICL@SS does that in their csv files)