### PR TITLE
Provide the full count as counter

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
         <version>3.14</version>
     </parent>
     <artifactId>sirius-kernel</artifactId>
-    <version>11.4</version>
+    <version>11.5</version>
     <name>Sirius Kernel</name>
     <description>Provides common core classes and the microkernel powering all Sirius applications</description>
 


### PR DESCRIPTION
The sample counter is a counter mostly interesting for the average class itself, not for the other classes. Furthermore, the average is now more of a sliding value by not hard resetting the sum and count when reaching the max samples.

Tags: average