### PR TITLE
Fixes a wrong timeunit usage when initializing an inline cache

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
         <version>3.9</version>
     </parent>
     <artifactId>sirius-kernel</artifactId>
-    <version>6.8</version>
+    <version>6.8.1</version>
     <name>Sirius Kernel</name>
     <description>Provides common core classes and the microkernel powering all Sirius applications</description>
 

--- a/src/main/java/sirius/kernel/cache/CacheManager.java
+++ b/src/main/java/sirius/kernel/cache/CacheManager.java
@@ -123,7 +123,7 @@ public class CacheManager {
      * <p>
      * An inline cache can be used to compute a single value, which is then cached for a certain amount of time.
      *
-     * @param ttl      specifies the duration in seconds which the computed value will be cached
+     * @param ttl      specifies the duration which the computed value will be cached
      * @param computer the provider which is used to re-compute the value once it expired
      * @param <E>      the type of values being cached
      * @return an inline cache which keeps a computed value for the given amount of time and then uses the provided

--- a/src/main/java/sirius/kernel/cache/CacheManager.java
+++ b/src/main/java/sirius/kernel/cache/CacheManager.java
@@ -123,14 +123,14 @@ public class CacheManager {
      * <p>
      * An inline cache can be used to compute a single value, which is then cached for a certain amount of time.
      *
-     * @param ttl      specifies the duration which the computed value will be cached
+     * @param ttl      specifies the duration in seconds which the computed value will be cached
      * @param computer the provider which is used to re-compute the value once it expired
      * @param <E>      the type of values being cached
      * @return an inline cache which keeps a computed value for the given amount of time and then uses the provided
      * computer to re-compute the value
      */
     public static <E> InlineCache<E> createInlineCache(Duration ttl, Supplier<E> computer) {
-        return new InlineCache<>(computer, TimeUnit.MILLISECONDS.convert(ttl.getNano(), TimeUnit.NANOSECONDS));
+        return new InlineCache<>(computer, TimeUnit.MILLISECONDS.convert(ttl.getSeconds(), TimeUnit.SECONDS));
     }
 
     private static final Duration INLINE_CACHE_DEFAULT_TTL = Duration.ofSeconds(10);

--- a/src/main/java/sirius/kernel/cache/CacheManager.java
+++ b/src/main/java/sirius/kernel/cache/CacheManager.java
@@ -130,7 +130,7 @@ public class CacheManager {
      * computer to re-compute the value
      */
     public static <E> InlineCache<E> createInlineCache(Duration ttl, Supplier<E> computer) {
-        return new InlineCache<>(computer, TimeUnit.MILLISECONDS.convert(ttl.getSeconds(), TimeUnit.SECONDS));
+        return new InlineCache<>(computer, ttl.toMillis());
     }
 
     private static final Duration INLINE_CACHE_DEFAULT_TTL = Duration.ofSeconds(10);


### PR DESCRIPTION
just use toMillis() instead of convert()