### PR TITLE
Won't log any exceptions which where caused by handledExceptions

### DIFF
--- a/src/main/java/sirius/kernel/health/Exceptions.java
+++ b/src/main/java/sirius/kernel/health/Exceptions.java
@@ -194,7 +194,6 @@ public class Exceptions {
                 processError = false;
                 LOG.FINE("Did not process the exception %s because its root (%s) was already handled",
                         ex.getMessage(), Exceptions.getRootCause(ex).getMessage());
-
             }
 
             try {
@@ -414,14 +413,16 @@ public class Exceptions {
      * @return the root {@link Throwable} of the given one
      */
     public static Throwable getRootCause(@Nullable Throwable e) {
-        if (e == null){
+        if (e == null) {
             return null;
         }
 
         Throwable cause = e;
 
-        while (cause.getCause() != null) {
+        int circuitBreaker = 11;
+        while (circuitBreaker > 0 && cause.getCause() != null) {
             cause = cause.getCause();
+            circuitBreaker--;
         }
 
         return cause;

--- a/src/main/java/sirius/kernel/health/Exceptions.java
+++ b/src/main/java/sirius/kernel/health/Exceptions.java
@@ -16,6 +16,7 @@ import sirius.kernel.di.PartCollection;
 import sirius.kernel.di.std.Parts;
 import sirius.kernel.nls.NLS;
 
+import javax.annotation.Nullable;
 import java.util.Map;
 
 /**
@@ -188,6 +189,14 @@ public class Exceptions {
             if (ex instanceof HandledException) {
                 return (HandledException) ex;
             }
+
+            if (Exceptions.getRootCause(ex) instanceof HandledException) {
+                processError = false;
+                LOG.FINE("Did not process the exception %s because its root (%s) was already handled",
+                        ex.getMessage(), Exceptions.getRootCause(ex).getMessage());
+
+            }
+
             try {
                 String message = computeMessage();
                 HandledException result = new HandledException(message, ex);
@@ -396,5 +405,24 @@ public class Exceptions {
                              deprecatedMethod.getMethodName(),
                              caller.getClassName(),
                              caller.getMethodName());
+
+    /**
+     * Retrieves the actual root {@link Throwable} which ended in the given exception.
+     *
+     * @param e the throwable to begin with
+     * @return the root {@link Throwable} of the given one
+     */
+    public static Throwable getRootCause(@Nullable Throwable e) {
+        if (e == null){
+            return null;
+        }
+
+        Throwable cause = e;
+
+        while (cause.getCause() != null) {
+            cause = cause.getCause();
+        }
+
+        return cause;
     }
 }

--- a/src/main/java/sirius/kernel/health/Exceptions.java
+++ b/src/main/java/sirius/kernel/health/Exceptions.java
@@ -401,11 +401,12 @@ public class Exceptions {
         StackTraceElement deprecatedMethod = stack[2];
         StackTraceElement caller = stack[3];
         DEPRECATION_LOG.WARN("The deprecated method '%s.%s' was called by '%s.%s'",
-                             deprecatedMethod.getClassName(),
-                             deprecatedMethod.getMethodName(),
-                             caller.getClassName(),
-                             caller.getMethodName());
-
+                deprecatedMethod.getClassName(),
+                deprecatedMethod.getMethodName(),
+                caller.getClassName(),
+                caller.getMethodName());
+    }
+    
     /**
      * Retrieves the actual root {@link Throwable} which ended in the given exception.
      *

--- a/src/test/java/sirius/kernel/health/ExceptionsSpec.groovy
+++ b/src/test/java/sirius/kernel/health/ExceptionsSpec.groovy
@@ -1,0 +1,18 @@
+package sirius.kernel.health
+
+import sirius.kernel.BaseSpecification
+
+class ExceptionsSpec extends BaseSpecification {
+
+    def "the root cause"() {
+        when:
+        def root = Exceptions.createHandled().withSystemErrorMessage("Root Cause").handle()
+        def e = new IllegalArgumentException(root)
+        e = new Exception(e)
+        e = Exceptions.handle(e)
+        then:
+        Exceptions.getRootCause(e) instanceof HandledException
+        and:
+        Exceptions.getRootCause(e) == root
+    }
+}


### PR DESCRIPTION
This happens e.g. when we render pdfs. The external library will add our handledException to the root
cause but will throw its own exception. We would then handle the same exception twice, which is unnecessary.
- Fixes: SE-5174