### PR TITLE
Fixes Bug in Tests

### DIFF
--- a/src/test/java/sirius/kernel/commons/ValueSpec.groovy
+++ b/src/test/java/sirius/kernel/commons/ValueSpec.groovy
@@ -135,8 +135,8 @@ class ValueSpec extends Specification {
         "true"             | true
         false              | false
         true               | true
-        NLS.get("NLS.Yes") | true
-        NLS.get("NLS.No")  | false
+        NLS.get("NLS.yes") | true
+        NLS.get("NLS.no")  | false
     }
 
 
@@ -161,7 +161,7 @@ class ValueSpec extends Specification {
         "true"             | true
         false              | false
         true               | true
-        NLS.get("NLS.Yes") | true
-        NLS.get("NLS.No")  | false
+        NLS.get("NLS.yes") | true
+        NLS.get("NLS.no")  | false
     }
 }


### PR DESCRIPTION
The "NLS.Yes" and "NLS.No" translations keys where deleted because "NLS.yes" and "NLS.no" already existed