### PR TITLE
Adds a possibility for Handlers to interrupt XMLReader parsing

### DIFF
--- a/src/main/java/sirius/kernel/xml/XMLReader.java
+++ b/src/main/java/sirius/kernel/xml/XMLReader.java
@@ -150,6 +150,14 @@ public class XMLReader extends DefaultHandler {
     }
 
     /**
+     * Used to signal the reader to end the current processing
+     */
+    public static class EndOfProcessingException extends RuntimeException {
+
+        private static final long serialVersionUID = 7376735589037262998L;
+    }
+
+    /**
      * Parses the given stream using the given locator and interrupt signal.
      *
      * @param stream          the stream containing the XML data
@@ -173,9 +181,9 @@ public class XMLReader extends DefaultHandler {
             reader.parse(new InputSource(stream));
         } catch (ParserConfigurationException | SAXException e) {
             throw new IOException(e);
-        } catch (UserInterruptException e) {
-            // IGNORED - this is used to cancel parsing if the used tried to
-            // cancel a process.
+        } catch (UserInterruptException | EndOfProcessingException e) {
+            // IGNORED - this is used to cancel parsing 
+            Exceptions.ignore(e);
         } finally {
             stream.close();
         }

--- a/src/test/java/sirius/kernel/xml/XMLReaderSpec.groovy
+++ b/src/test/java/sirius/kernel/xml/XMLReaderSpec.groovy
@@ -17,6 +17,10 @@ import javax.xml.xpath.XPathExpressionException
 
 class XMLReaderSpec extends BaseSpecification {
 
+
+    public static
+    final String TEST_XML = "<doc><test><value>1</value></test><test><value>2</value></test><test><value>5</value></test></doc>"
+
     def "XMLReader extracts XPATH expression"() {
         given:
         def check = ValueHolder.of(null)
@@ -32,11 +36,33 @@ class XMLReaderSpec extends BaseSpecification {
             }
         } as NodeHandler)
         when:
-        r.parse(new ByteArrayInputStream(
-                "<doc><test><value>1</value></test><test><value>2</value></test><test><value>5</value></test></doc>".getBytes()))
+        r.parse(new ByteArrayInputStream(TEST_XML.getBytes()))
         then:
         check.get() == "5"
         and:
         nodes.getCount() == 3
+    }
+
+    def "XMLReader can be interrupted by a handler"() {
+        given:
+        def check = ValueHolder.of(null)
+        def nodes = new Counter()
+        def r = new XMLReader()
+        and:
+        r.addHandler("test", { n ->
+            try {
+                nodes.inc()
+                check.set(n.queryString("value"))
+            } catch (XPathExpressionException e) {
+                throw Exceptions.handle(e)
+            }
+            throw new XMLReader.EndOfProcessingException()
+        } as NodeHandler)
+        when:
+        r.parse(new ByteArrayInputStream(TEST_XML.getBytes()))
+        then:
+        check.get() == "1"
+        and:
+        nodes.getCount() == 1
     }
 }


### PR DESCRIPTION
This can be useful when verifying a header or generally reading elements that are usually found near the start of the document.