### PR TITLE
Provides a default timeout for Outcall (connect and read).

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
         <version>3.11.4</version>
     </parent>
     <artifactId>sirius-kernel</artifactId>
-    <version>7.4.1</version>
+    <version>7.5</version>
     <name>Sirius Kernel</name>
     <description>Provides common core classes and the microkernel powering all Sirius applications</description>
 

--- a/src/main/java/sirius/kernel/xml/Outcall.java
+++ b/src/main/java/sirius/kernel/xml/Outcall.java
@@ -29,6 +29,7 @@ import java.net.URL;
 import java.net.URLEncoder;
 import java.nio.charset.Charset;
 import java.util.Map;
+import java.util.concurrent.TimeUnit;
 
 /**
  * Used to call an URL and send or receive data.
@@ -38,6 +39,8 @@ import java.util.Map;
  */
 public class Outcall {
 
+    private static final int DEFAULT_CONNECT_TIMEOUT = (int) TimeUnit.MILLISECONDS.convert(5, TimeUnit.MINUTES);
+    private static final int DEFAULT_READ_TIMEOUT = (int) TimeUnit.MILLISECONDS.convert(5, TimeUnit.MINUTES);
     private HttpURLConnection connection;
     private Charset charset = Charsets.UTF_8;
 
@@ -51,6 +54,8 @@ public class Outcall {
         connection = (HttpURLConnection) url.openConnection();
         connection.setDoInput(true);
         connection.setDoOutput(true);
+        connection.setConnectTimeout(DEFAULT_CONNECT_TIMEOUT);
+        connection.setReadTimeout(DEFAULT_READ_TIMEOUT);
     }
 
     /**


### PR DESCRIPTION
By default we now fail after 5 mins - Java would hang
FOREVER otherwise and there is no sane way to terminate
a connection from the outside.