### PR TITLE
Makes it possible to reliably overwrite translations

### DIFF
--- a/src/main/java/sirius/kernel/nls/Babelfish.java
+++ b/src/main/java/sirius/kernel/nls/Babelfish.java
@@ -167,16 +167,26 @@ public class Babelfish {
     }
 
     private void loadProvidedProperties(Classpath classpath, Map<String, Translation> newTranslations) {
-        // Load core translations and keep customizations in a separate list as we have to work out the
-        // correct ordering first...
+        // Load core translations.
+        // Files loaded later in the process will overwrite translations added by earlier files.
+        // The order is as follows:
+        // 1. Load the regualar files.
+        // 2. Load the "product"-prefix files.
+        // 3. Load the customizations files.
+
         List<Matcher> customizations = Lists.newArrayList();
+        List<Matcher> productFiles = Lists.newArrayList();
         classpath.find(PROPERTIES_FILE).forEach(value -> {
             if (Sirius.isCustomizationResource(value.group())) {
                 customizations.add(value);
+            } else if (value.group().startsWith("product")) {
+                productFiles.add(value);
             } else {
                 loadMatchedResource(value, newTranslations);
             }
         });
+
+        productFiles.forEach(value -> loadMatchedResource(value, newTranslations));
 
         // Sort configurations according to system config
         customizations.sort((a, b) -> {

--- a/src/main/java/sirius/kernel/nls/Babelfish.java
+++ b/src/main/java/sirius/kernel/nls/Babelfish.java
@@ -239,7 +239,7 @@ public class Babelfish {
         entry.setAutocreated(false);
 
         String previous = entry.addTranslation(lang, value);
-        if (previous != null && !Strings.areEqual(previous, value) && !Sirius.isCustomizationResource(file)) {
+        if (shouldLogOverrideWarning(file, value, previous)) {
             Babelfish.LOG.WARN("Overriding translation for '%s' (%s) in language %s: '%s' --> '%s'",
                                key,
                                file,
@@ -247,6 +247,19 @@ public class Babelfish {
                                previous,
                                value);
         }
+    }
+
+    private boolean shouldLogOverrideWarning(String file, String value, String previous) {
+        if (previous == null) {
+            return false;
+        }
+        if (Strings.areEqual(previous, value)) {
+            return false;
+        }
+        if (Sirius.isCustomizationResource(file)) {
+            return false;
+        }
+        return !"product".equals(file);
     }
 
     /**


### PR DESCRIPTION
By loading files with the "product"-prefix after the regular translations