### PR TITLE
Removes a warning which created excessive warnings during startup.

### DIFF
--- a/src/main/java/sirius/kernel/settings/ExtendedSettings.java
+++ b/src/main/java/sirius/kernel/settings/ExtendedSettings.java
@@ -64,12 +64,12 @@ import java.util.concurrent.ConcurrentHashMap;
 public class ExtendedSettings extends Settings {
 
     /**
-     * Used as cache for already loaded extension lists
+     * Used as cache for already loaded extension lists.
      */
     private Map<String, Map<String, Extension>> cache = new ConcurrentHashMap<>();
 
     /**
-     * Used as cache for the default values of a given extension type
+     * Used as cache for the default values of a given extension type.
      */
     private Map<String, Extension> defaultsCache = new ConcurrentHashMap<>();
 
@@ -83,7 +83,7 @@ public class ExtendedSettings extends Settings {
     }
 
     /**
-     * Returns the <tt>Extension</tt> for the given <tt>id</tt> of the given <tt>type</tt>
+     * Returns the <tt>Extension</tt> for the given <tt>id</tt> of the given <tt>type</tt>.
      *
      * @param type the type of the extension to be returned
      * @param id   the unique id of the extension to be returned
@@ -100,7 +100,7 @@ public class ExtendedSettings extends Settings {
     }
 
     /**
-     * Returns all extensions available for the given type
+     * Returns all extensions available for the given type.
      * <p>
      * The order of the extensions can be defined, setting a property named <tt>priority</tt>. If no value is
      * present {@link sirius.kernel.commons.PriorityCollector#DEFAULT_PRIORITY} is assumed.

--- a/src/main/java/sirius/kernel/settings/ExtendedSettings.java
+++ b/src/main/java/sirius/kernel/settings/ExtendedSettings.java
@@ -12,7 +12,6 @@ import com.google.common.collect.Maps;
 import com.typesafe.config.Config;
 import com.typesafe.config.ConfigObject;
 import com.typesafe.config.ConfigValue;
-import sirius.kernel.Sirius;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
@@ -22,7 +21,6 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
-import java.util.regex.Pattern;
 
 /**
  * Provides an advanced wrapper for a {@link Config} object, which supports to represent inner maps as {@link Extension
@@ -66,11 +64,6 @@ import java.util.regex.Pattern;
 public class ExtendedSettings extends Settings {
 
     /**
-     * Provides a regular expression which verifies if an extension name is well formed.
-     */
-    public static final Pattern VALID_EXTENSION_ID = Pattern.compile("[a-z0-9\\-]+");
-
-    /**
      * Used as cache for already loaded extension lists
      */
     private Map<String, Map<String, Extension>> cache = new ConcurrentHashMap<>();
@@ -98,11 +91,6 @@ public class ExtendedSettings extends Settings {
      */
     @Nullable
     public Extension getExtension(String type, String id) {
-        if (Sirius.isDev() && !VALID_EXTENSION_ID.matcher(id).matches()) {
-            Extension.LOG.WARN("Bad extension id detected: '%s' (for type: %s). Names should only consist of"
-                               + " lowercase letters, digits or '-'", id, type);
-        }
-
         Extension result = getExtensionMap(type).get(id);
         if (result == null) {
             return getDefault(type);


### PR DESCRIPTION
Due to naming conventions and legacy code this warning triggered a lot of false alarms.
Therefore it was removed entirely.