### PR TITLE
Use separated map for formatters with/without seconds

### DIFF
--- a/src/main/java/sirius/kernel/nls/NLS.java
+++ b/src/main/java/sirius/kernel/nls/NLS.java
@@ -94,6 +94,7 @@ public class NLS {
             DateTimeFormatter.ofPattern("H:mm[:ss]", Locale.ENGLISH);
     private static final DateTimeFormatter MACHINE_FORMAT_TIME_FORMAT =
             DateTimeFormatter.ofPattern("HH:mm:ss", Locale.ENGLISH);
+    private static final Map<String, DateTimeFormatter> fullDateTimeFormatters = Maps.newTreeMap();
     private static final Map<String, DateTimeFormatter> dateTimeFormatters = Maps.newTreeMap();
     private static final Map<String, DateTimeFormatter> dateFormatters = Maps.newTreeMap();
     private static final Map<String, DateTimeFormatter> shortDateFormatters = Maps.newTreeMap();
@@ -718,8 +719,8 @@ public class NLS {
      * @return a format initialized with the pattern described by the given language
      */
     public static DateTimeFormatter getDateTimeFormat(String lang) {
-        return dateTimeFormatters.computeIfAbsent(lang,
-                                                  l -> DateTimeFormatter.ofPattern(get("NLS.patternDateTime", l)));
+        return fullDateTimeFormatters.computeIfAbsent(lang,
+                                                      l -> DateTimeFormatter.ofPattern(get("NLS.patternDateTime", l)));
     }
 
     /**

--- a/src/test/java/sirius/kernel/nls/NLSSpec.groovy
+++ b/src/test/java/sirius/kernel/nls/NLSSpec.groovy
@@ -218,4 +218,19 @@ class NLSSpec extends BaseSpecification {
         '$nls.test.translate' | "übersetzungs test"  | "de"
         '$nls.test.translate' | "translation test"   | "en"
     }
+
+    def "test various formatters"(){
+        given:
+        LocalDateTime date = LocalDateTime.of(2000, 1, 2, 3, 4, 5)
+        expect:
+        NLS.getTimeFormat("de").format(date) == "03:04"
+        NLS.getTimeFormat("en").format(date) == "03:04 AM"
+        NLS.getDateTimeFormat("de").format(date) == "02.01.2000 03:04:05"
+        NLS.getDateTimeFormat("en").format(date) == "01/02/2000 03:04:05"
+        NLS.getDateTimeFormatWithoutSeconds("de").format(date) == "02.01.2000 03:04"
+        NLS.getDateTimeFormatWithoutSeconds("en").format(date) == "01/02/2000 03:04"
+        NLS.getTimeFormatWithSeconds("de").format(date) == "03:04:05"
+        NLS.getTimeFormatWithSeconds("en").format(date) == "03:04:05 AM"
+
+    }
 }


### PR DESCRIPTION
Else the formatters will be overriden per language code.