### PR TITLE
Mark failed Promise as non successful

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
         <version>3.10.1</version>
     </parent>
     <artifactId>sirius-kernel</artifactId>
-    <version>6.18</version>
+    <version>6.19</version>
     <name>Sirius Kernel</name>
     <description>Provides common core classes and the microkernel powering all Sirius applications</description>
 

--- a/src/main/java/sirius/kernel/async/Promise.java
+++ b/src/main/java/sirius/kernel/async/Promise.java
@@ -132,7 +132,7 @@ public class Promise<V> {
      * @return <tt>true</tt> if the promise was successfully completed, <tt>false</tt> otherwise.
      */
     public boolean isSuccessful() {
-        return value != null;
+        return value != null && !isFailed();
     }
 
     /**

--- a/src/test/java/sirius/kernel/async/PromiseSpec.groovy
+++ b/src/test/java/sirius/kernel/async/PromiseSpec.groovy
@@ -119,4 +119,21 @@ class PromiseSpec extends BaseSpecification {
         output.isFailed()
     }
 
+    def "A completed Promise with a value and error is marked as non successful and failed"() {
+        given: "a promise"
+        Promise<String> test = Tasks.promise()
+        and: "and a test exception"
+        def exception = new Exception()
+        and: "add a dummy handler so that no output is written into the console"
+        test.onFailure(ValueHolder.of(null))
+        when: "mark promise as successful"
+        test.success(null)
+        and: "and mark it as failed as well"
+        test.fail(exception)
+        then: "the promise is considered as 'failed'"
+        test.isFailed()
+        and: "the promise is not considered as 'successful'"
+        !test.isSuccessful()
+    }
+
 }


### PR DESCRIPTION
A failed promise was marked as successful. This could happen if the promise was marked as successful with a value and in one of the success handlers an exception is thrown. In this case the promise is marked as successful and failed at the same time. If a fail handler is attached after this, it would be executed as if the promise was successful. With this change, the handler in this case would be executed as failed.