### PR TITLE
Corrects javadoc to NLS.getDateTimeFormat and offers a way to recieve dateTimes without seconds

### DIFF
--- a/src/main/java/sirius/kernel/nls/NLS.java
+++ b/src/main/java/sirius/kernel/nls/NLS.java
@@ -712,7 +712,7 @@ public class NLS {
     }
 
     /**
-     * Returns the date and time format (without seconds) for the given language.
+     * Returns the date and time format (with seconds) for the given language.
      *
      * @param lang the language for which the format is requested
      * @return a format initialized with the pattern described by the given language
@@ -720,6 +720,19 @@ public class NLS {
     public static DateTimeFormatter getDateTimeFormat(String lang) {
         return dateTimeFormatters.computeIfAbsent(lang,
                                                   l -> DateTimeFormatter.ofPattern(get("NLS.patternDateTime", l)));
+    }
+
+    /**
+     * Returns the date and time format (without seconds) for the given language.
+     *
+     * @param lang the language for which the format is requested
+     * @return a format initialized with the pattern described by the given language
+     */
+    public static DateTimeFormatter getDateTimeFormatWithoutSeconds(String lang) {
+        return dateTimeFormatters.computeIfAbsent(lang,
+                                                  l -> DateTimeFormatter.ofPattern(get(
+                                                          "NLS.patternDateTime.withoutSeconds",
+                                                          l)));
     }
 
     /**

--- a/src/main/resources/kernel_de.properties
+++ b/src/main/resources/kernel_de.properties
@@ -66,6 +66,7 @@ NLS.oneHourAgo = vor einer Stunde
 NLS.parseError = Objekte vom Typ '${type}' können nicht verarbeitet werden.
 NLS.patternDate = dd.MM.yyyy
 NLS.patternDateTime = dd.MM.yyyy HH:mm:ss
+NLS.patternDateTime.withoutSeconds = dd.MM.yyyy HH:mm
 NLS.patternDecimal = #,##0.00
 NLS.patternFullTime = HH:mm:ss
 NLS.patternParseTime = H[:mm[:ss]]

--- a/src/main/resources/kernel_en.properties
+++ b/src/main/resources/kernel_en.properties
@@ -65,6 +65,7 @@ NLS.oneHourAgo = one hour ago
 NLS.parseError = Objects of type '${type}' cannot be processed.
 NLS.patternDate = MM/dd/yyyy
 NLS.patternDateTime = MM/dd/yyyy HH:mm:ss
+NLS.patternDateTime.withoutSeconds = MM/dd/yyyy HH:mm
 NLS.patternDecimal = #,##0.00
 NLS.patternFullTime = hh:mm:ss a
 NLS.patternParseTime = h[:mm[:ss]] a


### PR DESCRIPTION
NLS::getDateTimeFormat had an error in its javadoc, stating it would omit seconds when infact it didn't.
Creates NLS::getDateTimeFormatWithoutSeconds which omits seconds.

Fixes: SIRI-65