### PR TITLE
Changes the warnings for log file size.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
         <version>3.7.1</version>
     </parent>
     <artifactId>sirius-kernel</artifactId>
-    <version>4.0</version>
+    <version>4.0.1</version>
     <name>Sirius Kernel</name>
     <description>Provides common core classes and the microkernel powering all Sirius applications</description>
 

--- a/src/main/resources/component-kernel.conf
+++ b/src/main/resources/component-kernel.conf
@@ -214,8 +214,8 @@ health {
 
         # Size of all log files in mb
         sys-log-size.gray = 32
-        sys-log-size.warning = 64
-        sys-log-size.error = 128
+        sys-log-size.warning = 128
+        sys-log-size.error = 0
 
         # Filesystem usage in %
         sys-fs.gray = 80


### PR DESCRIPTION
Changes the warnings for log file size.

We now warn at 128 MB but we will not report
an error because as long as enough free disk
space is available, this isn't a fault condition