### PR TITLE
Allow to disable custom logging configuration

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -10,9 +10,27 @@
     </parent>
     <artifactId>sirius-kernel</artifactId>
     <name>SIRIUS kernel</name>
-    <version>DEVELOPMENT-SNAPSHOT</version>
+    <version>12.0-rc27adbe1</version>
     <description>Provides common core classes and the microkernel powering all Sirius applications</description>
-
+    <build>
+        <plugins>
+        <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-deploy-plugin</artifactId>
+            <version>3.0.0-M1</version>
+            <configuration>
+            <skip>false</skip>
+            </configuration>
+        </plugin>
+        <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-gpg-plugin</artifactId>
+            <configuration>
+                <skip>true</skip>
+            </configuration>
+        </plugin>
+        </plugins>
+    </build>
     <dependencies>
         <!-- Provides the tools to load the system configuration -->
         <dependency>
@@ -56,4 +74,18 @@
             <version>0.34.0</version>
         </dependency>
     </dependencies>
+    <distributionManagement>
+    <repository>
+      <id>${maven-release-repo-id}</id>
+      <uniqueVersion>false</uniqueVersion>
+      <name>Release Repository</name>
+      <url>${maven-release-repo-url}</url>
+    </repository>
+    <snapshotRepository>
+      <id>${maven-snapshot-repo-id}</id>
+      <uniqueVersion>true</uniqueVersion>
+      <name>Snapshot Repository</name>
+      <url>${maven-snapshot-repo-url}</url>
+    </snapshotRepository>
+    </distributionManagement>
 </project>

--- a/src/main/java/sirius/kernel/Setup.java
+++ b/src/main/java/sirius/kernel/Setup.java
@@ -69,6 +69,7 @@ public class Setup {
 
     protected ClassLoader loader;
     protected Mode mode;
+    protected boolean configureLogging = true;
     protected boolean logToConsole;
     protected boolean logToFile;
     protected Level defaultLevel = Level.INFO;
@@ -86,6 +87,17 @@ public class Setup {
         this.loader = loader;
         logToConsole = mode != Mode.PROD || getProperty("console").asBoolean(false);
         logToFile = mode == Mode.PROD && !getProperty("disableLogfile").asBoolean(false);
+    }
+
+    /**
+     * Specifies whether logging should be configured or not
+     *
+     * @param logging - true|false
+     * @return the setup itself for fluent method calls
+     */
+    public Setup withConfigureLogging(boolean logging) {
+        this.configureLogging = logging;
+        return this;
     }
 
     /**
@@ -259,6 +271,9 @@ public class Setup {
      * log into the logs directory.
      */
     protected void setupLogging() {
+        if (!shouldConfigureLogging()) {
+            return;
+        }
         final LoggerRepository repository = Logger.getRootLogger().getLoggerRepository();
         repository.resetConfiguration();
         Logger.getRootLogger().setLevel(defaultLevel);
@@ -343,6 +358,15 @@ public class Setup {
      */
     protected String getLogFileName() {
         return DEFAULT_LOG_FILE_NAME;
+    }
+
+    /**
+     * Determines if custom logging should be configured
+     *
+     * @return <tt>true</tt> if the framework should configure logging
+     */
+    protected boolean shouldConfigureLogging() {
+        return configureLogging;
     }
 
     /**

--- a/src/main/java/sirius/kernel/Setup.java
+++ b/src/main/java/sirius/kernel/Setup.java
@@ -92,7 +92,7 @@ public class Setup {
     /**
      * Specifies whether logging should be configured or not
      *
-     * @param logging - true|false
+     * @param logging determines if the log4j system should be configured by sirius
      * @return the setup itself for fluent method calls
      */
     public Setup withConfigureLogging(boolean logging) {

--- a/src/main/java/sirius/kernel/async/Promise.java
+++ b/src/main/java/sirius/kernel/async/Promise.java
@@ -37,7 +37,7 @@ import java.util.function.Function;
  * the computation is completed.
  * <p>
  * Since promises can be chained ({@link #chain(Promise)}, {@link #failChain(Promise, sirius.kernel.commons.Callback)})
- * or aggregated ({@link Tasks#sequence(java.util.List)}, {@link Barrier}) complex computations can be glued
+ * or aggregated, {@link Barrier}) complex computations can be glued
  * together using simple components.
  *
  * @param <V> contains the type of the value which is to be computed

--- a/src/main/java/sirius/kernel/cache/Cache.java
+++ b/src/main/java/sirius/kernel/cache/Cache.java
@@ -26,9 +26,9 @@ import java.util.function.Predicate;
  * time so that only values which are really used remain in the cache. Therefore system resources (most essentially
  * heap storage) is released if no longer required.
  * <p>
- * A new Cache is created by invoking {@link CacheManager#createCache(String)}. The maximal size as well as the
+ * A new Cache is created by invoking {@link CacheManager#createCoherentCache(String)} (String)}. The maximal size as well as the
  * time to live value for each entry is set via the <tt>cache.[cacheName]</tt> extension. Additionally
- * {@link CacheManager#createCache(String, ValueComputer, ValueVerifier)} can be used to supply a
+ * {@link CacheManager#createCoherentCache(String, ValueComputer, ValueVerifier)} can be used to supply a
  * <tt>ValueComputer</tt> as well as a <tt>ValueVerifier</tt>. Those classes are responsible for creating non-
  * existent cache values or to verify that cached values are still up to date, before they are returned to a
  * user of the cache.


### PR DESCRIPTION
Custom logging in sk is colliding in our test scenarios with the test logging.
This patch adds support for disabling logging and relying on log4j settings in environment