### PR TITLE
Implements a detach method for Composable

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
         <version>3.14</version>
     </parent>
     <artifactId>sirius-kernel</artifactId>
-    <version>11.5</version>
+    <version>11.6</version>
     <name>Sirius Kernel</name>
     <description>Provides common core classes and the microkernel powering all Sirius applications</description>
 

--- a/src/main/java/sirius/kernel/di/transformers/Composable.java
+++ b/src/main/java/sirius/kernel/di/transformers/Composable.java
@@ -138,4 +138,18 @@ public class Composable implements Transformable {
     public void attach(Object component) {
         attach(component.getClass(), component);
     }
+
+    /**
+     * Removes an attached component from the current instance.
+     * <p>
+     * The type of the component is used as identifier of the component to be removed.
+     *
+     * @param type the type of the component which should be removed
+     * @param <T>  the generic type which ensures that the component actually implements the given type
+     */
+    public <T> void detach(Class<? extends T> type) {
+        if (components != null) {
+            components.remove(type);
+        }
+    }
 }


### PR DESCRIPTION
This allows us to remove a transformed object from the objects components cache.
Can be used to enforce the usage of the make method.

- Fixes: SE-4296