### PR TITLE
Transforming also checks superclass

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
         <version>3.11.4</version>
     </parent>
     <artifactId>sirius-kernel</artifactId>
-    <version>7.5.3</version>
+    <version>7.6</version>
     <name>Sirius Kernel</name>
     <description>Provides common core classes and the microkernel powering all Sirius applications</description>
 

--- a/src/main/java/sirius/kernel/di/transformers/Transformer.java
+++ b/src/main/java/sirius/kernel/di/transformers/Transformer.java
@@ -35,6 +35,18 @@ public interface Transformer<S, T> extends Priorized {
     }
 
     /**
+     * Determines if child classes of the provided source class are also supported by this transformer.
+     * <p>
+     * In order to avoid unwanted transformations, this can be set to false. In this case, only the matching
+     * class to the provided source class is transformed.
+     *
+     * @return <tt>true</tt> if child classes should also be transformed via this transformer, <tt>false</tt> otherwise
+     */
+    default boolean supportChildClasses() {
+        return true;
+    }
+
+    /**
      * Returns the source type for which this factory can perform transformations.
      *
      * @return the source type for which transformations are supported.

--- a/src/test/java/sirius/kernel/di/transformers/BlockingFirstChildClass.java
+++ b/src/test/java/sirius/kernel/di/transformers/BlockingFirstChildClass.java
@@ -1,0 +1,12 @@
+/*
+ * Made with all the love in the world
+ * by scireum in Remshalden, Germany
+ *
+ * Copyright by scireum GmbH
+ * http://www.scireum.de - info@scireum.de
+ */
+
+package sirius.kernel.di.transformers;
+
+public class BlockingFirstChildClass extends BlockingParentClass {
+}

--- a/src/test/java/sirius/kernel/di/transformers/BlockingParentClass.java
+++ b/src/test/java/sirius/kernel/di/transformers/BlockingParentClass.java
@@ -1,0 +1,12 @@
+/*
+ * Made with all the love in the world
+ * by scireum in Remshalden, Germany
+ *
+ * Copyright by scireum GmbH
+ * http://www.scireum.de - info@scireum.de
+ */
+
+package sirius.kernel.di.transformers;
+
+public class BlockingParentClass extends Composable {
+}

--- a/src/test/java/sirius/kernel/di/transformers/BlockingParentClassTargetClassTransformer.java
+++ b/src/test/java/sirius/kernel/di/transformers/BlockingParentClassTargetClassTransformer.java
@@ -1,0 +1,39 @@
+/*
+ * Made with all the love in the world
+ * by scireum in Remshalden, Germany
+ *
+ * Copyright by scireum GmbH
+ * http://www.scireum.de - info@scireum.de
+ */
+
+package sirius.kernel.di.transformers;
+
+import sirius.kernel.di.std.Register;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+
+@Register
+public class BlockingParentClassTargetClassTransformer implements Transformer<BlockingParentClass, TargetClass> {
+
+    @Override
+    public boolean supportChildClasses() {
+        return false;
+    }
+
+    @Override
+    public Class<BlockingParentClass> getSourceClass() {
+        return BlockingParentClass.class;
+    }
+
+    @Override
+    public Class<TargetClass> getTargetClass() {
+        return TargetClass.class;
+    }
+
+    @Nullable
+    @Override
+    public TargetClass make(@Nonnull BlockingParentClass source) {
+        return new TargetClass();
+    }
+}

--- a/src/test/java/sirius/kernel/di/transformers/FirstChildClass.java
+++ b/src/test/java/sirius/kernel/di/transformers/FirstChildClass.java
@@ -1,0 +1,12 @@
+/*
+ * Made with all the love in the world
+ * by scireum in Remshalden, Germany
+ *
+ * Copyright by scireum GmbH
+ * http://www.scireum.de - info@scireum.de
+ */
+
+package sirius.kernel.di.transformers;
+
+public class FirstChildClass extends ParentClass {
+}

--- a/src/test/java/sirius/kernel/di/transformers/ParentClass.java
+++ b/src/test/java/sirius/kernel/di/transformers/ParentClass.java
@@ -1,0 +1,12 @@
+/*
+ * Made with all the love in the world
+ * by scireum in Remshalden, Germany
+ *
+ * Copyright by scireum GmbH
+ * http://www.scireum.de - info@scireum.de
+ */
+
+package sirius.kernel.di.transformers;
+
+public class ParentClass extends Composable {
+}

--- a/src/test/java/sirius/kernel/di/transformers/ParentClassTargetClassTransformer.java
+++ b/src/test/java/sirius/kernel/di/transformers/ParentClassTargetClassTransformer.java
@@ -1,0 +1,34 @@
+/*
+ * Made with all the love in the world
+ * by scireum in Remshalden, Germany
+ *
+ * Copyright by scireum GmbH
+ * http://www.scireum.de - info@scireum.de
+ */
+
+package sirius.kernel.di.transformers;
+
+import sirius.kernel.di.std.Register;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+
+@Register
+public class ParentClassTargetClassTransformer implements Transformer<ParentClass, TargetClass> {
+
+    @Override
+    public Class<ParentClass> getSourceClass() {
+        return ParentClass.class;
+    }
+
+    @Override
+    public Class<TargetClass> getTargetClass() {
+        return TargetClass.class;
+    }
+
+    @Nullable
+    @Override
+    public TargetClass make(@Nonnull ParentClass source) {
+        return new TargetClass();
+    }
+}

--- a/src/test/java/sirius/kernel/di/transformers/SecondChildClass.java
+++ b/src/test/java/sirius/kernel/di/transformers/SecondChildClass.java
@@ -1,0 +1,12 @@
+/*
+ * Made with all the love in the world
+ * by scireum in Remshalden, Germany
+ *
+ * Copyright by scireum GmbH
+ * http://www.scireum.de - info@scireum.de
+ */
+
+package sirius.kernel.di.transformers;
+
+public class SecondChildClass extends FirstChildClass {
+}

--- a/src/test/java/sirius/kernel/di/transformers/TargetClass.java
+++ b/src/test/java/sirius/kernel/di/transformers/TargetClass.java
@@ -1,0 +1,12 @@
+/*
+ * Made with all the love in the world
+ * by scireum in Remshalden, Germany
+ *
+ * Copyright by scireum GmbH
+ * http://www.scireum.de - info@scireum.de
+ */
+
+package sirius.kernel.di.transformers;
+
+public class TargetClass {
+}

--- a/src/test/java/sirius/kernel/di/transformers/TransformersSpec.groovy
+++ b/src/test/java/sirius/kernel/di/transformers/TransformersSpec.groovy
@@ -1,0 +1,52 @@
+/*
+ * Made with all the love in the world
+ * by scireum in Remshalden, Germany
+ *
+ * Copyright by scireum GmbH
+ * http://www.scireum.de - info@scireum.de
+ */
+
+package sirius.kernel.di.transformers
+
+import sirius.kernel.BaseSpecification
+
+class TransformersSpec extends BaseSpecification{
+
+    def "Transforming two classes regularly"() {
+        given:
+        def parent = new ParentClass()
+        expect:
+        parent.tryAs(TargetClass.class).isPresent()
+        parent.as(TargetClass.class) instanceof TargetClass
+    }
+
+    def "Transforming child class"() {
+        given:
+        def firstChild = new FirstChildClass()
+        expect:
+        firstChild.tryAs(TargetClass.class).isPresent()
+        firstChild.as(TargetClass.class) instanceof TargetClass
+    }
+
+    def "Transforming second child class is not possible"() {
+        given:
+        def secondChild = new SecondChildClass()
+        expect:
+        !secondChild.tryAs(TargetClass.class).isPresent()
+    }
+
+    def "Transforming two matching classes with blocking flag works"() {
+        given:
+        def parent = new BlockingParentClass()
+        expect:
+        parent.tryAs(TargetClass.class).isPresent()
+        parent.as(TargetClass.class) instanceof TargetClass
+    }
+
+    def "Transforming first child class with transformer blocking child transforming"() {
+        given:
+        def firstChild = new BlockingFirstChildClass()
+        expect:
+        !firstChild .tryAs(TargetClass.class).isPresent()
+    }
+}


### PR DESCRIPTION
In some cases there might be a need to transform two classes which are not directly bound by a transformer e.g. if the source class is a more specific implementation. In this case it was needed to write multiple transformers in order to support this case. With these changes not only the source class itself is checked for transforming, but also its superclass. If this is not desired, the transformer can indicate this by setting a flag.