### PR TITLE
Adds fallback language for translations

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
         <version>3.9</version>
     </parent>
     <artifactId>sirius-kernel</artifactId>
-    <version>5.0.2</version>
+    <version>5.1</version>
     <name>Sirius Kernel</name>
     <description>Provides common core classes and the microkernel powering all Sirius applications</description>
 

--- a/src/main/java/sirius/kernel/async/CallContext.java
+++ b/src/main/java/sirius/kernel/async/CallContext.java
@@ -177,7 +177,7 @@ public class CallContext {
         newCtx.mdc.put(MDC_PARENT, mdc.get(TaskContext.MDC_SYSTEM));
         subContext.entrySet().forEach(e -> newCtx.subContext.put(e.getKey(), e.getValue().fork()));
         newCtx.lang = lang;
-        newCtx.fallBackLang = fallBackLang;
+        newCtx.fallbackLang = fallbackLang;
         return newCtx;
     }
 
@@ -229,7 +229,7 @@ public class CallContext {
     private Map<Class<? extends SubContext>, SubContext> subContext = Collections.synchronizedMap(Maps.newHashMap());
     private Watch watch = Watch.start();
     private String lang = NLS.getDefaultLanguage();
-    private String fallBackLang;
+    private String fallbackLang;
 
     /**
      * Returns the current mapped diagnostic context (MDC).
@@ -338,8 +338,8 @@ public class CallContext {
      * @return a two-letter language code used for the current thread.
      */
     @Nullable
-    public String getFallBackLang() {
-        return fallBackLang;
+    public String getFallbackLang() {
+        return fallbackLang;
     }
 
     /**
@@ -358,16 +358,11 @@ public class CallContext {
 
     /**
      * Sets the current fallback language for the current thread.
-     * <p>
-     * If <tt>null</tt> or an empty string is passed in, the fallback language will not be changed.
-     * </p>
      *
-     * @param fallBackLang the two-letter language code for this thread.
+     * @param fallbackLang the two-letter language code for this thread.
      */
-    public void setFallBackLang(@Nullable String fallBackLang) {
-        if (Strings.isFilled(fallBackLang)) {
-            this.fallBackLang = fallBackLang;
-        }
+    public void setFallbackLang(@Nullable String fallbackLang) {
+        this.fallbackLang = fallbackLang;
     }
 
     @Override

--- a/src/main/java/sirius/kernel/async/CallContext.java
+++ b/src/main/java/sirius/kernel/async/CallContext.java
@@ -177,6 +177,7 @@ public class CallContext {
         newCtx.mdc.put(MDC_PARENT, mdc.get(TaskContext.MDC_SYSTEM));
         subContext.entrySet().forEach(e -> newCtx.subContext.put(e.getKey(), e.getValue().fork()));
         newCtx.lang = lang;
+        newCtx.fallBackLang = fallBackLang;
         return newCtx;
     }
 
@@ -228,6 +229,7 @@ public class CallContext {
     private Map<Class<? extends SubContext>, SubContext> subContext = Collections.synchronizedMap(Maps.newHashMap());
     private Watch watch = Watch.start();
     private String lang = NLS.getDefaultLanguage();
+    private String fallBackLang;
 
     /**
      * Returns the current mapped diagnostic context (MDC).
@@ -331,6 +333,16 @@ public class CallContext {
     }
 
     /**
+     * Returns the current fallback language determined for the current thread.
+     *
+     * @return a two-letter language code used for the current thread.
+     */
+    @Nullable
+    public String getFallBackLang() {
+        return fallBackLang;
+    }
+
+    /**
      * Sets the current language for the current thread.
      * <p>
      * If <tt>null</tt> or an empty string is passed in, the language will not be changed.
@@ -341,6 +353,20 @@ public class CallContext {
     public void setLang(@Nullable String lang) {
         if (Strings.isFilled(lang)) {
             this.lang = lang;
+        }
+    }
+
+    /**
+     * Sets the current fallback language for the current thread.
+     * <p>
+     * If <tt>null</tt> or an empty string is passed in, the fallback language will not be changed.
+     * </p>
+     *
+     * @param fallBackLang the two-letter language code for this thread.
+     */
+    public void setFallBackLang(@Nullable String fallBackLang) {
+        if (Strings.isFilled(fallBackLang)) {
+            this.fallBackLang = fallBackLang;
         }
     }
 

--- a/src/main/java/sirius/kernel/nls/NLS.java
+++ b/src/main/java/sirius/kernel/nls/NLS.java
@@ -135,12 +135,12 @@ public class NLS {
      * @return the language code of the fallback language
      */
     @Nonnull
-    public static String getFallBackLanguage() {
-        String fallBack = CallContext.getCurrent().getFallBackLang();
-        if (Strings.isEmpty(fallBack)) {
-            fallBack = NLS.getDefaultLanguage();
+    public static String getFallbackLanguage() {
+        String fallback = CallContext.getCurrent().getFallbackLang();
+        if (Strings.isEmpty(fallback)) {
+            fallback = getDefaultLanguage();
         }
-        return fallBack;
+        return fallback;
     }
 
     /**

--- a/src/main/java/sirius/kernel/nls/NLS.java
+++ b/src/main/java/sirius/kernel/nls/NLS.java
@@ -129,6 +129,21 @@ public class NLS {
     }
 
     /**
+     * Returns the two-letter code of the fall back language. Provided via the {@link CallContext}. If the value is
+     * empty, {@link NLS::getDefaultLanguage} is returned.
+     *
+     * @return the language code of the fallback language
+     */
+    @Nonnull
+    public static String getFallBackLanguage() {
+        String fallBack = CallContext.getCurrent().getFallBackLang();
+        if (Strings.isEmpty(fallBack)) {
+            fallBack = NLS.getDefaultLanguage();
+        }
+        return fallBack;
+    }
+
+    /**
      * Overrides the default language as defined in the configuration ({@code nls.defaultLanguage}).
      * <p>
      * This can be used to enforce the system language. However, setting nls.defaultLanguage to 'auto' is

--- a/src/main/java/sirius/kernel/nls/Translation.java
+++ b/src/main/java/sirius/kernel/nls/Translation.java
@@ -118,7 +118,7 @@ public class Translation {
         this.accessed = true;
         String result = translationTable.get(lang);
         if (result == null) {
-            result = translationTable.get(NLS.getDefaultLanguage());
+            result = translationTable.get(NLS.getFallBackLanguage());
         }
         if (result == null) {
             return key;

--- a/src/main/java/sirius/kernel/nls/Translation.java
+++ b/src/main/java/sirius/kernel/nls/Translation.java
@@ -118,7 +118,7 @@ public class Translation {
         this.accessed = true;
         String result = translationTable.get(lang);
         if (result == null) {
-            result = translationTable.get(NLS.getFallBackLanguage());
+            result = translationTable.get(NLS.getFallbackLanguage());
         }
         if (result == null) {
             return key;


### PR DESCRIPTION
If the fallback language is filled, this language will be prefered over the default language. If not, the default language is also the fallback language.