### PR TITLE
Uses a HashMap instead of a TreeMap in the Context

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
         <version>3.10.1</version>
     </parent>
     <artifactId>sirius-kernel</artifactId>
-    <version>6.15</version>
+    <version>6.15.1</version>
     <name>Sirius Kernel</name>
     <description>Provides common core classes and the microkernel powering all Sirius applications</description>
 

--- a/src/main/java/sirius/kernel/commons/Context.java
+++ b/src/main/java/sirius/kernel/commons/Context.java
@@ -10,10 +10,7 @@ package sirius.kernel.commons;
 
 import javax.annotation.Nonnull;
 import javax.script.ScriptContext;
-import java.util.Collection;
-import java.util.Map;
-import java.util.Set;
-import java.util.TreeMap;
+import java.util.*;
 
 /**
  * Provides an execution context to scripts etc.
@@ -22,7 +19,7 @@ import java.util.TreeMap;
  */
 public class Context implements Map<String, Object> {
 
-    protected Map<String, Object> data = new TreeMap<String, Object>();
+    protected Map<String, Object> data = new HashMap<>();
 
     @Override
     public int size() {


### PR DESCRIPTION
This ensures the correct order of the context values.