### PR TITLE
Adds a flag which lets all docker containers continue to run.

### DIFF
--- a/src/main/java/sirius/kernel/DockerHelper.java
+++ b/src/main/java/sirius/kernel/DockerHelper.java
@@ -64,6 +64,9 @@ public class DockerHelper extends PortMapper implements Initializable, Killable 
     @ConfigValue("docker.pull")
     private boolean pull;
 
+    @ConfigValue("docker.keepRunning")
+    private boolean keepRunning;
+
     private static final Log LOG = Log.get("docker");
 
     private DockerCompose dockerCompose;
@@ -211,6 +214,10 @@ public class DockerHelper extends PortMapper implements Initializable, Killable 
     @Override
     public void awaitTermination() {
         if (Strings.isEmpty(dockerfile)) {
+            return;
+        }
+
+        if (keepRunning) {
             return;
         }
 


### PR DESCRIPTION
This GREATLY increases the developer productivity as it minimizes
the restart time of the debugger in case of a chance which cannot be
performed via hot code replacement.

This _can_ also be specified when executing tests although this should
be handled with care and not be enabled on a CI system.