### PR TITLE
Lets SubContexts control how to behave when their CallContext is forked.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
         <version>3.2</version>
     </parent>
     <artifactId>sirius-kernel</artifactId>
-    <version>2.16</version>
+    <version>3.0</version>
     <name>Sirius Kernel</name>
     <description>Provides common core classes and the microkernel powering all Sirius applications</description>
 

--- a/src/main/java/sirius/kernel/async/CallContext.java
+++ b/src/main/java/sirius/kernel/async/CallContext.java
@@ -169,7 +169,7 @@ public class CallContext {
         CallContext newCtx = initialize(mdc.get(MDC_FLOW));
         newCtx.watch = watch;
         newCtx.mdc.put(MDC_PARENT, mdc.get(TaskContext.MDC_SYSTEM));
-        newCtx.subContext.putAll(subContext);
+        subContext.entrySet().forEach(e -> newCtx.subContext.put(e.getKey(), e.getValue().fork()));
         newCtx.lang = lang;
     }
 

--- a/src/main/java/sirius/kernel/async/SubContext.java
+++ b/src/main/java/sirius/kernel/async/SubContext.java
@@ -14,6 +14,14 @@ package sirius.kernel.async;
 public interface SubContext {
 
     /**
+     * Returns an instance which is used in a forked {@link CallContext}.
+     *
+     * @return either the instance itself - if can or has to be used in both threads - or clone or copy of the instance
+     * which replicates the current state
+     */
+    SubContext fork();
+
+    /**
      * Gets notified if the associated CallContext is detached.
      */
     void detach();

--- a/src/main/java/sirius/kernel/async/TaskContext.java
+++ b/src/main/java/sirius/kernel/async/TaskContext.java
@@ -300,6 +300,14 @@ public class TaskContext implements SubContext {
     }
 
     @Override
+    public SubContext fork() {
+        TaskContext child = new TaskContext();
+        child.adapter = adapter;
+
+        return child;
+    }
+
+    @Override
     public void detach() {
     }
 }


### PR DESCRIPTION
Lets SubContexts control how to behave when their CallContext is forked.

If a CallContext is forked, all sub context were originally just also added to the forked context.
However, in some cases - UserContext in sirius-web e.g. - a copy behaviour where both
 contexts can be modified independently, would be much more transparent.
 Therefore we now provide a fork method, which can deciede what to do.