### PR TITLE
Fixes Bug in which sirius could not stop on Sirius::stop

### DIFF
--- a/src/main/java/sirius/kernel/async/Tasks.java
+++ b/src/main/java/sirius/kernel/async/Tasks.java
@@ -379,7 +379,6 @@ public class Tasks implements Startable, Stoppable, Killable {
 
     @Override
     public void started() {
-        executors.clear();
         running = true;
         startScheduler();
         startBackgroundLoops();
@@ -407,6 +406,7 @@ public class Tasks implements Startable, Stoppable, Killable {
                 blockUnitExecutorTerminates(e.getKey(), exec);
             }
         }
+        executors.clear();
     }
 
     private void blockUnitExecutorTerminates(String name, AsyncExecutor exec) {


### PR DESCRIPTION
The problem was, there were two Default-Executor created.

Sirius starts Default-Executor before Tasks::Started and adds it to the Tasks.executers map. In Tasks::Started the map is cleared. When another Default-Executor task is started, another Default-Executor is created. Only one of those two Default-Executors is in the Tasks.executers map and gets shut down.
The other one is not shut down, because it is not in the Task.executers-Map and hinders the program to terminate.