### PR TITLE
Uses the charsets property as default encoding value

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
         <version>3.10.1</version>
     </parent>
     <artifactId>sirius-kernel</artifactId>
-    <version>6.13.3</version>
+    <version>6.13.4</version>
     <name>Sirius Kernel</name>
     <description>Provides common core classes and the microkernel powering all Sirius applications</description>
 

--- a/src/main/java/sirius/kernel/xml/Outcall.java
+++ b/src/main/java/sirius/kernel/xml/Outcall.java
@@ -90,6 +90,7 @@ public class Outcall {
      */
     public Outcall postData(Context params, Charset charset) throws IOException {
         connection.setRequestMethod("POST");
+        this.charset = charset;
 
         OutputStreamWriter writer = new OutputStreamWriter(getOutput(), charset.name());
         StringBuilder sb = new StringBuilder();
@@ -222,7 +223,7 @@ public class Outcall {
      */
     public Charset getContentEncoding() {
         if (connection.getContentEncoding() == null) {
-            return Charsets.UTF_8;
+            return charset;
         }
         try {
             return Charset.forName(connection.getContentEncoding());


### PR DESCRIPTION
Fixes a bug where the encoding of the response is assumed as UTF-8 even though it wasn't.
Now the encoding is assumed to be the same as the encoding of the request.