### PR TITLE
Adds flatMapping from Values to Optionals

### DIFF
--- a/src/main/java/sirius/kernel/commons/Value.java
+++ b/src/main/java/sirius/kernel/commons/Value.java
@@ -250,9 +250,10 @@ public class Value {
 
     /**
      * Returns an optional value computed by the given mapper. If this value is <tt>empty</tt> the mapper will not
-     * be called, but an empty optional will be returned. This method is similar to {@link #map(Function)},
-     * but the provided mapper is one whose result is already an {@link Optional}, and if invoked,
-     * {@code flatMap} does not wrap it with an additional {@link Optional}.
+     * be called, but an empty optional will be returned.
+     * <p>
+     * This method is similar to {@link #map(Function)}, but the provided mapper is one whose result is already an {@link Optional},
+     * and if invoked, {@code flatMap} does not wrap it with an additional {@link Optional}.
      *
      * @param mapper the function used to convert the value into the desired optional object
      * @param <R>    the type of the desired result

--- a/src/main/java/sirius/kernel/commons/Value.java
+++ b/src/main/java/sirius/kernel/commons/Value.java
@@ -217,18 +217,36 @@ public class Value {
     }
 
     /**
-     * Returns an optional value computed by the given mapper. If this value is <tt>empty</tt> the mapper will not
+     * Returns an optional wrapping the value computed by the given mapper. If this value is <tt>empty</tt> the mapper will not
      * be called, but an empty optional will be returned.
      *
      * @param mapper the function used to convert the value into the desired object
      * @param <R>    the type of the desired result
-     * @return an Optional object wrapping the result of the computation or an empty Optional, if the value wasn't
-     * filled
+     * @return an Optional object wrapping the result of the computation or an empty Optional, if the value wasn't filled
      */
     @Nonnull
     public <R> Optional<R> map(@Nonnull Function<Value, R> mapper) {
         if (isFilled()) {
             return Optional.ofNullable(mapper.apply(this));
+        } else {
+            return Optional.empty();
+        }
+    }
+
+    /**
+     * Returns an optional value computed by the given mapper. If this value is <tt>empty</tt> the mapper will not
+     * be called, but an empty optional will be returned. This method is similar to {@link #map(Function)},
+     * but the provided mapper is one whose result is already an {@link Optional}, and if invoked,
+     * {@code flatMap} does not wrap it with an additional {@link Optional}.
+     *
+     * @param mapper the function used to convert the value into the desired optional object
+     * @param <R>    the type of the desired result
+     * @return the Optional object from the result of the computation or an empty Optional, if the value wasn't filled
+     */
+    @Nonnull
+    public <R> Optional<R> flatMap(@Nonnull Function<Value, Optional<R>> mapper) {
+        if (isFilled()) {
+            return mapper.apply(this);
         } else {
             return Optional.empty();
         }

--- a/src/test/java/sirius/kernel/commons/ValueSpec.groovy
+++ b/src/test/java/sirius/kernel/commons/ValueSpec.groovy
@@ -176,4 +176,35 @@ class ValueSpec extends BaseSpecification {
         LocalDate.of(1999, 1, 1) | LocalDate.of(1999, 1, 1) | null
         ["test1", "test2"]       | ["test1", "test2"]       | null
     }
+
+    def "Boxing and retrieving an amount works"() {
+        expect:
+        Value.of(Amount.of(0.00001)).getAmount() == Amount.of(0.00001)
+    }
+    
+    def "map() does not call the mapper on an empty Value"() {
+        given:
+        def count = 0
+        def mapper = { value ->
+            count++
+            ""
+        }
+        when:
+        Value.EMPTY.map(mapper)
+        then:
+        count == 0
+    }
+
+    def "flatMap() does not call the mapper on an empty Value"() {
+        given:
+        def count = 0
+        def mapper = { value ->
+            count++
+            Optional.empty()
+        }
+        when:
+        Value.EMPTY.flatMap(mapper)
+        then:
+        count == 0
+    }
 }


### PR DESCRIPTION
This for example can simplify code like this:

```
portal.getConfig("standard.requestTargetPortal")
                                    .map(value -> mango.find(Portal.class, value.asString()).orElse(portal))
                                    .orElse(portal);
```

to

```
portal.getConfig("standard.requestTargetPortal")
                                    .flatMap(value -> mango.find(Portal.class, value.asString()))
                                    .orElse(portal);
```

and can save even more depending on the onElse implementation