### PR TITLE
Makes it very easy to mock Parts when testing

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
         <version>3.9</version>
     </parent>
     <artifactId>sirius-kernel</artifactId>
-    <version>6.8</version>
+    <version>6.10</version>
     <name>Sirius Kernel</name>
     <description>Provides common core classes and the microkernel powering all Sirius applications</description>
 

--- a/src/test/java/sirius/kernel/TestHelper.java
+++ b/src/test/java/sirius/kernel/TestHelper.java
@@ -8,12 +8,17 @@
 
 package sirius.kernel;
 
+import sirius.kernel.di.GlobalContext;
+import sirius.kernel.di.std.Part;
 import sirius.kernel.nls.NLS;
 
 /**
  * Initializes and stops Sirius as part of the tests.
  */
 public class TestHelper {
+
+    @Part
+    private static GlobalContext ctx;
 
     private static Class<?> frameworkStarter = null;
 
@@ -35,6 +40,8 @@ public class TestHelper {
             frameworkStarter = testClass;
             Sirius.start(new Setup(Setup.Mode.TEST, Sirius.class.getClassLoader()));
             NLS.setDefaultLanguage("de");
+
+            ctx.getParts(TestMock.class).forEach(ctx::wire);
         }
     }
 

--- a/src/test/java/sirius/kernel/TestMock.java
+++ b/src/test/java/sirius/kernel/TestMock.java
@@ -1,0 +1,15 @@
+/*
+ * Made with all the love in the world
+ * by scireum in Remshalden, Germany
+ *
+ * Copyright by scireum GmbH
+ * http://www.scireum.de - info@scireum.de
+ */
+
+package sirius.kernel;
+
+/**
+ * Marker interface to mark a class as a mock of its superclass that should be replaced when in TEST environment
+ */
+public interface TestMock {
+}


### PR DESCRIPTION
Simply extend the class to be mocked an Register your new class as a `TestMock` class:
Said, you want to mock a class `Converter`, create the following class:

```
@Register(classes = {Converter.class, TestMock.class})
public class ConverterMock extends Converter implements TestMock {

    /**
     * doin' nothin' special
     */
    @Override
    public Result execute(Param param) {
        return 42;
    }
}
```

This injects `ConverterMock` to all places, where
```
@Part
private Converter converter;
```
would usually inject the original `Converter` class, but only when running in TEST mode (aka when calling `TestHelper.setUp()` from you TestSuite)