### PR TITLE
Avoid NPE on comparing two Amounts

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
         <version>3.8.3</version>
     </parent>
     <artifactId>sirius-kernel</artifactId>
-    <version>4.2</version>
+    <version>4.2.1</version>
     <name>Sirius Kernel</name>
     <description>Provides common core classes and the microkernel powering all Sirius applications</description>
 

--- a/src/main/java/sirius/kernel/commons/Amount.java
+++ b/src/main/java/sirius/kernel/commons/Amount.java
@@ -481,6 +481,9 @@ public class Amount implements Comparable<Amount> {
         if (Objects.equals(amount, o.amount)) {
             return 0;
         }
+        if (o.amount == null) {
+            return 1;
+        }
         if (amount == null) {
             return -1;
         }

--- a/src/test/java/sirius/kernel/commons/AmountSpec.groovy
+++ b/src/test/java/sirius/kernel/commons/AmountSpec.groovy
@@ -114,4 +114,14 @@ class AmountSpec extends BaseSpecification {
         Amount.ZERO.max(Amount.NOTHING) == Amount.ZERO
     }
 
+    def "compare returns which amount is higher"() {
+        expect:
+        Amount.NOTHING.compareTo(Amount.NOTHING) == 0
+        Amount.ONE.compareTo(Amount.NOTHING) > 0
+        Amount.NOTHING.compareTo(Amount.ONE) < 0
+        Amount.ONE.compareTo(Amount.ONE) == 0
+        Amount.ONE.compareTo(Amount.MINUS_ONE) > 0
+        Amount.MINUS_ONE.compareTo(Amount.ONE) < 0
+    }
+
 }


### PR DESCRIPTION
The compareTo method of Amount caused a NPE if the other Amount was of type Amount.NOTHING as null was passed as value to BigDecimal.compareTo.