### PR TITLE
Bugfix for coherentcache remove method

### DIFF
--- a/src/main/java/sirius/kernel/cache/CoherentCache.java
+++ b/src/main/java/sirius/kernel/cache/CoherentCache.java
@@ -60,6 +60,10 @@ class CoherentCache<V> extends ManagedCache<String, V> {
 
     @Override
     public void removeIf(@Nonnull Predicate<CacheEntry<String, V>> predicate) {
+        if (data == null) {
+            return;
+        }
+
         data.asMap().values().stream().filter(predicate).map(CacheEntry::getKey).forEach(this::remove);
     }
 }


### PR DESCRIPTION
We did not check if the data property was null, which lead to NPEs within some
sirius-biz tests, when removeIf was called before any element was cached