### PR TITLE
 Determine if csv-column should be quoted before starting processing in CSVWriter

### DIFF
--- a/src/main/java/sirius/kernel/commons/CSVWriter.java
+++ b/src/main/java/sirius/kernel/commons/CSVWriter.java
@@ -165,9 +165,9 @@ public class CSVWriter implements Closeable {
             stringValue = "";
         }
         StringBuilder effectiveValue = new StringBuilder();
-        boolean shouldQuote =
-                stringValue.contains(String.valueOf(separator)) || stringValue.contains("\n") || stringValue.contains(
-                        "\r");
+        boolean shouldQuote = quotation != '\0' && (stringValue.contains(String.valueOf(separator))
+                                                    || stringValue.contains("\n")
+                                                    || stringValue.contains("\r"));
         for (int i = 0; i < stringValue.length(); i++) {
             char currentChar = stringValue.charAt(i);
             processCharacter(currentChar, effectiveValue, shouldQuote);

--- a/src/main/java/sirius/kernel/commons/CSVWriter.java
+++ b/src/main/java/sirius/kernel/commons/CSVWriter.java
@@ -165,10 +165,12 @@ public class CSVWriter implements Closeable {
             stringValue = "";
         }
         StringBuilder effectiveValue = new StringBuilder();
-        boolean shouldQuote = false;
+        boolean shouldQuote =
+                stringValue.contains(String.valueOf(separator)) || stringValue.contains("\n") || stringValue.contains(
+                        "\r");
         for (int i = 0; i < stringValue.length(); i++) {
             char currentChar = stringValue.charAt(i);
-            shouldQuote = processCharacter(currentChar, effectiveValue, shouldQuote);
+            processCharacter(currentChar, effectiveValue, shouldQuote);
         }
         if (shouldQuote) {
             writer.append(quotation);
@@ -179,19 +181,15 @@ public class CSVWriter implements Closeable {
         }
     }
 
-    private boolean processCharacter(char currentChar, StringBuilder effectiveValue, boolean shouldQuote) {
+    private void processCharacter(char currentChar, StringBuilder effectiveValue, boolean shouldQuote) {
         if (currentChar == escape) {
             effectiveValue.append(escape).append(currentChar);
-            return shouldQuote;
+            return;
         }
 
         if (quotation == '\0') {
             processCharacterWithoutQuotation(currentChar, effectiveValue);
-            return shouldQuote;
-        }
-
-        if (currentChar == separator || currentChar == '\r' || currentChar == '\n') {
-            shouldQuote = true;
+            return;
         }
 
         if (shouldQuote && currentChar == quotation) {
@@ -203,7 +201,6 @@ public class CSVWriter implements Closeable {
             }
         }
         effectiveValue.append(currentChar);
-        return shouldQuote;
     }
 
     private void processCharacterWithoutQuotation(char currentChar, StringBuilder effectiveValue) {

--- a/src/test/java/sirius/kernel/commons/CSVWriterSpec.groovy
+++ b/src/test/java/sirius/kernel/commons/CSVWriterSpec.groovy
@@ -10,8 +10,6 @@ package sirius.kernel.commons
 
 import sirius.kernel.BaseSpecification
 
-import java.util.function.Consumer
-
 class CSVWriterSpec extends BaseSpecification {
 
     def "simple data is output as CSV"() {
@@ -42,6 +40,21 @@ class CSVWriterSpec extends BaseSpecification {
         output.close()
         then:
         output.toString() == '"a;";b;c\n1;"2\n2";3'
+    }
+
+    def "escaping of quotation works when using quotation"() {
+        given:
+        StringWriter output = new StringWriter()
+        and:
+        CSVWriter writer = new CSVWriter(output)
+        when:
+        writer.writeArray('"a"\nb')
+        writer.writeArray('"a";b')
+        then:
+        and:
+        output.close()
+        then:
+        output.toString() == '"\\"a\\"\nb"\n"\\"a\\";b"'
     }
 
     def "escaping works for escape character and quotation"() {

--- a/src/test/java/sirius/kernel/commons/CSVWriterSpec.groovy
+++ b/src/test/java/sirius/kernel/commons/CSVWriterSpec.groovy
@@ -83,4 +83,65 @@ class CSVWriterSpec extends BaseSpecification {
         then:
         output.toString() == 'a\\;b'
     }
+
+    def "throw an exception if we have to escape quotes, but there is no escape-char"() {
+        given:
+        StringWriter output = new StringWriter()
+        and:
+        CSVWriter writer = new CSVWriter(output)
+        writer.withEscape('\0' as char)
+        when:
+        def thrownException
+        try {
+            writer.writeArray('"a";b')
+        } catch (Exception e) {
+            thrownException = e
+        }
+        and:
+        output.close()
+        then:
+        thrownException instanceof IllegalArgumentException
+        thrownException.getMessage() == "Cannot output a quotation character within a quoted string without an escape character."
+    }
+
+    def "throw an exception if there is a separator in the text, but there is no quotation-char and no escape-char"() {
+        given:
+        StringWriter output = new StringWriter()
+        and:
+        CSVWriter writer = new CSVWriter(output)
+        writer.withQuotation('\0' as char)
+        writer.withEscape('\0' as char)
+        when:
+        def thrownException
+        try {
+            writer.writeArray('a;b')
+        } catch (Exception e) {
+            thrownException = e
+        }
+        and:
+        output.close()
+        then:
+        thrownException instanceof IllegalArgumentException
+        thrownException.getMessage() == "Cannot output a column which contains the separator character ';' without an escape or quotation character."
+    }
+
+    def "throw an exception if there is a new line in the text, but there is no quotation-char"() {
+        given:
+        StringWriter output = new StringWriter()
+        and:
+        CSVWriter writer = new CSVWriter(output)
+        writer.withQuotation('\0' as char)
+        when:
+        def thrownException
+        try {
+            writer.writeArray('a\nb')
+        } catch (Exception e) {
+            thrownException = e
+        }
+        and:
+        output.close()
+        then:
+        thrownException instanceof IllegalArgumentException
+        thrownException.getMessage() == "Cannot output a column which contains a line break without an quotation character."
+    }
 }

--- a/src/test/java/sirius/kernel/commons/CSVWriterSpec.groovy
+++ b/src/test/java/sirius/kernel/commons/CSVWriterSpec.groovy
@@ -91,17 +91,12 @@ class CSVWriterSpec extends BaseSpecification {
         CSVWriter writer = new CSVWriter(output)
         writer.withEscape('\0' as char)
         when:
-        def thrownException
-        try {
-            writer.writeArray('"a";b')
-        } catch (Exception e) {
-            thrownException = e
-        }
+        writer.writeArray('"a";b')
         and:
         output.close()
         then:
-        thrownException instanceof IllegalArgumentException
-        thrownException.getMessage() == "Cannot output a quotation character within a quoted string without an escape character."
+        def e = thrown(IllegalArgumentException)
+        e.getMessage() == "Cannot output a quotation character within a quoted string without an escape character."
     }
 
     def "throw an exception if there is a separator in the text, but there is no quotation-char and no escape-char"() {
@@ -112,17 +107,12 @@ class CSVWriterSpec extends BaseSpecification {
         writer.withQuotation('\0' as char)
         writer.withEscape('\0' as char)
         when:
-        def thrownException
-        try {
-            writer.writeArray('a;b')
-        } catch (Exception e) {
-            thrownException = e
-        }
+        writer.writeArray('a;b')
         and:
         output.close()
         then:
-        thrownException instanceof IllegalArgumentException
-        thrownException.getMessage() == "Cannot output a column which contains the separator character ';' without an escape or quotation character."
+        def e = thrown(IllegalArgumentException)
+        e.getMessage() == "Cannot output a column which contains the separator character ';' without an escape or quotation character."
     }
 
     def "throw an exception if there is a new line in the text, but there is no quotation-char"() {
@@ -132,16 +122,11 @@ class CSVWriterSpec extends BaseSpecification {
         CSVWriter writer = new CSVWriter(output)
         writer.withQuotation('\0' as char)
         when:
-        def thrownException
-        try {
-            writer.writeArray('a\nb')
-        } catch (Exception e) {
-            thrownException = e
-        }
+        writer.writeArray('a\nb')
         and:
         output.close()
         then:
-        thrownException instanceof IllegalArgumentException
-        thrownException.getMessage() == "Cannot output a column which contains a line break without an quotation character."
+        def e = thrown(IllegalArgumentException)
+        e.getMessage() == "Cannot output a column which contains a line break without an quotation character."
     }
 }

--- a/src/test/java/sirius/kernel/commons/CSVWriterSpec.groovy
+++ b/src/test/java/sirius/kernel/commons/CSVWriterSpec.groovy
@@ -70,4 +70,17 @@ class CSVWriterSpec extends BaseSpecification {
         output.toString() == '"a;b\\"";\\\\;c'
     }
 
+    def "escaping of separator with escape-char works if there is no quotation-char"() {
+        given:
+        StringWriter output = new StringWriter()
+        and:
+        CSVWriter writer = new CSVWriter(output)
+        writer.withQuotation('\0' as char)
+        when:
+        writer.writeArray("a;b")
+        and:
+        output.close()
+        then:
+        output.toString() == 'a\\;b'
+    }
 }


### PR DESCRIPTION
Or else quotations will not be escaped when the seperator or new-line is after the quotation