### PR TITLE
Strings.join now ignores null and empty values

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
         <version>2.0.2</version>
     </parent>
     <artifactId>sirius-kernel</artifactId>
-    <version>2.4.1</version>
+    <version>2.4.2</version>
     <name>Sirius Kernel</name>
     <description>Provides common core classes and the microkernel powering all Sirius applications</description>
 

--- a/src/main/java/sirius/kernel/commons/Strings.java
+++ b/src/main/java/sirius/kernel/commons/Strings.java
@@ -271,7 +271,8 @@ public class Strings {
      * Returns a string concatenation of the given lists items.
      * <p>
      * Generates a string which contains the string representation of each item separated by the given separator.
-     * The conversion method for the list items used is {@link NLS#toMachineString(Object)}.
+     * The conversion method for the list items used is {@link NLS#toMachineString(Object)}. This method will filter
+     * empty values (<tt>""</tt> or <tt>null</tt>) and ignore those.
      *
      * @param list      the list items to join
      * @param separator the separator to place between the items
@@ -284,10 +285,12 @@ public class Strings {
         if (list != null) {
             Monoflop mf = Monoflop.create();
             for (Object item : list) {
-                if (mf.successiveCall()) {
-                    result.append(separator);
+                if (Strings.isFilled(item)) {
+                    if (mf.successiveCall()) {
+                        result.append(separator);
+                    }
+                    result.append(NLS.toMachineString(item));
                 }
-                result.append(NLS.toMachineString(item));
             }
         }
 

--- a/src/test/java/sirius/kernel/commons/StringsTest.java
+++ b/src/test/java/sirius/kernel/commons/StringsTest.java
@@ -52,7 +52,7 @@ public class StringsTest {
     @Test
     public void apply() {
         assertEquals("B A", Strings.apply("%s A", "B"));
-        assertEquals("A null", Strings.apply("A %s", (String)null));
+        assertEquals("A null", Strings.apply("A %s", (String) null));
     }
 
     @Test
@@ -63,7 +63,7 @@ public class StringsTest {
         assertEquals("A", Strings.firstFilled("", "A"));
         assertEquals("A", Strings.firstFilled(null, null, "A"));
         assertNull(Strings.firstFilled());
-        assertNull(Strings.firstFilled((String)null));
+        assertNull(Strings.firstFilled((String) null));
         assertNull(Strings.firstFilled(""));
     }
 
@@ -83,6 +83,15 @@ public class StringsTest {
     }
 
     @Test
+    public void join() {
+        assertEquals("A,B,C", Strings.join(",", "A", "B", "C"));
+        assertEquals("A,C", Strings.join(",", "A", null, "", "C"));
+        assertEquals("A", Strings.join(",", "A"));
+        assertEquals("", Strings.join(","));
+        assertEquals("ABC", Strings.join("", "A", "B", "C"));
+    }
+
+    @Test
     public void toSaneFilename() {
         assertEquals(Strings.toSaneFileName("test.pdf").orElse(""), "test.pdf");
         assertEquals(Strings.toSaneFileName("test").orElse(""), "test");
@@ -99,5 +108,4 @@ public class StringsTest {
         assertEquals(Strings.toSaneFileName("   "), Optional.<String>empty());
         assertEquals(Strings.toSaneFileName(""), Optional.<String>empty());
     }
-
 }


### PR DESCRIPTION
While not backward compatible, this is really the expected behaviour
for this method.