### PR TITLE
Additional transformation sources

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
         <version>3.11.4</version>
     </parent>
     <artifactId>sirius-kernel</artifactId>
-    <version>7.5.3</version>
+    <version>7.6</version>
     <name>Sirius Kernel</name>
     <description>Provides common core classes and the microkernel powering all Sirius applications</description>
 

--- a/src/main/java/sirius/kernel/di/transformers/Transformer.java
+++ b/src/main/java/sirius/kernel/di/transformers/Transformer.java
@@ -12,6 +12,7 @@ import sirius.kernel.di.std.Priorized;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
+import java.util.function.Consumer;
 
 /**
  * Transforms a <tt>Transformable</tt> into a given target type.
@@ -32,6 +33,17 @@ public interface Transformer<S, T> extends Priorized {
     @Override
     default int getPriority() {
         return Priorized.DEFAULT_PRIORITY;
+    }
+
+    /**
+     * Provides a {@link Consumer} which takes additional source classes which can be transformed via the
+     * transformer into the target class. The additional source classes have to extend the provided source
+     * type.
+     *
+     * @param additionalSourceClassesConsumer consumer accepting additional source classes
+     */
+    default void additionalSourceClasses(Consumer<Class<? extends S>> additionalSourceClassesConsumer) {
+        // Accept nothing in addition by default
     }
 
     /**

--- a/src/main/java/sirius/kernel/di/transformers/Transformers.java
+++ b/src/main/java/sirius/kernel/di/transformers/Transformers.java
@@ -35,6 +35,9 @@ public class Transformers {
             MultiMap<Tuple<Class<?>, Class<?>>, Transformer<?, ?>> result = MultiMap.createOrdered();
             for (Transformer<?, ?> factory : factoryList) {
                 result.put(Tuple.create(factory.getSourceClass(), factory.getTargetClass()), factory);
+                factory.additionalSourceClasses(additionalClass -> result.put(Tuple.create(additionalClass,
+                                                                                           factory.getTargetClass()),
+                                                                              factory));
             }
             factories = result;
         }

--- a/src/test/java/sirius/kernel/di/transformers/FirstChildClass.java
+++ b/src/test/java/sirius/kernel/di/transformers/FirstChildClass.java
@@ -1,0 +1,12 @@
+/*
+ * Made with all the love in the world
+ * by scireum in Remshalden, Germany
+ *
+ * Copyright by scireum GmbH
+ * http://www.scireum.de - info@scireum.de
+ */
+
+package sirius.kernel.di.transformers;
+
+public class FirstChildClass extends ParentClass {
+}

--- a/src/test/java/sirius/kernel/di/transformers/ParentClass.java
+++ b/src/test/java/sirius/kernel/di/transformers/ParentClass.java
@@ -1,0 +1,12 @@
+/*
+ * Made with all the love in the world
+ * by scireum in Remshalden, Germany
+ *
+ * Copyright by scireum GmbH
+ * http://www.scireum.de - info@scireum.de
+ */
+
+package sirius.kernel.di.transformers;
+
+public class ParentClass extends Composable {
+}

--- a/src/test/java/sirius/kernel/di/transformers/ParentClassTargetClassTransformer.java
+++ b/src/test/java/sirius/kernel/di/transformers/ParentClassTargetClassTransformer.java
@@ -1,0 +1,40 @@
+/*
+ * Made with all the love in the world
+ * by scireum in Remshalden, Germany
+ *
+ * Copyright by scireum GmbH
+ * http://www.scireum.de - info@scireum.de
+ */
+
+package sirius.kernel.di.transformers;
+
+import sirius.kernel.di.std.Register;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import java.util.function.Consumer;
+
+@Register
+public class ParentClassTargetClassTransformer implements Transformer<ParentClass, TargetClass> {
+
+    @Override
+    public void additionalSourceClasses(Consumer<Class<? extends ParentClass>> additionalSourceClassesConsumer) {
+        additionalSourceClassesConsumer.accept(FirstChildClass.class);
+    }
+
+    @Override
+    public Class<ParentClass> getSourceClass() {
+        return ParentClass.class;
+    }
+
+    @Override
+    public Class<TargetClass> getTargetClass() {
+        return TargetClass.class;
+    }
+
+    @Nullable
+    @Override
+    public TargetClass make(@Nonnull ParentClass source) {
+        return new TargetClass();
+    }
+}

--- a/src/test/java/sirius/kernel/di/transformers/SecondChildClass.java
+++ b/src/test/java/sirius/kernel/di/transformers/SecondChildClass.java
@@ -1,0 +1,12 @@
+/*
+ * Made with all the love in the world
+ * by scireum in Remshalden, Germany
+ *
+ * Copyright by scireum GmbH
+ * http://www.scireum.de - info@scireum.de
+ */
+
+package sirius.kernel.di.transformers;
+
+public class SecondChildClass extends ParentClass {
+}

--- a/src/test/java/sirius/kernel/di/transformers/TargetClass.java
+++ b/src/test/java/sirius/kernel/di/transformers/TargetClass.java
@@ -1,0 +1,12 @@
+/*
+ * Made with all the love in the world
+ * by scireum in Remshalden, Germany
+ *
+ * Copyright by scireum GmbH
+ * http://www.scireum.de - info@scireum.de
+ */
+
+package sirius.kernel.di.transformers;
+
+public class TargetClass {
+}

--- a/src/test/java/sirius/kernel/di/transformers/TransformersSpec.groovy
+++ b/src/test/java/sirius/kernel/di/transformers/TransformersSpec.groovy
@@ -1,0 +1,37 @@
+/*
+ * Made with all the love in the world
+ * by scireum in Remshalden, Germany
+ *
+ * Copyright by scireum GmbH
+ * http://www.scireum.de - info@scireum.de
+ */
+
+package sirius.kernel.di.transformers
+
+import sirius.kernel.BaseSpecification
+
+class TransformersSpec extends BaseSpecification{
+
+    def "Transforming two classes regularly"() {
+        given:
+        def parent = new ParentClass()
+        expect:
+        parent.tryAs(TargetClass.class).isPresent()
+        parent.as(TargetClass.class) instanceof TargetClass
+    }
+
+    def "Transforming accepted child class"() {
+        given:
+        def firstChild = new FirstChildClass()
+        expect:
+        firstChild.tryAs(TargetClass.class).isPresent()
+        firstChild.as(TargetClass.class) instanceof TargetClass
+    }
+
+    def "Transforming second child class which is not accepted is not possible"() {
+        given:
+        def secondChild = new SecondChildClass()
+        expect:
+        !secondChild.tryAs(TargetClass.class).isPresent()
+    }
+}


### PR DESCRIPTION
Sometimes child classes of a class should be transformed as well as their parent class. In order to avoid writing multiple transformers for each case, transformers now support adding multiple classes additionally as source classes for transforming them into the target class. The only restriction is that the additional classes have to extend the parent class.