### PR TITLE
As the JVM loves to fill up the heap until it is really maxed out.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
         <version>3.2</version>
     </parent>
     <artifactId>sirius-kernel</artifactId>
-    <version>3.3.1</version>
+    <version>3.3.2</version>
     <name>Sirius Kernel</name>
     <description>Provides common core classes and the microkernel powering all Sirius applications</description>
 

--- a/src/main/resources/component-kernel.conf
+++ b/src/main/resources/component-kernel.conf
@@ -240,12 +240,12 @@ health {
         # Heap usage in %
         jvm-heap.gray = 50
         jvm-heap.warning = 75
-        jvm-heap.error = 95
+        jvm-heap.error = 99
 
         # Old gen usage in %
         jvm-old-heap.gray = 50
         jvm-old-heap.warning = 75
-        jvm-old-heap.error = 95
+        jvm-old-heap.error = 99
 
         # Number of garbage collections performed
         jvm-gc.gray = 25


### PR DESCRIPTION
As the JVM loves to fill up the heap until it is really maxed out.