### PR TITLE
Provides a faster way of creating an ExecutionPoint

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
         <version>3.9</version>
     </parent>
     <artifactId>sirius-kernel</artifactId>
-    <version>6.6</version>
+    <version>6.7</version>
     <name>Sirius Kernel</name>
     <description>Provides common core classes and the microkernel powering all Sirius applications</description>
 


### PR DESCRIPTION
For some usecases toString() will only be evaluated
when things go wrong. Therefore, when creating an
execution point, we want to do this as fast as possible.

By using an Exception instead of a fully blown array of
StackTraceElements, we implove the performance by a
factor of 4.