### PR TITLE
Does not preserve the global Caches between multiple Sirius run instances

### DIFF
--- a/src/main/java/sirius/kernel/cache/CacheManager.java
+++ b/src/main/java/sirius/kernel/cache/CacheManager.java
@@ -246,4 +246,9 @@ public class CacheManager {
             ((CoherentCache<?>) cache).removeLocal(key);
         }
     }
+
+    protected static void reset() {
+        caches.values().forEach(ManagedCache::clear);
+        caches.clear();
+    }
 }

--- a/src/main/java/sirius/kernel/cache/Caches.java
+++ b/src/main/java/sirius/kernel/cache/Caches.java
@@ -1,0 +1,24 @@
+/*
+ * Made with all the love in the world
+ * by scireum in Remshalden, Germany
+ *
+ * Copyright by scireum GmbH
+ * http://www.scireum.de - info@scireum.de
+ */
+
+package sirius.kernel.cache;
+
+import sirius.kernel.Stoppable;
+import sirius.kernel.di.std.Register;
+
+/**
+ * Clears the caches when Sirius is shutting down
+ */
+@Register
+public class Caches implements Stoppable {
+
+    @Override
+    public void stopped() {
+        CacheManager.reset();
+    }
+}


### PR DESCRIPTION
This caused annoying error messages when executing tests from the ScenarioSuite, because it started Sirius multiple times after another in a single java process and tried to create the caches every time again.

```
sirius.kernel.health.HandledException: Ein Fehler ist aufgetreten: Failed to auto-load: memoio.helper.Calendars with ClassLoadAction: AutoRegisterAction: null (java.lang.reflect.InvocationTargetException)
	at sirius.kernel.health.Exceptions$ErrorHandler.handle(Exceptions.java:193)
	at sirius.kernel.di.Injector.applyClassLoadActions(Injector.java:152)
	...
Caused by: java.lang.reflect.InvocationTargetException
	...
	... 10 more
Caused by: sirius.kernel.health.HandledException: Ein Fehler ist aufgetreten: A cache named 'calendar-to-state' has already been created!
	at sirius.kernel.health.Exceptions$ErrorHandler.handle(Exceptions.java:193)
	at sirius.kernel.cache.CacheManager.verifyUniquenessOfName(CacheManager.java:108)
	at sirius.kernel.cache.CacheManager.createLocalCache(CacheManager.java:98)
	at sirius.kernel.cache.CacheManager.createLocalCache(CacheManager.java:152)
	at memoio.helper.Calendars.<init>(Calendars.java:48)
	... 16 more
```