### PR TITLE
Adds indention to xml output

### DIFF
--- a/src/main/java/sirius/kernel/xml/XMLStructuredOutput.java
+++ b/src/main/java/sirius/kernel/xml/XMLStructuredOutput.java
@@ -75,6 +75,7 @@ public class XMLStructuredOutput extends AbstractStructuredOutput {
             }
             serializer.setOutputProperty(OutputKeys.ENCODING, encoding.name());
             serializer.setOutputProperty(OutputKeys.INDENT, "yes");
+            serializer.setOutputProperty("{http://xml.apache.org/xslt}indent-amount", "4");
             hd.setResult(streamResult);
             hd.startDocument();
         } catch (Exception e) {


### PR DESCRIPTION
`serializer.setOutputProperty(OutputKeys.INDENT, "yes"); ` only adds a newline for each xml-object, but does not actually indent on its own. 