### PR TITLE
Add fast-track to Value#asBoolean

### DIFF
--- a/src/main/java/sirius/kernel/commons/Value.java
+++ b/src/main/java/sirius/kernel/commons/Value.java
@@ -663,6 +663,15 @@ public class Value {
         if (data instanceof Boolean) {
             return (Boolean) data;
         }
+
+        // fast-track for common cases without the need to involve NLS framework
+        if ("true".equalsIgnoreCase(String.valueOf(data))) {
+            return true;
+        }
+        if ("false".equalsIgnoreCase(String.valueOf(data))) {
+            return false;
+        }
+
         return NLS.parseUserString(Boolean.class, String.valueOf(data).trim());
     }
 


### PR DESCRIPTION
This skips the need to call "NLS#parseUserString" which calls "CallContext#getLang", which initialises the language to the default-language when no language is set. This is what we want to avoid, because else the default-lang is set before the user is added to the context and so the default-lang is set instead of the user-language in some cases (after first login)

Fixes: OX-5421