### PR TITLE
Loads all translation files (NLS) if the sirius project is started as test

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
         <version>3.11.4</version>
     </parent>
     <artifactId>sirius-kernel</artifactId>
-    <version>7.5.3</version>
+    <version>7.5.4</version>
     <name>Sirius Kernel</name>
     <description>Provides common core classes and the microkernel powering all Sirius applications</description>
 

--- a/src/main/java/sirius/kernel/Classpath.java
+++ b/src/main/java/sirius/kernel/Classpath.java
@@ -105,10 +105,12 @@ public class Classpath {
         }).map(pattern::matcher).filter(Matcher::matches);
     }
 
-    /*
+    /**
      * Scans all files below the given root URL. This can handle file:// and jar:// URLs
+     *
+     * @param url the root url to scan
      */
-    private Stream<String> scan(URL url) {
+    public Stream<String> scan(URL url) {
         List<String> result = new ArrayList<>();
         if ("file".equals(url.getProtocol())) {
             try {


### PR DESCRIPTION
This allows NLS calls in customizations without failing tests because of the reportMissingTranslations.
Without these changes NLS.get("customization.key") would be reported as missing because NLS.get is static and the customization property would not be loaded during the test.
- Fixes: SE-3811