### PR TITLE
Fixes the Translation file Load order

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
         <version>3.11.4</version>
     </parent>
     <artifactId>sirius-kernel</artifactId>
-    <version>8.0.5</version>
+    <version>9.0.0</version>
     <name>Sirius Kernel</name>
     <description>Provides common core classes and the microkernel powering all Sirius applications</description>
 

--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
         <version>3.11.4</version>
     </parent>
     <artifactId>sirius-kernel</artifactId>
-    <version>8.0.4</version>
+    <version>8.0.5</version>
     <name>Sirius Kernel</name>
     <description>Provides common core classes and the microkernel powering all Sirius applications</description>
 

--- a/src/main/java/sirius/kernel/Sirius.java
+++ b/src/main/java/sirius/kernel/Sirius.java
@@ -429,8 +429,8 @@ public class Sirius {
      * @param resource the resource path to check
      * @return <tt>true</tt> if the given resource is part of a configuration, <tt>false</tt> otherwise
      */
-    public static boolean isConfigurationResource(@Nullable String resource) {
-        return resource != null && resource.startsWith("configurations");
+    public static boolean isCustomizationResource(@Nullable String resource) {
+        return resource != null && resource.startsWith("customizations");
     }
 
     /**

--- a/src/main/java/sirius/kernel/Sirius.java
+++ b/src/main/java/sirius/kernel/Sirius.java
@@ -424,10 +424,10 @@ public class Sirius {
     }
 
     /**
-     * Determines if the given resource is part of a configuration.
+     * Determines if the given resource is part of a customization.
      *
      * @param resource the resource path to check
-     * @return <tt>true</tt> if the given resource is part of a configuration, <tt>false</tt> otherwise
+     * @return <tt>true</tt> if the given resource is part of a customization, <tt>false</tt> otherwise
      */
     public static boolean isCustomizationResource(@Nullable String resource) {
         return resource != null && resource.startsWith("customizations");

--- a/src/main/java/sirius/kernel/nls/Babelfish.java
+++ b/src/main/java/sirius/kernel/nls/Babelfish.java
@@ -152,7 +152,7 @@ public class Babelfish {
         // correct ordering first...
         List<Matcher> customizations = Lists.newArrayList();
         classpath.find(PROPERTIES_FILE).forEach(value -> {
-            if (Sirius.isConfigurationResource(value.group())) {
+            if (Sirius.isCustomizationResource(value.group())) {
                 customizations.add(value);
             } else {
                 loadMatchedResource(value);


### PR DESCRIPTION
- Fixes the customization resource recognition

Up to now all the customization translation files were not recognized as customization files. This lead to a random load order of the translation files in the babelfish class.