### PR TITLE
Allow transformers for child classes

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
         <version>3.11.4</version>
     </parent>
     <artifactId>sirius-kernel</artifactId>
-    <version>7.5.3</version>
+    <version>7.6</version>
     <name>Sirius Kernel</name>
     <description>Provides common core classes and the microkernel powering all Sirius applications</description>
 

--- a/src/test/java/sirius/kernel/di/transformers/FirstChildClass.java
+++ b/src/test/java/sirius/kernel/di/transformers/FirstChildClass.java
@@ -1,0 +1,12 @@
+/*
+ * Made with all the love in the world
+ * by scireum in Remshalden, Germany
+ *
+ * Copyright by scireum GmbH
+ * http://www.scireum.de - info@scireum.de
+ */
+
+package sirius.kernel.di.transformers;
+
+public class FirstChildClass extends ParentClass {
+}

--- a/src/test/java/sirius/kernel/di/transformers/ParentClass.java
+++ b/src/test/java/sirius/kernel/di/transformers/ParentClass.java
@@ -1,0 +1,12 @@
+/*
+ * Made with all the love in the world
+ * by scireum in Remshalden, Germany
+ *
+ * Copyright by scireum GmbH
+ * http://www.scireum.de - info@scireum.de
+ */
+
+package sirius.kernel.di.transformers;
+
+public class ParentClass extends Composable {
+}

--- a/src/test/java/sirius/kernel/di/transformers/ParentClassTargetClassTransformer.java
+++ b/src/test/java/sirius/kernel/di/transformers/ParentClassTargetClassTransformer.java
@@ -1,0 +1,35 @@
+/*
+ * Made with all the love in the world
+ * by scireum in Remshalden, Germany
+ *
+ * Copyright by scireum GmbH
+ * http://www.scireum.de - info@scireum.de
+ */
+
+package sirius.kernel.di.transformers;
+
+import sirius.kernel.di.std.Register;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import java.util.function.Consumer;
+
+@Register
+public class ParentClassTargetClassTransformer implements Transformer<ParentClass, TargetClass> {
+
+    @Override
+    public Class<ParentClass> getSourceClass() {
+        return ParentClass.class;
+    }
+
+    @Override
+    public Class<TargetClass> getTargetClass() {
+        return TargetClass.class;
+    }
+
+    @Nullable
+    @Override
+    public TargetClass make(@Nonnull ParentClass source) {
+        return new TargetClass();
+    }
+}

--- a/src/test/java/sirius/kernel/di/transformers/SecondChildClass.java
+++ b/src/test/java/sirius/kernel/di/transformers/SecondChildClass.java
@@ -1,0 +1,12 @@
+/*
+ * Made with all the love in the world
+ * by scireum in Remshalden, Germany
+ *
+ * Copyright by scireum GmbH
+ * http://www.scireum.de - info@scireum.de
+ */
+
+package sirius.kernel.di.transformers;
+
+public class SecondChildClass extends ParentClass {
+}

--- a/src/test/java/sirius/kernel/di/transformers/TargetClass.java
+++ b/src/test/java/sirius/kernel/di/transformers/TargetClass.java
@@ -1,0 +1,12 @@
+/*
+ * Made with all the love in the world
+ * by scireum in Remshalden, Germany
+ *
+ * Copyright by scireum GmbH
+ * http://www.scireum.de - info@scireum.de
+ */
+
+package sirius.kernel.di.transformers;
+
+public class TargetClass {
+}

--- a/src/test/java/sirius/kernel/di/transformers/TransformersSpec.groovy
+++ b/src/test/java/sirius/kernel/di/transformers/TransformersSpec.groovy
@@ -1,0 +1,38 @@
+/*
+ * Made with all the love in the world
+ * by scireum in Remshalden, Germany
+ *
+ * Copyright by scireum GmbH
+ * http://www.scireum.de - info@scireum.de
+ */
+
+package sirius.kernel.di.transformers
+
+import sirius.kernel.BaseSpecification
+
+class TransformersSpec extends BaseSpecification{
+
+    def "Transforming two classes regularly"() {
+        given:
+        def parent = new ParentClass()
+        expect:
+        parent.tryAs(TargetClass.class).isPresent()
+        parent.as(TargetClass.class) instanceof TargetClass
+    }
+
+    def "Transforming first child class"() {
+        given:
+        def firstChild = new FirstChildClass()
+        expect:
+        firstChild.tryAs(TargetClass.class).isPresent()
+        firstChild.as(TargetClass.class) instanceof TargetClass
+    }
+
+    def "Transforming second child class"() {
+        given:
+        def secondChild = new SecondChildClass()
+        expect:
+        secondChild.tryAs(TargetClass.class).isPresent()
+        secondChild.as(TargetClass.class) instanceof TargetClass
+    }
+}


### PR DESCRIPTION
Sometimes there is only a transformer for a parent class to another class. In order to avoid writing multiple transformers for these child classes, transformers now walk the inheritance path down until the visited class can be transformed into the target class or the class to check does not implement the Transformable interface in order to avoid unnecessary transformation attempts.