### PR TITLE
Initializes the looked up adapter types when checking for transformat…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
         <version>3.9</version>
     </parent>
     <artifactId>sirius-kernel</artifactId>
-    <version>5.5</version>
+    <version>5.6</version>
     <name>Sirius Kernel</name>
     <description>Provides common core classes and the microkernel powering all Sirius applications</description>
 

--- a/src/main/java/sirius/kernel/di/transformers/Composable.java
+++ b/src/main/java/sirius/kernel/di/transformers/Composable.java
@@ -60,7 +60,9 @@ public class Composable implements Transformable {
 
         if (components != null) {
             Object result = components.get(type);
-            return result != NULL && result != null;
+            if (result != null) {
+                return result != NULL;
+            }
         }
 
         return tryAs(type).isPresent();


### PR DESCRIPTION
…ions.

Before this, only the first looked up adapter type was cached,
following lookups for further adapter types always returned false
as the cache was checked for them.