### PR TITLE
Splits the parsing from the resolving part when loading the system co…

### DIFF
--- a/src/main/java/sirius/kernel/Setup.java
+++ b/src/main/java/sirius/kernel/Setup.java
@@ -418,7 +418,7 @@ public class Setup {
         Sirius.getClasspath().find(Pattern.compile("application-([^.]*?)\\.conf")).forEach(value -> {
             try {
                 Sirius.LOG.INFO("Loading config: %s", value.group());
-                result.set(result.get().withFallback(ConfigFactory.load(getLoader(), value.group())));
+                result.set(result.get().withFallback(ConfigFactory.parseResources(getLoader(), value.group())));
             } catch (Exception e) {
                 Exceptions.ignore(e);
                 Sirius.LOG.WARN("Cannot load %s: %s", value, e.getMessage());
@@ -428,7 +428,7 @@ public class Setup {
         if (Sirius.class.getResource("/application.conf") != null) {
             Sirius.LOG.INFO("using application.conf from classpath...");
             try {
-                result.set(ConfigFactory.load(loader, "application.conf").withFallback(result.get()));
+                result.set(ConfigFactory.parseResources(loader, "application.conf").withFallback(result.get()));
             } catch (Exception e) {
                 Exceptions.ignore(e);
                 Sirius.LOG.WARN("Cannot load application.conf: %s", e.getMessage());
@@ -454,7 +454,7 @@ public class Setup {
         if (Sirius.class.getResource("/test.conf") != null) {
             Sirius.LOG.INFO("using test.conf from classpath...");
             try {
-                return ConfigFactory.load(loader, "test.conf").withFallback(config);
+                return ConfigFactory.parseResources(loader, "test.conf").withFallback(config);
             } catch (Exception e) {
                 Exceptions.ignore(e);
                 Sirius.LOG.WARN("Cannot load test.conf: %s", e.getMessage());
@@ -482,7 +482,7 @@ public class Setup {
 
         Sirius.LOG.INFO("using %s from classpath...", scenarioFile);
         try {
-            return ConfigFactory.load(loader, scenarioFile).withFallback(config);
+            return ConfigFactory.parseResources(loader, scenarioFile).withFallback(config);
         } catch (Exception e) {
             Exceptions.ignore(e);
             Sirius.LOG.WARN("Cannot load test.conf: %s", e.getMessage());

--- a/src/main/java/sirius/kernel/Sirius.java
+++ b/src/main/java/sirius/kernel/Sirius.java
@@ -306,7 +306,7 @@ public class Sirius {
                 LOG.INFO("loading settings.conf for customization '" + conf + "'");
                 String configName = "customizations/" + conf + "/settings.conf";
                 try {
-                    config = ConfigFactory.load(setup.getLoader(), configName).withFallback(config);
+                    config = ConfigFactory.parseResources(setup.getLoader(), configName).withFallback(config);
                 } catch (Exception e) {
                     handleConfigError(configName, e);
                 }
@@ -343,7 +343,7 @@ public class Sirius {
             classpath.find(Pattern.compile("component-test-([^.]*?)\\.conf")).forEach(value -> {
                 try {
                     LOG.INFO("Loading test config: %s", value.group());
-                    config = config.withFallback(ConfigFactory.load(setup.getLoader(), value.group()));
+                    config = config.withFallback(ConfigFactory.parseResources(setup.getLoader(), value.group()));
                 } catch (Exception e) {
                     handleConfigError(value.group(), e);
                 }
@@ -355,12 +355,14 @@ public class Sirius {
             if (!"test".equals(value.group(1))) {
                 try {
                     LOG.INFO("Loading config: %s", value.group());
-                    config = config.withFallback(ConfigFactory.load(setup.getLoader(), value.group()));
+                    config = config.withFallback(ConfigFactory.parseResources(setup.getLoader(), value.group()));
                 } catch (Exception e) {
                     handleConfigError(value.group(), e);
                 }
             }
         });
+
+        config = config.resolve();
 
         LOG.INFO(SEPARATOR_LINE);
     }


### PR DESCRIPTION
…nfig.

This is required e.g. to merge arrays where an instance.conf or a
application.conf enhances an array or string from a base config.

Fixes: SIRI-72