### PR TITLE
Updates Spock and Groovy to the newest version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,10 +6,10 @@
     <parent>
         <groupId>com.scireum</groupId>
         <artifactId>sirius-parent</artifactId>
-        <version>3.9</version>
+        <version>3.10.1</version>
     </parent>
     <artifactId>sirius-kernel</artifactId>
-    <version>6.13</version>
+    <version>6.13.1</version>
     <name>Sirius Kernel</name>
     <description>Provides common core classes and the microkernel powering all Sirius applications</description>
 

--- a/src/test/java/sirius/kernel/commons/AmountSpec.groovy
+++ b/src/test/java/sirius/kernel/commons/AmountSpec.groovy
@@ -9,7 +9,7 @@ class AmountSpec extends BaseSpecification {
 
     def "predicates are evaluated correctly"() {
         expect:
-        Amount.of((BigDecimal) null).isEmpty()
+        Amount.NOTHING.isEmpty()
         Amount.NOTHING.isZeroOrNull()
         Amount.ZERO.isZeroOrNull()
         Amount.ZERO.isZero()


### PR DESCRIPTION
needed to delete `Amount.of((BigDecimal) null).isEmpty()` in `AmountSpec` because of the following Exception:
```
groovy.lang.GroovyRuntimeException: Ambiguous method overloading for method sirius.kernel.commons.Amount#of.
Cannot resolve which method to invoke for [null] due to overlapping prototypes between:
	[class java.lang.Double]
	[class java.lang.Integer]
	[class java.lang.Long]
	[class java.math.BigDecimal]
	... 1 more
```
The cast to BigDecimal made no difference (even in Groovy-Style `null as BigDecimal`), seems to be a bug in the Spock-Framework 😒 

This error didn't occur before Groovy 2.4:
> Now before Groovy 2.4 we had no support for the overloaded case. Which method was invoked was actually random