### PR TITLE
Provides additional methods for frameworks to report some activity.

### DIFF
--- a/src/main/java/sirius/kernel/async/BasicTaskContextAdapter.java
+++ b/src/main/java/sirius/kernel/async/BasicTaskContextAdapter.java
@@ -8,6 +8,8 @@
 
 package sirius.kernel.async;
 
+import java.util.function.Supplier;
+
 /**
  * Default implementation for <tt>TaskContextAdapter</tt>
  */
@@ -42,6 +44,21 @@ public class BasicTaskContextAdapter implements TaskContextAdapter {
     @Override
     public void setState(String message) {
         this.state = message;
+    }
+
+    @Override
+    public void logLimited(Object message) {
+        // Ignored by the default implementation.
+    }
+
+    @Override
+    public void smartLogLimited(Supplier<Object> messageSupplier) {
+        // Ignored by the default implementation.
+    }
+
+    @Override
+    public void addTiming(String counter, long millis) {
+        // Ignored by the default implementation.
     }
 
     @Override

--- a/src/main/java/sirius/kernel/async/TaskContext.java
+++ b/src/main/java/sirius/kernel/async/TaskContext.java
@@ -14,6 +14,7 @@ import sirius.kernel.di.std.Part;
 
 import java.util.concurrent.TimeUnit;
 import java.util.function.Consumer;
+import java.util.function.Supplier;
 
 /**
  * Provides an interface between a running task and a monitoring system.
@@ -120,6 +121,50 @@ public class TaskContext implements SubContext {
      */
     public void setState(String newState, Object... args) {
         adapter.setState(Strings.apply(newState, args));
+    }
+
+    /**
+     * Logs the given message unless the method is called too frequently.
+     * <p>
+     * This method has an internal rate limit and can therefore be used by loops etc. to report the progress
+     * every now and then.
+     * <p>
+     * A caller can rely on the rate limit and therefore can invoke this method as often as desired. However
+     * one must not rely on any message to be shown.
+     * <p>
+     * Note that the default implementation will skip these logs entirely.
+     *
+     * @param message the message to add to the logs.
+     */
+    public void logLimited(Object message) {
+        adapter.logLimited(message);
+    }
+
+    /**
+     * Logs the given message unless the method is called too frequently.
+     * <p>
+     * Note that the given supplier is only evaluated if the message will be actually invoked and thus might save the
+     * system from doing excessive computations.
+     *
+     * @param messageSupplier the supplier which yields the message to log on demand
+     */
+    public void smartLogLimited(Supplier<Object> messageSupplier) {
+        adapter.smartLogLimited(messageSupplier);
+    }
+
+    /**
+     * Increments the given performance counter by one and supplies a loop duration in milliseconds.
+     * <p>
+     * The avarage value will be computed for the given counter and gives the user a rough estimate what the current
+     * task is doing.
+     * <p>
+     * Note that the default implementation will simply ignore the provided timings.
+     *
+     * @param counter the counter to increment
+     * @param millis  the current duration for the block being counted
+     */
+    public void addTiming(String counter, long millis) {
+        adapter.addTiming(counter, millis);
     }
 
     /**

--- a/src/main/java/sirius/kernel/async/TaskContextAdapter.java
+++ b/src/main/java/sirius/kernel/async/TaskContextAdapter.java
@@ -8,6 +8,8 @@
 
 package sirius.kernel.async;
 
+import java.util.function.Supplier;
+
 /**
  * Implementations of this interface can be attached to a {@link sirius.kernel.async.TaskContext} of a thread to
  * perform
@@ -35,6 +37,29 @@ public interface TaskContextAdapter {
      * @param message the message to set as state
      */
     void setState(String message);
+
+    /**
+     * Invoked if {@link sirius.kernel.async.TaskContext#logLimited(Object)} is called in the attached context.
+     *
+     * @param message the message to add to the logs.
+     */
+    void logLimited(Object message);
+
+    /**
+     * Invoked if {@link sirius.kernel.async.TaskContext#smartLogLimited(Supplier)} is called in the attached context.
+     *
+     * @param messageSupplier the supplier which yields the message to log on demand
+     * @see #logLimited(Object)
+     */
+    void smartLogLimited(Supplier<Object> messageSupplier);
+
+    /**
+     * Invoked if {@link sirius.kernel.async.TaskContext#addTiming(String, long)} is called in the attached context.
+     *
+     * @param counter the counter to increment
+     * @param millis  the current duration for the block being counted
+     */
+    void addTiming(String counter, long millis);
 
     /**
      * Invoked if {@link TaskContext#markErroneous()} is called in the attached context.


### PR DESCRIPTION
Note that this is ignored by default but can be picked up by frameworks
like Processes in sirius-biz.