### PR TITLE
Introduction of event handling

### DIFF
--- a/src/main/java/sirius/kernel/event/EventBus.java
+++ b/src/main/java/sirius/kernel/event/EventBus.java
@@ -1,0 +1,56 @@
+/*
+ * Made with all the love in the world
+ * by scireum in Remshalden, Germany
+ *
+ * Copyright by scireum GmbH
+ * http://www.scireum.de - info@scireum.de
+ */
+
+package sirius.kernel.event;
+
+import sirius.kernel.commons.Strings;
+import sirius.kernel.di.PartCollection;
+import sirius.kernel.di.std.Parts;
+import sirius.kernel.di.std.Register;
+import sirius.kernel.health.Exceptions;
+
+/**
+ * Event bus handling fired events.
+ * <p/>
+ * Checks every fired event against all registered
+ * {@link EventHandler} and triggers the handle function
+ * in the matching handlers.
+ */
+
+@Register(classes = EventBus.class)
+public class EventBus {
+
+    /**
+     * Contains all registered {@link EventHandler}
+     */
+    @Parts(EventHandler.class)
+    private PartCollection<EventHandler> handlers;
+
+    /**
+     * Forwards the given object to the matching handler
+     *
+     * @param event  name of the event {@link EventHandler} is listening on
+     * @param object passed to the matching {@link EventHandler}
+     */
+    public void fireEvent(String event, Object object) {
+        if (Strings.isFilled(event)) {
+            for (EventHandler handler : handlers.getParts()) {
+                if (Strings.areEqual(event, handler.getEvent())) {
+                    try {
+                        handler.handle(event, object);
+                    } catch (Throwable e) {
+                        Exceptions.handle()
+                                  .withSystemErrorMessage("Error while handling event '%s': %s (%s)", event)
+                                  .error(e)
+                                  .handle();
+                    }
+                }
+            }
+        }
+    }
+}

--- a/src/main/java/sirius/kernel/event/EventBus.java
+++ b/src/main/java/sirius/kernel/event/EventBus.java
@@ -16,7 +16,7 @@ import sirius.kernel.health.Exceptions;
 
 /**
  * Event bus handling fired events.
- * <p/>
+ * <p>
  * Checks every fired event against all registered
  * {@link EventHandler} and triggers the handle function
  * in the matching handlers.
@@ -25,30 +25,28 @@ import sirius.kernel.health.Exceptions;
 @Register(classes = EventBus.class)
 public class EventBus {
 
-    /**
-     * Contains all registered {@link EventHandler}
-     */
     @Parts(EventHandler.class)
     private PartCollection<EventHandler> handlers;
 
     /**
      * Forwards the given object to the matching handler
      *
-     * @param event  name of the event {@link EventHandler} is listening on
+     * @param event  name of the event the {@link EventHandler} is listening on
      * @param object passed to the matching {@link EventHandler}
      */
     public void fireEvent(String event, Object object) {
-        if (Strings.isFilled(event)) {
-            for (EventHandler handler : handlers.getParts()) {
-                if (Strings.areEqual(event, handler.getEvent())) {
-                    try {
-                        handler.handle(event, object);
-                    } catch (Throwable e) {
-                        Exceptions.handle()
-                                  .withSystemErrorMessage("Error while handling event '%s': %s (%s)", event)
-                                  .error(e)
-                                  .handle();
-                    }
+        if (Strings.isEmpty(event)) {
+            return;
+        }
+        for (EventHandler handler : handlers.getParts()) {
+            if (Strings.areEqual(event, handler.getEvent())) {
+                try {
+                    handler.handle(event, object);
+                } catch (Throwable e) {
+                    Exceptions.handle()
+                              .withSystemErrorMessage("Error while handling event '%s': %s (%s)", event)
+                              .error(e)
+                              .handle();
                 }
             }
         }

--- a/src/main/java/sirius/kernel/event/EventBus.java
+++ b/src/main/java/sirius/kernel/event/EventBus.java
@@ -16,7 +16,7 @@ import sirius.kernel.health.Exceptions;
 
 /**
  * Event bus handling fired events.
- * <p>
+ *
  * Checks every fired event against all registered
  * {@link EventHandler} and triggers the handle function
  * in the matching handlers.

--- a/src/main/java/sirius/kernel/event/EventHandler.java
+++ b/src/main/java/sirius/kernel/event/EventHandler.java
@@ -9,9 +9,10 @@
 package sirius.kernel.event;
 
 /**
- * Interface of EventHandler handling an event
- * The implementing class needs to be registered
- * as {@link EventHandler} in order to be
+ * Handles events dispatched by the {@link EventHandler}
+ * <p>
+ * Implementing classes need to be registered using
+ * {@link sirius.kernel.di.std.Register} in order to be
  * recognized by the {@link EventBus}
  *
  * @param <E> type of class handled by the implementing handler
@@ -20,7 +21,6 @@ public interface EventHandler<E> {
 
     /**
      * Name of event the handler is listening on
-     * {@link EventBus}
      *
      * @return name of event
      */

--- a/src/main/java/sirius/kernel/event/EventHandler.java
+++ b/src/main/java/sirius/kernel/event/EventHandler.java
@@ -1,0 +1,36 @@
+/*
+ * Made with all the love in the world
+ * by scireum in Remshalden, Germany
+ *
+ * Copyright by scireum GmbH
+ * http://www.scireum.de - info@scireum.de
+ */
+
+package sirius.kernel.event;
+
+/**
+ * Interface of EventHandler handling an event
+ * The implementing class needs to be registered
+ * as {@link EventHandler} in order to be
+ * recognized by the {@link EventBus}
+ *
+ * @param <E> type of class handled by the implementing handler
+ */
+public interface EventHandler<E> {
+
+    /**
+     * Name of event the handler is listening on
+     * {@link EventBus}
+     *
+     * @return name of event
+     */
+    String getEvent();
+
+    /**
+     * Method handling a matching event
+     *
+     * @param event  name of the matching event
+     * @param object fired with the event
+     */
+    void handle(String event, E object);
+}

--- a/src/main/java/sirius/kernel/event/EventHandler.java
+++ b/src/main/java/sirius/kernel/event/EventHandler.java
@@ -10,7 +10,7 @@ package sirius.kernel.event;
 
 /**
  * Handles events dispatched by the {@link EventHandler}
- * <p>
+ * 
  * Implementing classes need to be registered using
  * {@link sirius.kernel.di.std.Register} in order to be
  * recognized by the {@link EventBus}

--- a/src/test/java/sirius/kernel/event/FireEventSpec.groovy
+++ b/src/test/java/sirius/kernel/event/FireEventSpec.groovy
@@ -12,7 +12,7 @@ import sirius.kernel.BaseSpecification
 import sirius.kernel.di.std.Part
 
 
-class FireEventTest extends BaseSpecification{
+class FireEventSpec extends BaseSpecification {
 
     @Part
     private static EventBus eventBus;

--- a/src/test/java/sirius/kernel/event/FireEventTest.groovy
+++ b/src/test/java/sirius/kernel/event/FireEventTest.groovy
@@ -1,0 +1,42 @@
+/*
+ * Made with all the love in the world
+ * by scireum in Remshalden, Germany
+ *
+ * Copyright by scireum GmbH
+ * http://www.scireum.de - info@scireum.de
+ */
+
+package sirius.kernel.event
+
+import sirius.kernel.BaseSpecification
+import sirius.kernel.di.std.Part
+
+
+class FireEventTest extends BaseSpecification{
+
+    @Part
+    private static EventBus eventBus;
+
+    def "Fire matching event"() {
+        given:
+        TestEventHandler.testString = "String-call"
+        and:
+        "String-call".equals(TestEventHandler.testString)
+        when:
+        eventBus.fireEvent("String-call", "String-call_completed")
+        then: "Event should be handled"
+        "String-call_completed".equals(TestEventHandler.testString)
+    }
+
+    def "Fire non-matching event"() {
+        given:
+        TestEventHandler.testString = "String-call"
+        and:
+        "String-call".equals(TestEventHandler.testString)
+        when:
+        eventBus.fireEvent("non-String-call", "non-String-call_completed")
+        then: "Event should not be handled"
+        "String-call".equals(TestEventHandler.testString)
+    }
+
+}

--- a/src/test/java/sirius/kernel/event/TestEventHandler.java
+++ b/src/test/java/sirius/kernel/event/TestEventHandler.java
@@ -10,7 +10,7 @@ package sirius.kernel.event;
 
 import sirius.kernel.di.std.Register;
 
-@Register(classes = EventHandler.class)
+@Register
 public class TestEventHandler implements EventHandler<String>{
 
     public static String testString = "beforeTest";

--- a/src/test/java/sirius/kernel/event/TestEventHandler.java
+++ b/src/test/java/sirius/kernel/event/TestEventHandler.java
@@ -1,0 +1,27 @@
+/*
+ * Made with all the love in the world
+ * by scireum in Remshalden, Germany
+ *
+ * Copyright by scireum GmbH
+ * http://www.scireum.de - info@scireum.de
+ */
+
+package sirius.kernel.event;
+
+import sirius.kernel.di.std.Register;
+
+@Register(classes = EventHandler.class)
+public class TestEventHandler implements EventHandler<String>{
+
+    public static String testString = "beforeTest";
+
+    @Override
+    public String getEvent() {
+        return "String-call";
+    }
+
+    @Override
+    public void handle(String event, String object) {
+        testString = object;
+    }
+}

--- a/src/test/java/sirius/kernel/event/TestEventHandler.java
+++ b/src/test/java/sirius/kernel/event/TestEventHandler.java
@@ -11,7 +11,7 @@ package sirius.kernel.event;
 import sirius.kernel.di.std.Register;
 
 @Register
-public class TestEventHandler implements EventHandler<String>{
+public class TestEventHandler implements EventHandler<String> {
 
     public static String testString = "beforeTest";
 


### PR DESCRIPTION
Now it is possible to fire events and let them be handled by implementations of the EventHandler interface.
Import the EventBus via Part annotation in order to fire an event which will be handled by registered EventHandler implementations.