### PR TITLE
Drops log4j and reduces usage of Guava.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -32,7 +32,7 @@
         <dependency>
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
-            <version>21.0</version>
+            <version>28.2-jre</version>
         </dependency>
 
         <!-- JSR305 annotations like @Nonnull etc. -->

--- a/pom.xml
+++ b/pom.xml
@@ -35,13 +35,6 @@
             <version>21.0</version>
         </dependency>
 
-        <!-- The logging framework we use -->
-        <dependency>
-            <groupId>log4j</groupId>
-            <artifactId>log4j</artifactId>
-            <version>1.2.17</version>
-        </dependency>
-
         <!-- JSR305 annotations like @Nonnull etc. -->
         <dependency>
             <groupId>com.google.code.findbugs</groupId>
@@ -49,11 +42,11 @@
             <version>3.0.2</version>
         </dependency>
 
-        <!-- Required logging bridge to make slf4j log to log4j -->
+        <!-- Required logging bridge to make slf4j log to our logging system -->
         <dependency>
             <groupId>org.slf4j</groupId>
-            <artifactId>slf4j-log4j12</artifactId>
-            <version>1.7.28</version>
+            <artifactId>slf4j-jdk14</artifactId>
+            <version>1.7.30</version>
         </dependency>
 
         <!-- Used to auto-start Docker environments -->

--- a/src/main/java/sirius/kernel/Classpath.java
+++ b/src/main/java/sirius/kernel/Classpath.java
@@ -8,7 +8,6 @@
 
 package sirius.kernel;
 
-import com.google.common.base.Objects;
 import sirius.kernel.commons.Strings;
 import sirius.kernel.health.Log;
 
@@ -22,6 +21,7 @@ import java.util.Collections;
 import java.util.Comparator;
 import java.util.Enumeration;
 import java.util.List;
+import java.util.Objects;
 import java.util.jar.JarEntry;
 import java.util.jar.JarFile;
 import java.util.regex.Matcher;
@@ -155,7 +155,7 @@ public class Classpath {
     private String buildRelativePath(File reference, File child) {
         List<String> path = new ArrayList<>();
         File iter = child;
-        while (iter != null && !Objects.equal(iter, reference)) {
+        while (iter != null && !Objects.equals(iter, reference)) {
             path.add(0, iter.getName());
             iter = iter.getParentFile();
         }

--- a/src/main/java/sirius/kernel/Sirius.java
+++ b/src/main/java/sirius/kernel/Sirius.java
@@ -10,7 +10,6 @@ package sirius.kernel;
 
 import com.typesafe.config.Config;
 import com.typesafe.config.ConfigFactory;
-import org.apache.log4j.Level;
 import sirius.kernel.async.Future;
 import sirius.kernel.async.Operation;
 import sirius.kernel.async.Tasks;
@@ -34,6 +33,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.logging.Level;
 import java.util.regex.Pattern;
 
 /**
@@ -135,7 +135,7 @@ public class Sirius {
      */
     private static void setupLogLevels() {
         if (Sirius.isDev()) {
-            Log.setLevel(DEBUG_LOGGER_NAME, Level.ALL);
+            Log.setLevel(DEBUG_LOGGER_NAME, Level.FINEST);
         } else {
             Log.setLevel(DEBUG_LOGGER_NAME, Level.OFF);
         }
@@ -159,7 +159,7 @@ public class Sirius {
         Config logging = config.getConfig("logging");
         for (Map.Entry<String, com.typesafe.config.ConfigValue> entry : logging.entrySet()) {
             LOG.INFO("* Setting %s to: %s", entry.getKey(), logging.getString(entry.getKey()));
-            Log.setLevel(entry.getKey(), Level.toLevel(logging.getString(entry.getKey())));
+            Log.setLevel(entry.getKey(), Level.parse(logging.getString(entry.getKey())));
         }
     }
 

--- a/src/main/java/sirius/kernel/Sirius.java
+++ b/src/main/java/sirius/kernel/Sirius.java
@@ -8,8 +8,6 @@
 
 package sirius.kernel;
 
-import com.google.common.collect.Lists;
-import com.google.common.collect.Maps;
 import com.typesafe.config.Config;
 import com.typesafe.config.ConfigFactory;
 import org.apache.log4j.Level;
@@ -31,7 +29,9 @@ import javax.annotation.Nullable;
 import java.lang.management.ManagementFactory;
 import java.lang.management.ThreadInfo;
 import java.time.Duration;
+import java.util.ArrayList;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.regex.Pattern;
@@ -57,8 +57,8 @@ public class Sirius {
     private static Setup setup;
     private static Config config;
     private static ExtendedSettings settings;
-    private static Map<String, Boolean> frameworks = Maps.newHashMap();
-    private static List<String> customizations = Lists.newArrayList();
+    private static Map<String, Boolean> frameworks = new HashMap<>();
+    private static List<String> customizations = new ArrayList<>();
     private static Classpath classpath;
     private static volatile boolean started = false;
     private static volatile boolean initialized = false;
@@ -169,7 +169,7 @@ public class Sirius {
      */
     private static void setupFrameworks() {
         Config frameworkConfig = config.getConfig("sirius.frameworks");
-        Map<String, Boolean> frameworkStatus = Maps.newHashMap();
+        Map<String, Boolean> frameworkStatus = new HashMap<>();
         int total = 0;
         int numEnabled = 0;
         LOG.DEBUG_INFO("Scanning framework status (sirius.frameworks):");

--- a/src/main/java/sirius/kernel/async/CallContext.java
+++ b/src/main/java/sirius/kernel/async/CallContext.java
@@ -8,7 +8,6 @@
 
 package sirius.kernel.async;
 
-import com.google.common.collect.Maps;
 import sirius.kernel.Sirius;
 import sirius.kernel.commons.Strings;
 import sirius.kernel.commons.Tuple;
@@ -26,6 +25,7 @@ import java.net.InetAddress;
 import java.net.UnknownHostException;
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -60,7 +60,7 @@ public class CallContext {
     public static final String MDC_PARENT = "parent";
 
     private static final ThreadLocal<CallContext> currentContext = new ThreadLocal<>();
-    private static Map<Long, CallContext> contextMap = Maps.newConcurrentMap();
+    private static Map<Long, CallContext> contextMap = new ConcurrentHashMap<>();
     private static String nodeName = null;
     private static Counter interactionCounter = new Counter();
 
@@ -69,7 +69,7 @@ public class CallContext {
     /*
      * Needs to be synchronized as a CallContext might be shared across several sub tasks
      */
-    private Map<Class<? extends SubContext>, SubContext> subContext = Collections.synchronizedMap(Maps.newHashMap());
+    private Map<Class<? extends SubContext>, SubContext> subContext = Collections.synchronizedMap(new HashMap<>());
     private Watch watch = Watch.start();
     private String lang;
     private Consumer<CallContext> lazyLanguageInstaller;

--- a/src/main/java/sirius/kernel/async/Operation.java
+++ b/src/main/java/sirius/kernel/async/Operation.java
@@ -8,7 +8,6 @@
 
 package sirius.kernel.async;
 
-import com.google.common.collect.Lists;
 import sirius.kernel.commons.Watch;
 import sirius.kernel.di.std.Register;
 import sirius.kernel.health.metrics.MetricProvider;
@@ -16,6 +15,7 @@ import sirius.kernel.health.metrics.MetricsCollector;
 import sirius.kernel.nls.NLS;
 
 import java.time.Duration;
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Set;
@@ -97,7 +97,7 @@ public class Operation implements AutoCloseable {
      * @return a list of all known operations
      */
     public static List<Operation> getActiveOperations() {
-        return Lists.newArrayList(ops);
+        return new ArrayList<>(ops);
     }
 
     /**

--- a/src/main/java/sirius/kernel/async/Tasks.java
+++ b/src/main/java/sirius/kernel/async/Tasks.java
@@ -8,8 +8,6 @@
 
 package sirius.kernel.async;
 
-import com.google.common.collect.Lists;
-import com.google.common.collect.Maps;
 import sirius.kernel.Killable;
 import sirius.kernel.Sirius;
 import sirius.kernel.Startable;
@@ -30,6 +28,7 @@ import java.time.Duration;
 import java.time.Instant;
 import java.time.LocalDateTime;
 import java.time.ZoneId;
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Iterator;
@@ -72,7 +71,7 @@ public class Tasks implements Startable, Stoppable, Killable {
     public static final int LIFECYCLE_PRIORITY = 25;
 
     protected static final Log LOG = Log.get("tasks");
-    protected final Map<String, AsyncExecutor> executors = Maps.newConcurrentMap();
+    protected final Map<String, AsyncExecutor> executors = new ConcurrentHashMap<>();
 
     // If sirius is not started yet, we still consider it running already as the intention of this flag
     // is to detect a system halt and not to check if the startup sequence has finished.
@@ -82,7 +81,7 @@ public class Tasks implements Startable, Stoppable, Killable {
     private static PartCollection<BackgroundLoop> backgroundLoops;
 
     private final Map<Object, Long> scheduleTable = new ConcurrentHashMap<>();
-    private final List<ExecutionBuilder.TaskWrapper> schedulerQueue = Lists.newArrayList();
+    private final List<ExecutionBuilder.TaskWrapper> schedulerQueue = new ArrayList<>();
     private final Lock schedulerLock = new ReentrantLock();
     private final Condition workAvailable = schedulerLock.newCondition();
 
@@ -359,7 +358,7 @@ public class Tasks implements Startable, Stoppable, Killable {
      */
     public List<Tuple<String, LocalDateTime>> getScheduledTasks() {
         synchronized (schedulerQueue) {
-            List<Tuple<String, LocalDateTime>> result = Lists.newArrayList();
+            List<Tuple<String, LocalDateTime>> result = new ArrayList<>();
             for (ExecutionBuilder.TaskWrapper wrapper : schedulerQueue) {
                 result.add(Tuple.create(wrapper.category + " / " + wrapper.synchronizer.getClass().getName(),
                                         LocalDateTime.ofInstant(Instant.ofEpochMilli(wrapper.waitUntil),

--- a/src/main/java/sirius/kernel/commons/CSVReader.java
+++ b/src/main/java/sirius/kernel/commons/CSVReader.java
@@ -8,12 +8,12 @@
 
 package sirius.kernel.commons;
 
-import com.google.common.collect.Lists;
 import sirius.kernel.async.TaskContext;
 
 import javax.annotation.Nonnull;
 import java.io.IOException;
 import java.io.Reader;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.function.Consumer;
 
@@ -180,7 +180,7 @@ public class CSVReader {
      * input as quotet columns may contain line breaks.
      */
     private void readRow() throws IOException {
-        List<String> row = Lists.newArrayList();
+        List<String> row = new ArrayList<>();
         while (!isEOF() && !isAtNewline()) {
             row.add(readField());
             if (buffer == separator) {

--- a/src/main/java/sirius/kernel/commons/Hasher.java
+++ b/src/main/java/sirius/kernel/commons/Hasher.java
@@ -1,0 +1,201 @@
+/*
+ * Made with all the love in the world
+ * by scireum in Remshalden, Germany
+ *
+ * Copyright by scireum GmbH
+ * http://www.scireum.de - info@scireum.de
+ */
+
+package sirius.kernel.commons;
+
+import sirius.kernel.health.Exceptions;
+import sirius.kernel.health.Log;
+
+import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.util.Base64;
+
+/**
+ * Provides a convenient way of computing commong hash functions.
+ */
+public class Hasher {
+
+    private static final MessageDigest MD5 = obtainDigest("MD5");
+    private static final MessageDigest SHA1 = obtainDigest("SHA1");
+    private static final MessageDigest SHA256 = obtainDigest("SHA-256");
+    private static final MessageDigest SHA512 = obtainDigest("SHA-512");
+
+    private MessageDigest digest;
+
+    private Hasher(MessageDigest digest) {
+        this.digest = digest;
+    }
+
+    private static MessageDigest obtainDigest(String name) {
+        try {
+            return MessageDigest.getInstance(name);
+        } catch (NoSuchAlgorithmException e) {
+            Log.SYSTEM.SEVERE(e);
+            return null;
+        }
+    }
+
+    /**
+     * Creates a hasher based on the <tt>MD5</tt> hash function.
+     *
+     * @return a new instance to perform the hash function
+     */
+    public static Hasher md5() {
+        try {
+            return new Hasher((MessageDigest) MD5.clone());
+        } catch (Exception e) {
+            throw Exceptions.handle(Log.SYSTEM, e);
+        }
+    }
+
+    /**
+     * Creates a hasher based on the <tt>SHA 1</tt> hash function.
+     *
+     * @return a new instance to perform the hash function
+     */
+    public static Hasher sha1() {
+        try {
+            return new Hasher((MessageDigest) SHA1.clone());
+        } catch (Exception e) {
+            throw Exceptions.handle(Log.SYSTEM, e);
+        }
+    }
+
+    /**
+     * Creates a hasher based on the <tt>SHA 256</tt> hash function.
+     *
+     * @return a new instance to perform the hash function
+     */
+    public static Hasher sha256() {
+        try {
+            return new Hasher((MessageDigest) SHA256.clone());
+        } catch (Exception e) {
+            throw Exceptions.handle(Log.SYSTEM, e);
+        }
+    }
+
+    /**
+     * Creates a hasher based on the <tt>SHA 512</tt> hash function.
+     *
+     * @return a new instance to perform the hash function
+     */
+    public static Hasher sha512() {
+        try {
+            return new Hasher((MessageDigest) SHA512.clone());
+        } catch (Exception e) {
+            throw Exceptions.handle(Log.SYSTEM, e);
+        }
+    }
+
+    /**
+     * Appends the given value to the data to be hashed.
+     *
+     * @param value the value to hash. If <tt>null</tt> is given, the call is ignored. Otherwise, we use the
+     *              <b>UTF-8</b> bytes of the string representation of the given value.
+     * @return the hasher itself for fluent method calls
+     */
+    public Hasher hash(Object value) {
+        if (value == null) {
+            return this;
+        }
+
+        checkState();
+
+        this.digest.update(value.toString().getBytes(StandardCharsets.UTF_8));
+        return this;
+    }
+
+    private void checkState() {
+        if (digest == null) {
+            throw new IllegalStateException("Hash has already been computed");
+        }
+    }
+
+    /**
+     * Appends the given bytes to the data to be hashed.
+     *
+     * @param data the bytes to put into the hash function
+     * @return the hasher itself for fluent method calls
+     */
+    public Hasher hashBytes(byte[] data) {
+        checkState();
+
+        this.digest.update(data);
+        return this;
+    }
+
+    /**
+     * Appends the bytes of the given long value to the data to be hashed.
+     * @param data the long value to be hashed
+     *  @return the hasher itself for fluent method calls
+     */
+    public Hasher hashLong(long data) {
+        ByteBuffer buffer = ByteBuffer.allocate(Long.BYTES);
+        buffer.putLong(data);
+        return hashBytes(buffer.array());
+    }
+
+    /**
+     * Appends the given bytes to the data to be hashed.
+     *
+     * @param data   the bytes to put into the hash function
+     * @param offset the offset to start from in the array of bytes
+     * @param length the number of bytes to use, starting at <tt>offset</tt>
+     * @return the hasher itself for fluent method calls
+     */
+    public Hasher hashBytes(byte[] data, int offset, int length) {
+        checkState();
+
+        this.digest.update(data, offset, length);
+        return this;
+    }
+
+    /**
+     * Computes the hash function and returns the resulting bytes.
+     *
+     * @return the computes hash as byte array
+     */
+    public byte[] toHash() {
+        checkState();
+
+        byte[] result = digest.digest();
+        digest = null;
+        return result;
+    }
+
+    @Override
+    public String toString() {
+        return toHexString();
+    }
+
+    /**
+     * Computes the hash function and returns the resulting bytes as hex string.
+     *
+     * @return the computes hash as a string in hexadecimal encoded values
+     */
+    public String toHexString() {
+        byte[] hash = toHash();
+        StringBuilder sb = new StringBuilder(hash.length * 2);
+        for (byte b : hash) {
+            sb.append(String.format("%02x", b));
+        }
+
+        return sb.toString();
+    }
+
+    /**
+     * Computes the hash function and returns the resulting bytes as BASE64 string.
+     *
+     * @return the computes hash as a string using BASE64 as encoding
+     */
+    public String toBase64String() {
+        return Base64.getEncoder().encodeToString(toHash());
+    }
+}

--- a/src/main/java/sirius/kernel/commons/Streams.java
+++ b/src/main/java/sirius/kernel/commons/Streams.java
@@ -1,0 +1,111 @@
+/*
+ * Made with all the love in the world
+ * by scireum in Remshalden, Germany
+ *
+ * Copyright by scireum GmbH
+ * http://www.scireum.de - info@scireum.de
+ */
+
+package sirius.kernel.commons;
+
+import java.io.BufferedReader;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.io.Reader;
+import java.io.StringWriter;
+import java.io.Writer;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Provides utility methods when working with {@link InputStream input-} and {@link OutputStream output streams}.
+ */
+public class Streams {
+
+    private Streams() {
+
+    }
+
+    /**
+     * Transfers all bytes from the given source to the destination.
+     *
+     * @param source      the source to read bytes from
+     * @param destination the destination to write the bytes to
+     * @return the total number of transferred bytes
+     * @throws IOException in case of an IO error thrown by either the source or the destination
+     */
+    public static long transfer(InputStream source, OutputStream destination) throws IOException {
+        byte[] buffer = new byte[8192];
+        long transferredBytes = 0;
+        int readBytes = 0;
+        while ((readBytes = source.read(buffer)) > 0) {
+            destination.write(buffer, 0, readBytes);
+            transferredBytes += readBytes;
+        }
+
+        return transferredBytes;
+    }
+
+    /**
+     * Reads all available bytes in the given source.
+     *
+     * @param source the source to read all bytes from
+     * @return the number of bytes read
+     * @throws IOException in case of an IO error while reading from the source
+     */
+    public static long exhaust(InputStream source) throws IOException {
+        byte[] buffer = new byte[8192];
+        long totalBytes = 0;
+        int readBytes = 0;
+        while ((readBytes = source.read(buffer)) > 0) {
+            totalBytes += readBytes;
+        }
+
+        return totalBytes;
+    }
+
+    public static byte[] toByteArray(InputStream source) throws IOException {
+        ByteArrayOutputStream destination = new ByteArrayOutputStream();
+        transfer(source, destination);
+        return destination.toByteArray();
+    }
+
+    /**
+     * Transfers all bytes from the given source to the destination.
+     *
+     * @param source      the source to read bytes from
+     * @param destination the destination to write the bytes to
+     * @return the total number of transferred bytes
+     * @throws IOException in case of an IO error thrown by either the source or the destination
+     */
+    public static long transfer(Reader source, Writer destination) throws IOException {
+        char[] buffer = new char[4096];
+        long transferredBytes = 0;
+        int readBytes = 0;
+        while ((readBytes = source.read(buffer)) > 0) {
+            destination.write(buffer, 0, readBytes);
+            transferredBytes += readBytes;
+        }
+
+        return transferredBytes;
+    }
+
+    public static String readToString(Reader reader) throws IOException {
+        StringWriter destination = new StringWriter();
+        transfer(reader, destination);
+        return destination.toString();
+    }
+
+    public static List<String> readLines(Reader reader) throws IOException {
+        List<String> result = new ArrayList<>();
+        BufferedReader bufferedReader = new BufferedReader(reader);
+        String line;
+        while ((line = bufferedReader.readLine()) != null) {
+            result.add(line);
+        }
+
+        return result;
+    }
+}

--- a/src/main/java/sirius/kernel/commons/Strings.java
+++ b/src/main/java/sirius/kernel/commons/Strings.java
@@ -8,7 +8,6 @@
 
 package sirius.kernel.commons;
 
-import com.google.common.base.Objects;
 import sirius.kernel.health.Exceptions;
 import sirius.kernel.nls.NLS;
 
@@ -20,6 +19,7 @@ import java.nio.charset.StandardCharsets;
 import java.security.SecureRandom;
 import java.util.Arrays;
 import java.util.Map;
+import java.util.Objects;
 import java.util.TreeMap;
 import java.util.function.UnaryOperator;
 import java.util.regex.Matcher;
@@ -168,7 +168,7 @@ public class Strings {
         if (isEmpty(effectiveLeft)) {
             return isEmpty(effectiveRight);
         }
-        return Objects.equal(effectiveLeft, effectiveRight);
+        return Objects.equals(effectiveLeft, effectiveRight);
     }
 
     /**

--- a/src/main/java/sirius/kernel/commons/Trie.java
+++ b/src/main/java/sirius/kernel/commons/Trie.java
@@ -8,14 +8,13 @@
 
 package sirius.kernel.commons;
 
-import com.google.common.collect.Lists;
-import com.google.common.collect.Sets;
-
 import javax.annotation.Nonnull;
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
+import java.util.TreeSet;
 
 /**
  * A map like data structure which associates strings (char sequences) to values.
@@ -167,12 +166,12 @@ public class Trie<V> {
         /**
          * Contains a sorted list of keys
          */
-        private List<Character> keys = Lists.newArrayList();
+        private List<Character> keys = new ArrayList<>();
 
         /**
          * Contains the list of continuations matching the keys list
          */
-        private List<Node> continuations = Lists.newArrayList();
+        private List<Node> continuations = new ArrayList<>();
 
         /**
          * Contains the value associated with the path to this node
@@ -248,7 +247,7 @@ public class Trie<V> {
 
         @Override
         public Set<Character> getPossibilities() {
-            return Sets.newTreeSet(current.keys);
+            return new TreeSet<>(current.keys);
         }
 
         @Override
@@ -372,7 +371,7 @@ public class Trie<V> {
     private Set<String> getAllKeysBeginningWith(String prefix, ContainmentIterator<V> iter) {
         if (iter.getPossibilities().isEmpty()) {
             if (iter.getValue() != null) {
-                return Sets.newHashSet(prefix);
+                return Collections.singleton(prefix);
             } else {
                 return Collections.emptySet();
             }

--- a/src/main/java/sirius/kernel/commons/Tuple.java
+++ b/src/main/java/sirius/kernel/commons/Tuple.java
@@ -8,14 +8,13 @@
 
 package sirius.kernel.commons;
 
-import com.google.common.base.Objects;
-
 import javax.annotation.Nonnull;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.function.BinaryOperator;
 import java.util.function.Function;
 import java.util.function.Supplier;
@@ -133,7 +132,7 @@ public class Tuple<F, S> {
         }
         Tuple<?, ?> other = (Tuple<?, ?>) obj;
 
-        return Objects.equal(first, other.getFirst()) && Objects.equal(second, other.getSecond());
+        return Objects.equals(first, other.getFirst()) && Objects.equals(second, other.getSecond());
     }
 
     @Override
@@ -143,7 +142,7 @@ public class Tuple<F, S> {
 
     @Override
     public int hashCode() {
-        return Objects.hashCode(first, second);
+        return Objects.hash(first, second);
     }
 
     /**
@@ -231,9 +230,7 @@ public class Tuple<F, S> {
     public static <K, V> Collector<Tuple<K, V>, Map<K, V>, Map<K, V>> toMap(Supplier<Map<K, V>> supplier,
                                                                             BinaryOperator<V> merger) {
         return Collector.of(supplier, (map, tuple) -> map.put(tuple.getFirst(), tuple.getSecond()), (a, b) -> {
-            b.entrySet()
-             .forEach(entryInB -> a.compute(entryInB.getKey(),
-                                            (key, valueOfA) -> merger.apply(valueOfA, entryInB.getValue())));
+            b.forEach((key1, value) -> a.compute(key1, (key, valueOfA) -> merger.apply(valueOfA, value)));
             return a;
         }, Function.identity(), Collector.Characteristics.IDENTITY_FINISH);
     }

--- a/src/main/java/sirius/kernel/di/Injector.java
+++ b/src/main/java/sirius/kernel/di/Injector.java
@@ -8,7 +8,6 @@
 
 package sirius.kernel.di;
 
-import com.google.common.collect.Lists;
 import sirius.kernel.Classpath;
 import sirius.kernel.Sirius;
 import sirius.kernel.di.std.RegisterLoadAction;
@@ -16,6 +15,7 @@ import sirius.kernel.health.Exceptions;
 import sirius.kernel.health.Log;
 
 import javax.annotation.Nonnull;
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.regex.Matcher;
@@ -75,8 +75,8 @@ public class Injector {
         // Make the context itself visible for GlobalContext...
         ctx.registerPart(ctx, GlobalContext.class);
         cp = classpath;
-        loadedClasses = Lists.newArrayList();
-        actions = Lists.newArrayList();
+        loadedClasses = new ArrayList<>();
+        actions = new ArrayList<>();
         packageFilter = Sirius.getSettings().getStringList("di.packageFilter");
 
         LOG.INFO("Initializing the MicroKernel....");

--- a/src/main/java/sirius/kernel/di/PartRegistry.java
+++ b/src/main/java/sirius/kernel/di/PartRegistry.java
@@ -8,7 +8,6 @@
 
 package sirius.kernel.di;
 
-import com.google.common.collect.Maps;
 import sirius.kernel.Sirius;
 import sirius.kernel.async.ExecutionPoint;
 import sirius.kernel.commons.Explain;
@@ -23,6 +22,7 @@ import java.lang.reflect.Modifier;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Comparator;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
@@ -30,6 +30,7 @@ import java.util.Map;
 import java.util.NoSuchElementException;
 import java.util.Set;
 import java.util.TreeMap;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.stream.Collectors;
 
 /**
@@ -49,14 +50,14 @@ class PartRegistry implements MutableGlobalContext {
      *
      * Content: ClassToReplace -> Replacement
      */
-    private final Map<Class<?>, Object> shadowMap = Maps.newHashMap();
+    private final Map<Class<?>, Object> shadowMap = new HashMap<>();
 
     /*
      * Contains all registered parts with a unique name. These parts will also
      * be contained in parts. This is just a lookup map if searched by unique
      * name.
      */
-    private final Map<Class<?>, Map<String, Object>> namedParts = Maps.newConcurrentMap();
+    private final Map<Class<?>, Map<String, Object>> namedParts = new ConcurrentHashMap<>();
 
     @SuppressWarnings("unchecked")
     @Override

--- a/src/main/java/sirius/kernel/di/std/RegisterLoadAction.java
+++ b/src/main/java/sirius/kernel/di/std/RegisterLoadAction.java
@@ -54,10 +54,6 @@ public class RegisterLoadAction implements ClassLoadAction {
         }
 
         Set<Class<?>> registeredClasses = computeEffectiveClasses(clazz, registerAnnotation);
-        if (registeredClasses == null) {
-            return;
-        }
-
         Object part = clazz.getDeclaredConstructor().newInstance();
 
         String name = computeEffectiveName(clazz, registerAnnotation, part);

--- a/src/main/java/sirius/kernel/di/std/RegisterLoadAction.java
+++ b/src/main/java/sirius/kernel/di/std/RegisterLoadAction.java
@@ -8,15 +8,12 @@
 
 package sirius.kernel.di.std;
 
-import com.google.common.collect.Sets;
 import sirius.kernel.Sirius;
 import sirius.kernel.commons.Strings;
 import sirius.kernel.di.ClassLoadAction;
 import sirius.kernel.di.Injector;
 import sirius.kernel.di.MutableGlobalContext;
 
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
 import java.lang.annotation.Annotation;
 import java.util.Arrays;
 import java.util.HashSet;
@@ -72,7 +69,7 @@ public class RegisterLoadAction implements ClassLoadAction {
     }
 
     private Set<Class<?>> computeEffectiveClasses(Class<?> clazz, Register registerAnnotation) {
-        Set<Class<?>> registeredClasses = Sets.newHashSet(registerAnnotation.classes());
+        Set<Class<?>> registeredClasses = new HashSet<>(Arrays.asList(registerAnnotation.classes()));
         Set<Class<?>> detectedClasses = findAutoRegisterClasses(clazz);
 
         // Provide support for the legacy mechanism, which was "all available interfaces"...

--- a/src/main/java/sirius/kernel/di/transformers/Composable.java
+++ b/src/main/java/sirius/kernel/di/transformers/Composable.java
@@ -8,11 +8,11 @@
 
 package sirius.kernel.di.transformers;
 
-import com.google.common.collect.Maps;
 import sirius.kernel.commons.Strings;
 import sirius.kernel.di.std.Part;
 
 import javax.annotation.Nonnull;
+import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
 
@@ -123,7 +123,7 @@ public class Composable implements Transformable {
      */
     public <T> void attach(Class<? extends T> type, T component) {
         if (components == null) {
-            components = Maps.newHashMap();
+            components = new HashMap<>();
         }
         components.put(type, component);
     }

--- a/src/main/java/sirius/kernel/health/Exceptions.java
+++ b/src/main/java/sirius/kernel/health/Exceptions.java
@@ -8,7 +8,6 @@
 
 package sirius.kernel.health;
 
-import com.google.common.collect.Maps;
 import sirius.kernel.async.CallContext;
 import sirius.kernel.commons.Explain;
 import sirius.kernel.commons.Strings;
@@ -20,6 +19,7 @@ import sirius.kernel.nls.NLS;
 import javax.annotation.Nullable;
 import java.util.List;
 import java.util.Map;
+import java.util.TreeMap;
 
 /**
  * Central point for handling all system errors and exceptions.
@@ -95,7 +95,7 @@ public class Exceptions {
         private Object[] systemErrorMessageParams;
         private boolean processError = true;
         private String key = "HandledException.exception";
-        private Map<String, Object> params = Maps.newTreeMap();
+        private Map<String, Object> params = new TreeMap<>();
 
         /**
          * Use {@link Exceptions#handle()} to create an <tt>ErrorHandler</tt>

--- a/src/main/java/sirius/kernel/health/Log.java
+++ b/src/main/java/sirius/kernel/health/Log.java
@@ -8,12 +8,7 @@
 
 package sirius.kernel.health;
 
-import com.google.common.collect.Lists;
-import org.apache.log4j.Level;
-import org.apache.log4j.Logger;
-import org.apache.log4j.MDC;
 import sirius.kernel.Sirius;
-import sirius.kernel.async.CallContext;
 import sirius.kernel.commons.Explain;
 import sirius.kernel.commons.Strings;
 import sirius.kernel.di.PartCollection;
@@ -22,6 +17,12 @@ import sirius.kernel.nls.NLS;
 
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.logging.Level;
+import java.util.logging.LogRecord;
+import java.util.logging.Logger;
 
 /**
  * The logging facade used by the system.
@@ -48,8 +49,15 @@ import java.util.List;
 public class Log {
 
     private final Logger logger;
-    private Boolean fineLogging;
-    private static final List<Log> all = Lists.newCopyOnWriteArrayList();
+    private static final List<Log> all = new CopyOnWriteArrayList<>();
+
+    /**
+     * Keeps a hard reference to each {@link Logger} which level has been changed manually.
+     * <p>
+     * This is required as the wonderful Java logging implementation doesn't retain one. Therefore the logger
+     * might get garbage collected <i>and a new logger with the same name</i> is returned.
+     */
+    private static final Map<String, Logger> loggerHardReferences = new ConcurrentHashMap<>();
 
     /**
      * Provides a generic logger for application log messages.
@@ -77,9 +85,9 @@ public class Log {
     public static final Log BACKGROUND = Log.get("background");
 
     /**
-     * Used to cut endless loops while feeding taps
+     * Used to cut endless loops while feeding taps.
      */
-    private static ThreadLocal<Boolean> frozen = new ThreadLocal<>();
+    private static final ThreadLocal<Boolean> frozen = new ThreadLocal<>();
 
     @Parts(LogTap.class)
     private static PartCollection<LogTap> taps;
@@ -131,86 +139,52 @@ public class Log {
      * @param level  the desired log level
      */
     public static void setLevel(String logger, Level level) {
-        // Setup log4j
-        Logger.getLogger(logger).setLevel(level);
+        loggerHardReferences.computeIfAbsent(logger, Logger::getLogger).setLevel(level);
+    }
 
-        // Setup java.util.logging
-        java.util.logging.Logger.getLogger(logger).setLevel(convertLog4jLevel(level));
+    private void log(Level level, Object msg) {
+        StackTraceElement caller = new Throwable().getStackTrace()[2];
 
-        // Clear cached "isFINE" flag to be consistently re-computed on the next access.
-        for (Log log : all) {
-            if (log.getName().equals(logger)) {
-                log.fineLogging = null;
+        LogRecord logRecord = createLogRecord(level, msg, caller);
+        if (msg instanceof Throwable) {
+            logRecord.setThrown((Throwable) msg);
+        }
+
+        logger.log(logRecord);
+        tap(msg, caller, level);
+    }
+
+    private LogRecord createLogRecord(Level level, Object msg, StackTraceElement caller) {
+        LogRecord logRecord = new LogRecord(level, msg.toString());
+        logRecord.setLoggerName(logger.getName());
+        logRecord.setSourceClassName(caller.getFileName() + ":" + caller.getLineNumber());
+        return logRecord;
+    }
+
+    private void tap(Object msg, StackTraceElement caller, Level level) {
+        if (Boolean.TRUE.equals(frozen.get())) {
+            return;
+        }
+        if (taps == null) {
+            return;
+        }
+
+        try {
+            frozen.set(Boolean.TRUE);
+            for (LogTap tap : taps) {
+                try {
+                    tap.handleLogMessage(new LogMessage(NLS.toUserString(msg),
+                                                        level,
+                                                        this,
+                                                        caller,
+                                                        Thread.currentThread().getName()));
+                } catch (Exception e) {
+                    // Ignored - if we can't log s.th. let's just give up...
+                }
             }
+        } finally {
+            frozen.set(Boolean.FALSE);
         }
-    }
-
-    /**
-     * Converts a given java.util.logging.Level to a log4j level.
-     *
-     * @param juliLevel the java.util.logging level
-     * @return the converted equivalent for log4j
-     */
-    public static Level convertJuliLevel(java.util.logging.Level juliLevel) {
-        if (juliLevel.equals(java.util.logging.Level.FINEST)) {
-            return Level.TRACE;
-        }
-        if (juliLevel.equals(java.util.logging.Level.FINER)) {
-            return Level.DEBUG;
-        }
-        if (juliLevel.equals(java.util.logging.Level.FINE)) {
-            return Level.DEBUG;
-        }
-        if (juliLevel.equals(java.util.logging.Level.INFO)) {
-            return Level.INFO;
-        }
-        if (juliLevel.equals(java.util.logging.Level.WARNING)) {
-            return Level.WARN;
-        }
-        if (juliLevel.equals(java.util.logging.Level.SEVERE)) {
-            return Level.ERROR;
-        }
-        if (juliLevel.equals(java.util.logging.Level.ALL)) {
-            return Level.ALL;
-        }
-        if (juliLevel.equals(java.util.logging.Level.OFF)) {
-            return Level.OFF;
-        }
-        return Level.DEBUG;
-    }
-
-    /**
-     * Converts a given log4j to a java.util.logging.Level level.
-     *
-     * @param log4jLevel the log4j level
-     * @return the converted equivalent java.util.logging
-     */
-    public static java.util.logging.Level convertLog4jLevel(Level log4jLevel) {
-        if (log4jLevel.equals(Level.TRACE)) {
-            return java.util.logging.Level.FINEST;
-        }
-        if (log4jLevel.equals(Level.DEBUG)) {
-            return java.util.logging.Level.FINER;
-        }
-        if (log4jLevel.equals(Level.INFO)) {
-            return java.util.logging.Level.INFO;
-        }
-        if (log4jLevel.equals(Level.WARN)) {
-            return java.util.logging.Level.WARNING;
-        }
-        if (log4jLevel.equals(Level.ERROR)) {
-            return java.util.logging.Level.SEVERE;
-        }
-        if (log4jLevel.equals(Level.FATAL)) {
-            return java.util.logging.Level.SEVERE;
-        }
-        if (log4jLevel.equals(Level.ALL)) {
-            return java.util.logging.Level.ALL;
-        }
-        if (log4jLevel.equals(Level.OFF)) {
-            return java.util.logging.Level.OFF;
-        }
-        return java.util.logging.Level.FINE;
     }
 
     /**
@@ -222,25 +196,11 @@ public class Log {
      * @param msg the message to be logged
      */
     public void INFO(Object msg) {
-        if (msg == null) {
+        if (msg == null || !logger.isLoggable(Level.INFO)) {
             return;
         }
-        if (logger.isInfoEnabled()) {
-            fixMDC();
-            if (msg instanceof Throwable) {
-                logger.info(((Throwable) msg).getMessage(), (Throwable) msg);
-            } else {
-                logger.info(msg.toString());
-            }
-            tap(msg, Level.INFO);
-        }
-    }
 
-    private void fixMDC() {
-        if (logger.isDebugEnabled() || Sirius.isDev() || Sirius.isStartedAsTest()) {
-            CallContext callContext = CallContext.getCurrent();
-            MDC.put("flow", "|" + callContext.getWatch().elapsedMillis() + "ms");
-        }
+        log(Level.INFO, msg);
     }
 
     /**
@@ -257,30 +217,6 @@ public class Log {
         }
     }
 
-    private void tap(Object msg, Level level) {
-        if (Boolean.TRUE.equals(frozen.get())) {
-            return;
-        }
-        try {
-            frozen.set(Boolean.TRUE);
-            if (taps != null) {
-                for (LogTap tap : taps) {
-                    invokeTap(msg, level, tap);
-                }
-            }
-        } finally {
-            frozen.set(Boolean.FALSE);
-        }
-    }
-
-    private void invokeTap(Object msg, Level level, LogTap tap) {
-        try {
-            tap.handleLogMessage(new LogMessage(NLS.toUserString(msg), level, this, Thread.currentThread().getName()));
-        } catch (Exception e) {
-            // Ignored - if we can't log s.th. let's just give up...
-        }
-    }
-
     /**
      * Formats the given message at the INFO level using the supplied parameters.
      * <p>
@@ -290,11 +226,8 @@ public class Log {
      * @param params the parameters used to format the resulting log message
      */
     public void INFO(String msg, Object... params) {
-        if (logger.isInfoEnabled()) {
-            String effectiveMessage = Strings.apply(msg, params);
-            fixMDC();
-            logger.info(effectiveMessage);
-            tap(effectiveMessage, Level.INFO);
+        if (logger.isLoggable(Level.INFO)) {
+            log(Level.INFO, Strings.apply(msg, params));
         }
     }
 
@@ -308,15 +241,11 @@ public class Log {
      * @param msg the message to be logged
      */
     public void FINE(Object msg) {
-        if (logger.isDebugEnabled()) {
-            fixMDC();
-            if (msg instanceof Throwable) {
-                logger.debug(((Throwable) msg).getMessage(), (Throwable) msg);
-            } else {
-                logger.debug(NLS.toUserString(msg));
-            }
-            tap(msg, Level.DEBUG);
+        if (msg == null || !logger.isLoggable(Level.FINE)) {
+            return;
         }
+
+        log(Level.FINE, msg);
     }
 
     /**
@@ -329,11 +258,8 @@ public class Log {
      * @param params the parameters used to format the resulting log message
      */
     public void FINE(String msg, Object... params) {
-        if (logger.isDebugEnabled()) {
-            String effectiveMessage = Strings.apply(msg, params);
-            fixMDC();
-            logger.debug(effectiveMessage);
-            tap(effectiveMessage, Level.DEBUG);
+        if (logger.isLoggable(Level.FINE)) {
+            log(Level.FINE, Strings.apply(msg, params));
         }
     }
 
@@ -346,15 +272,11 @@ public class Log {
      * @param msg the message to be logged
      */
     public void WARN(Object msg) {
-        if (Level.WARN.isGreaterOrEqual(logger.getEffectiveLevel())) {
-            fixMDC();
-            if (msg instanceof Throwable) {
-                logger.warn(((Throwable) msg).getMessage(), (Throwable) msg);
-            } else {
-                logger.warn(NLS.toUserString(msg));
-            }
-            tap(msg, Level.WARN);
+        if (msg == null || !logger.isLoggable(Level.WARNING)) {
+            return;
         }
+
+        log(Level.WARNING, msg);
     }
 
     /**
@@ -366,11 +288,8 @@ public class Log {
      * @param params the parameters used to format the resulting log message
      */
     public void WARN(String msg, Object... params) {
-        if (Level.WARN.isGreaterOrEqual(logger.getEffectiveLevel())) {
-            String effectiveMessage = Strings.apply(msg, params);
-            fixMDC();
-            logger.warn(effectiveMessage);
-            tap(effectiveMessage, Level.WARN);
+        if (logger.isLoggable(Level.WARNING)) {
+            log(Level.WARNING, Strings.apply(msg, params));
         }
     }
 
@@ -384,15 +303,11 @@ public class Log {
      * @param msg the message to be logged
      */
     public void SEVERE(Object msg) {
-        if (Level.ERROR.isGreaterOrEqual(logger.getEffectiveLevel())) {
-            fixMDC();
-            if (msg instanceof Throwable) {
-                logger.error(((Throwable) msg).getMessage(), (Throwable) msg);
-            } else {
-                logger.error(NLS.toUserString(msg));
-            }
-            tap(msg, Level.ERROR);
+        if (msg == null || !logger.isLoggable(Level.SEVERE)) {
+            return;
         }
+
+        log(Level.SEVERE, msg);
     }
 
     /**
@@ -406,10 +321,7 @@ public class Log {
      * @return <tt>true</tt> if this logger logs FINE message, <tt>false</tt> otherwise
      */
     public boolean isFINE() {
-        if (fineLogging == null) {
-            fineLogging = logger.isDebugEnabled();
-        }
-        return fineLogging;
+        return logger.isLoggable(Level.FINE);
     }
 
     /**
@@ -427,6 +339,6 @@ public class Log {
      * @return the effective log level
      */
     public Level getLevel() {
-        return logger.getEffectiveLevel();
+        return logger.getLevel();
     }
 }

--- a/src/main/java/sirius/kernel/health/LogMessage.java
+++ b/src/main/java/sirius/kernel/health/LogMessage.java
@@ -8,10 +8,10 @@
 
 package sirius.kernel.health;
 
-import org.apache.log4j.Level;
 import sirius.kernel.nls.NLS;
 
 import java.time.Instant;
+import java.util.logging.Level;
 
 /**
  * Contains a log message passed from {@link Log} to {@link LogTap}.
@@ -21,6 +21,7 @@ public class LogMessage {
     private long timestamp;
     private Level logLevel;
     private Log receiver;
+    private StackTraceElement caller;
     private String thread;
 
     /**
@@ -29,9 +30,11 @@ public class LogMessage {
      * @param message  the message to log
      * @param logLevel the level of the message
      * @param receiver the original receiver
+     * @param caller   the stack frame where the log message was issued
      * @param thread   the thread in which the message was logged
      */
-    public LogMessage(String message, Level logLevel, Log receiver, String thread) {
+    public LogMessage(String message, Level logLevel, Log receiver, StackTraceElement caller, String thread) {
+        this.caller = caller;
         this.thread = thread;
         this.timestamp = System.currentTimeMillis();
         this.message = message;
@@ -91,5 +94,14 @@ public class LogMessage {
      */
     public String getThread() {
         return thread;
+    }
+
+    /**
+     * Returns the stack frame of the method which issued the log message
+     *
+     * @return the stack frame which issued the log message
+     */
+    public StackTraceElement getCaller() {
+        return caller;
     }
 }

--- a/src/main/java/sirius/kernel/health/Microtiming.java
+++ b/src/main/java/sirius/kernel/health/Microtiming.java
@@ -8,10 +8,9 @@
 
 package sirius.kernel.health;
 
-import com.google.common.collect.Maps;
-
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.stream.Collectors;
 
 /**
@@ -31,7 +30,7 @@ public class Microtiming {
 
     private static volatile boolean enabled = false;
     private static volatile long lastReset;
-    private static Map<String, Timing> timings = Maps.newConcurrentMap();
+    private static Map<String, Timing> timings = new ConcurrentHashMap<>();
 
     private Microtiming() {
     }

--- a/src/main/java/sirius/kernel/health/console/LoggerCommand.java
+++ b/src/main/java/sirius/kernel/health/console/LoggerCommand.java
@@ -8,11 +8,11 @@
 
 package sirius.kernel.health.console;
 
-import org.apache.log4j.Level;
 import sirius.kernel.di.std.Register;
 import sirius.kernel.health.Log;
 
 import javax.annotation.Nonnull;
+import java.util.logging.Level;
 
 /**
  * Permits to change the level of a logger at runtime.
@@ -23,7 +23,7 @@ public class LoggerCommand implements Command {
     @Override
     public void execute(Output output, String... params) {
         if (params.length == 2) {
-            Level level = Level.toLevel(params[1]);
+            Level level = Level.parse(params[1]);
             output.apply("Setting %s to: %s", params[0], level);
             Log.setLevel(params[0], level);
             output.blankLine();

--- a/src/main/java/sirius/kernel/health/console/MD5Command.java
+++ b/src/main/java/sirius/kernel/health/console/MD5Command.java
@@ -8,11 +8,10 @@
 
 package sirius.kernel.health.console;
 
-import com.google.common.hash.Hashing;
+import sirius.kernel.commons.Hasher;
 import sirius.kernel.di.std.Register;
 
 import javax.annotation.Nonnull;
-import java.nio.charset.StandardCharsets;
 
 /**
  * Console command which computes an MD5 hash of a given input.
@@ -27,7 +26,7 @@ public class MD5Command implements Command {
         } else {
             output.line("Input: " + params[0]);
             output.line("Timestamp: " + System.currentTimeMillis() / 1000);
-            output.line("MD5: " + Hashing.md5().hashString(params[0], StandardCharsets.UTF_8).toString());
+            output.line("MD5: " + Hasher.md5().hash(params[0]).toHexString());
         }
     }
 

--- a/src/main/java/sirius/kernel/health/console/TimerCommand.java
+++ b/src/main/java/sirius/kernel/health/console/TimerCommand.java
@@ -8,7 +8,6 @@
 
 package sirius.kernel.health.console;
 
-import com.google.common.collect.Sets;
 import sirius.kernel.Sirius;
 import sirius.kernel.commons.Values;
 import sirius.kernel.di.std.Part;
@@ -17,6 +16,9 @@ import sirius.kernel.timer.EveryDay;
 import sirius.kernel.timer.Timers;
 
 import javax.annotation.Nonnull;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashSet;
 import java.util.Set;
 
 /**
@@ -29,8 +31,11 @@ public class TimerCommand implements Command {
 
     private static final String LINE_FORMAT = "%20s %-30s";
 
-    private static final Set<String> ACCEPTED_PARAMS =
-            Sets.newHashSet("all", "oneMinute", "tenMinutes", "oneHour", "everyDay");
+    private static final Set<String> ACCEPTED_PARAMS = Collections.unmodifiableSet(new HashSet<>(Arrays.asList("all",
+                                                                                                               "oneMinute",
+                                                                                                               "tenMinutes",
+                                                                                                               "oneHour",
+                                                                                                               "everyDay")));
 
     private static final String USAGE = "Usage: timer all|oneMinute|tenMinutes|oneHour|everyDay <hour>";
 

--- a/src/main/java/sirius/kernel/health/metrics/Metrics.java
+++ b/src/main/java/sirius/kernel/health/metrics/Metrics.java
@@ -8,8 +8,6 @@
 
 package sirius.kernel.health.metrics;
 
-import com.google.common.collect.Lists;
-import com.google.common.collect.Maps;
 import sirius.kernel.Sirius;
 import sirius.kernel.async.Tasks;
 import sirius.kernel.commons.DataCollector;
@@ -20,8 +18,10 @@ import sirius.kernel.health.Exceptions;
 import sirius.kernel.health.Log;
 import sirius.kernel.timer.EveryMinute;
 
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -47,12 +47,12 @@ public class Metrics implements EveryMinute {
     /**
      * Contains all limits as defined in the system config
      */
-    private Map<String, Limit> limits = Maps.newHashMap();
+    private Map<String, Limit> limits = new HashMap<>();
 
     /**
      * Contains the last value of each metric in order to compute differential metrics
      */
-    private Map<String, Double> differentials = Maps.newHashMap();
+    private Map<String, Double> differentials = new HashMap<>();
 
     @Part
     private Tasks tasks;
@@ -60,7 +60,7 @@ public class Metrics implements EveryMinute {
     /**
      * Contains all collected metrics
      */
-    private List<Metric> metricsList = Lists.newArrayList();
+    private List<Metric> metricsList = new ArrayList<>();
 
     /**
      * Internal structure to combine the three limits available for each metric: gray, warning (yellow), error (red).

--- a/src/main/java/sirius/kernel/info/Module.java
+++ b/src/main/java/sirius/kernel/info/Module.java
@@ -8,7 +8,7 @@
 
 package sirius.kernel.info;
 
-import com.google.common.hash.Hashing;
+import sirius.kernel.commons.Hasher;
 import sirius.kernel.commons.Strings;
 import sirius.kernel.nls.NLS;
 
@@ -70,9 +70,9 @@ public class Module {
      * @return a unique version string per release or instance
      */
     public String getUniqueVersionString() {
-        return Hashing.md5()
-                      .hashString(fix(vcs, RANDOM_REPLACEMENT) + fix(build, RANDOM_REPLACEMENT), StandardCharsets.UTF_8)
-                      .toString();
+        return Hasher.md5()
+                     .hash(fix(vcs, RANDOM_REPLACEMENT) + fix(build, RANDOM_REPLACEMENT))
+                     .toHexString();
     }
 
     /**

--- a/src/main/java/sirius/kernel/info/Product.java
+++ b/src/main/java/sirius/kernel/info/Product.java
@@ -8,10 +8,11 @@
 
 package sirius.kernel.info;
 
-import com.google.common.collect.Lists;
 import sirius.kernel.Sirius;
 import sirius.kernel.settings.Extension;
 
+import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 
 /**
@@ -54,7 +55,7 @@ public class Product {
      */
     public static List<Module> getModules() {
         if (modules == null) {
-            List<Module> result = Lists.newArrayList();
+            List<Module> result = new ArrayList<>();
             for (Extension ext : Sirius.getSettings().getExtensions("product.modules")) {
                 result.add(new Module(ext.getId(),
                                       ext.get("version").asString(),
@@ -64,6 +65,6 @@ public class Product {
             }
             modules = result;
         }
-        return modules;
+        return Collections.unmodifiableList(modules);
     }
 }

--- a/src/main/java/sirius/kernel/nls/Babelfish.java
+++ b/src/main/java/sirius/kernel/nls/Babelfish.java
@@ -8,8 +8,6 @@
 
 package sirius.kernel.nls;
 
-import com.google.common.collect.Lists;
-import com.google.common.collect.Maps;
 import sirius.kernel.Classpath;
 import sirius.kernel.Sirius;
 import sirius.kernel.commons.Explain;
@@ -19,6 +17,7 @@ import sirius.kernel.health.Log;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -56,7 +55,7 @@ public class Babelfish {
     /**
      * Contains all known translations
      */
-    private Map<String, Translation> translationMap = Maps.newTreeMap();
+    private Map<String, Translation> translationMap = new TreeMap<>();
 
     /**
      * Describes the pattern for .properties files of interest.
@@ -67,7 +66,7 @@ public class Babelfish {
      * Contains a list of all loaded resource bundles. Once the framework is booted, this is passed to
      * the TimerService.addWatchedResource to reload changes from the development environment.
      */
-    private List<String> loadedResourceBundles = Lists.newArrayList();
+    private List<String> loadedResourceBundles = new ArrayList<>();
 
     private static final ResourceBundle.Control CONTROL = new NonCachingUTF8Control();
 
@@ -174,8 +173,8 @@ public class Babelfish {
         // 2. Load the "product"-prefix files.
         // 3. Load the customizations files.
 
-        List<Matcher> customizations = Lists.newArrayList();
-        List<Matcher> productFiles = Lists.newArrayList();
+        List<Matcher> customizations = new ArrayList<>();
+        List<Matcher> productFiles = new ArrayList<>();
         classpath.find(PROPERTIES_FILE).forEach(value -> {
             if (Sirius.isCustomizationResource(value.group())) {
                 customizations.add(value);

--- a/src/main/java/sirius/kernel/nls/Formatter.java
+++ b/src/main/java/sirius/kernel/nls/Formatter.java
@@ -8,13 +8,13 @@
 
 package sirius.kernel.nls;
 
-import com.google.common.collect.Lists;
-import com.google.common.collect.Maps;
 import sirius.kernel.commons.Strings;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.TreeMap;
 import java.util.function.Function;
 
 /**
@@ -46,7 +46,7 @@ import java.util.function.Function;
  */
 public class Formatter {
     private boolean urlEncode = false;
-    private Map<String, String> replacement = Maps.newTreeMap();
+    private Map<String, String> replacement = new TreeMap<>();
     private Function<String, Optional<String>> parameterProvider;
     private boolean ignoreMissingPrameters;
     private String pattern;
@@ -324,7 +324,7 @@ public class Formatter {
      * result in one stack level.
      */
     private String format(boolean smart) {
-        List<Block> blocks = Lists.newArrayList();
+        List<Block> blocks = new ArrayList<>();
         Block currentBlock = new Block();
         blocks.add(currentBlock);
         int index = 0;

--- a/src/main/java/sirius/kernel/nls/NLS.java
+++ b/src/main/java/sirius/kernel/nls/NLS.java
@@ -8,8 +8,6 @@
 
 package sirius.kernel.nls;
 
-import com.google.common.collect.Maps;
-import com.google.common.collect.Sets;
 import sirius.kernel.Classpath;
 import sirius.kernel.Sirius;
 import sirius.kernel.async.CallContext;
@@ -48,10 +46,12 @@ import java.time.temporal.ChronoUnit;
 import java.time.temporal.Temporal;
 import java.util.Calendar;
 import java.util.Collections;
+import java.util.LinkedHashSet;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
+import java.util.TreeMap;
 
 /**
  * Native Language Support used by the framework.
@@ -94,13 +94,13 @@ public class NLS {
             DateTimeFormatter.ofPattern("H:mm[:ss]", Locale.ENGLISH);
     private static final DateTimeFormatter MACHINE_FORMAT_TIME_FORMAT =
             DateTimeFormatter.ofPattern("HH:mm:ss", Locale.ENGLISH);
-    private static final Map<String, DateTimeFormatter> fullDateTimeFormatters = Maps.newTreeMap();
-    private static final Map<String, DateTimeFormatter> dateTimeFormatters = Maps.newTreeMap();
-    private static final Map<String, DateTimeFormatter> dateFormatters = Maps.newTreeMap();
-    private static final Map<String, DateTimeFormatter> shortDateFormatters = Maps.newTreeMap();
-    private static final Map<String, DateTimeFormatter> timeFormatters = Maps.newTreeMap();
-    private static final Map<String, DateTimeFormatter> parseTimeFormatters = Maps.newTreeMap();
-    private static final Map<String, DateTimeFormatter> fullTimeFormatters = Maps.newTreeMap();
+    private static final Map<String, DateTimeFormatter> fullDateTimeFormatters = new TreeMap<>();
+    private static final Map<String, DateTimeFormatter> dateTimeFormatters = new TreeMap<>();
+    private static final Map<String, DateTimeFormatter> dateFormatters = new TreeMap<>();
+    private static final Map<String, DateTimeFormatter> shortDateFormatters = new TreeMap<>();
+    private static final Map<String, DateTimeFormatter> timeFormatters = new TreeMap<>();
+    private static final Map<String, DateTimeFormatter> parseTimeFormatters = new TreeMap<>();
+    private static final Map<String, DateTimeFormatter> fullTimeFormatters = new TreeMap<>();
 
     private static final long SECOND = 1000;
     private static final long MINUTE = 60 * SECOND;
@@ -208,7 +208,7 @@ public class NLS {
                                            .getStringList("nls.languages")
                                            .stream()
                                            .map(String::toLowerCase)
-                                           .collect(Lambdas.into(Sets.newLinkedHashSet()));
+                                           .collect(Lambdas.into(new LinkedHashSet<>()));
             } catch (Exception e) {
                 Exceptions.handle(e);
             }
@@ -397,7 +397,7 @@ public class NLS {
      */
     @SuppressWarnings("squid:S2637")
     @Explain("Strings.isEmpty checks for null on lang")
-    public static Optional<String> getIfExists(@Nonnull String property, @Nullable String lang) {
+    public static Optional<String> getIfExists(String property, @Nullable String lang) {
         if (Strings.isEmpty(property)) {
             return Optional.empty();
         }

--- a/src/main/java/sirius/kernel/nls/Translation.java
+++ b/src/main/java/sirius/kernel/nls/Translation.java
@@ -8,11 +8,10 @@
 
 package sirius.kernel.nls;
 
-import com.google.common.collect.Maps;
-
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import java.util.Map;
+import java.util.TreeMap;
 
 /**
  * Describes a translated property.
@@ -22,7 +21,7 @@ import java.util.Map;
 public class Translation {
     private boolean autocreated;
     private String key;
-    private Map<String, String> translationTable = Maps.newTreeMap();
+    private Map<String, String> translationTable = new TreeMap<>();
 
     /**
      * Creates a new translation, containing all native language values for the given key.

--- a/src/main/java/sirius/kernel/settings/ExtendedSettings.java
+++ b/src/main/java/sirius/kernel/settings/ExtendedSettings.java
@@ -134,24 +134,32 @@ public class ExtendedSettings extends Settings {
 
     private Map<String, Extension> getExtensionMap(String type) {
         Map<String, Extension> result = cache.get(type);
-        if (result != null) {
-            return result;
+        if (result == null) {
+            result = computeExtensionMap(type);
+            cache.put(type, result);
         }
 
+        return result;
+    }
+
+    private Map<String, Extension> computeExtensionMap(String type) {
         if (!getConfig().hasPath(type)) {
+            if (strict) {
+                Extension.LOG.WARN("Unknown extension type requested: %s", type);
+            }
+
             return Collections.emptyMap();
         }
+
         ConfigObject cfg = getConfig().getConfig(type).root();
-        List<Extension> list = new ArrayList<>();
-        ConfigObject defaultObject = null;
-        if (cfg.containsKey(Extension.DEFAULT)) {
-            defaultObject = (ConfigObject) cfg.get(Extension.DEFAULT);
-        }
+        List<Extension> extensions = new ArrayList<>();
+        ConfigObject defaultObject = cfg.containsKey(Extension.DEFAULT) ? (ConfigObject) cfg.get(Extension.DEFAULT) : null;
+
         for (Map.Entry<String, ConfigValue> entry : cfg.entrySet()) {
             String key = entry.getKey();
             if (!Extension.DEFAULT.equals(key) && !key.contains(".")) {
                 if (entry.getValue() instanceof ConfigObject) {
-                    list.add(new Extension(type, key, (ConfigObject) entry.getValue(), defaultObject));
+                    extensions.add(new Extension(type, key, (ConfigObject) entry.getValue(), defaultObject));
                 } else {
                     Extension.LOG.WARN("Malformed extension within '%s'. Expected a config object but found: %s",
                                        type,
@@ -160,12 +168,13 @@ public class ExtendedSettings extends Settings {
             }
         }
 
-        Collections.sort(list);
-        for (Extension ex : list) {
+        Collections.sort(extensions);
+
         Map<String, Extension> result = new LinkedHashMap<>();
+        for (Extension ex : extensions) {
             result.put(ex.getId(), ex);
         }
-        cache.put(type, result);
+
         return result;
     }
 }

--- a/src/main/java/sirius/kernel/settings/ExtendedSettings.java
+++ b/src/main/java/sirius/kernel/settings/ExtendedSettings.java
@@ -171,8 +171,8 @@ public class ExtendedSettings extends Settings {
         Collections.sort(extensions);
 
         Map<String, Extension> result = new LinkedHashMap<>();
-        for (Extension ex : extensions) {
-            result.put(ex.getId(), ex);
+        for (Extension extension : extensions) {
+            result.put(extension.getId(), extension);
         }
 
         return result;

--- a/src/main/java/sirius/kernel/settings/ExtendedSettings.java
+++ b/src/main/java/sirius/kernel/settings/ExtendedSettings.java
@@ -8,7 +8,6 @@
 
 package sirius.kernel.settings;
 
-import com.google.common.collect.Maps;
 import com.typesafe.config.Config;
 import com.typesafe.config.ConfigObject;
 import com.typesafe.config.ConfigValue;
@@ -18,6 +17,7 @@ import javax.annotation.Nullable;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
@@ -161,8 +161,8 @@ public class ExtendedSettings extends Settings {
         }
 
         Collections.sort(list);
-        result = Maps.newLinkedHashMap();
         for (Extension ex : list) {
+        Map<String, Extension> result = new LinkedHashMap<>();
             result.put(ex.getId(), ex);
         }
         cache.put(type, result);

--- a/src/main/java/sirius/kernel/settings/Settings.java
+++ b/src/main/java/sirius/kernel/settings/Settings.java
@@ -8,7 +8,6 @@
 
 package sirius.kernel.settings;
 
-import com.google.common.collect.Lists;
 import com.typesafe.config.Config;
 import com.typesafe.config.ConfigException;
 import com.typesafe.config.ConfigFactory;
@@ -29,6 +28,7 @@ import javax.annotation.Nullable;
 import javax.annotation.ParametersAreNonnullByDefault;
 import java.lang.reflect.Field;
 import java.time.Duration;
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -182,7 +182,7 @@ public class Settings {
      */
     @Nonnull
     public List<? extends Config> getConfigs(String key) {
-        List<Config> result = Lists.newArrayList();
+        List<Config> result = new ArrayList<>();
         Config cfg = getConfig(key);
         if (cfg != null) {
             for (Map.Entry<String, ConfigValue> e : cfg.root().entrySet()) {

--- a/src/main/java/sirius/kernel/settings/Settings.java
+++ b/src/main/java/sirius/kernel/settings/Settings.java
@@ -54,7 +54,7 @@ public class Settings {
     private static final String ID = "id";
 
     private final Config config;
-    private final boolean strict;
+    protected final boolean strict;
 
     /**
      * Creates a new wrapper for the given config.

--- a/src/main/java/sirius/kernel/timer/Timers.java
+++ b/src/main/java/sirius/kernel/timer/Timers.java
@@ -8,7 +8,6 @@
 
 package sirius.kernel.timer;
 
-import com.google.common.collect.Lists;
 import sirius.kernel.Sirius;
 import sirius.kernel.Startable;
 import sirius.kernel.Stoppable;
@@ -37,6 +36,7 @@ import java.util.List;
 import java.util.Optional;
 import java.util.Timer;
 import java.util.TimerTask;
+import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.locks.ReentrantLock;
 
@@ -99,7 +99,7 @@ public class Timers implements Startable, Stoppable {
     /*
      * Contains the relative paths of all loaded files
      */
-    private List<WatchedResource> loadedFiles = Lists.newCopyOnWriteArrayList();
+    private List<WatchedResource> loadedFiles = new CopyOnWriteArrayList<>();
 
     /*
      * Used to frequently check loaded properties when running in DEVELOP mode.

--- a/src/main/java/sirius/kernel/xml/Outcall.java
+++ b/src/main/java/sirius/kernel/xml/Outcall.java
@@ -8,8 +8,8 @@
 
 package sirius.kernel.xml;
 
-import com.google.common.io.CharStreams;
 import sirius.kernel.commons.Context;
+import sirius.kernel.commons.Streams;
 import sirius.kernel.commons.Strings;
 import sirius.kernel.health.Exceptions;
 import sirius.kernel.nls.NLS;
@@ -203,12 +203,7 @@ public class Outcall {
      * @throws IOException in case of any IO error
      */
     public String getData() throws IOException {
-        StringWriter writer = new StringWriter();
-        InputStreamReader reader = new InputStreamReader(getInput(), getContentEncoding());
-        CharStreams.copy(reader, writer);
-        reader.close();
-
-        return writer.toString();
+        return Streams.readToString(new InputStreamReader(getInput(), getContentEncoding()));
     }
 
     /**

--- a/src/main/java/sirius/kernel/xml/XMLReader.java
+++ b/src/main/java/sirius/kernel/xml/XMLReader.java
@@ -8,8 +8,6 @@
 
 package sirius.kernel.xml;
 
-import com.google.common.collect.Lists;
-import com.google.common.collect.Maps;
 import org.xml.sax.Attributes;
 import org.xml.sax.EntityResolver;
 import org.xml.sax.InputSource;
@@ -30,8 +28,10 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.StringReader;
 import java.net.URL;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.TreeMap;
 import java.util.function.Function;
 
 /**
@@ -46,8 +46,8 @@ public class XMLReader extends DefaultHandler {
 
     private TaskContext taskContext;
 
-    private Map<String, NodeHandler> handlers = Maps.newTreeMap();
-    private List<SAX2DOMHandler> activeHandlers = Lists.newArrayList();
+    private Map<String, NodeHandler> handlers = new TreeMap<>();
+    private List<SAX2DOMHandler> activeHandlers = new ArrayList<>();
     private DocumentBuilder documentBuilder;
 
     /**

--- a/src/main/resources/component-kernel.conf
+++ b/src/main/resources/component-kernel.conf
@@ -83,7 +83,7 @@ di {
 }
 
 # Sets the logging configuration. Each logger can be enumerated here, along with its log level
-# This can be OFF, DEBUG, INFO, WARN, ERROR - the default level is INFO
+# This can be OFF, FINE, INFO, WARNING, SEVERE - the default level is INFO
 logging {
     # Turn this on to log "ignored" or unnecessary exceptions.
     ignored = OFF

--- a/src/test/java/sirius/kernel/commons/HasherTest.java
+++ b/src/test/java/sirius/kernel/commons/HasherTest.java
@@ -1,0 +1,32 @@
+/*
+ * Made with all the love in the world
+ * by scireum in Remshalden, Germany
+ *
+ * Copyright by scireum GmbH
+ * http://www.scireum.de - info@scireum.de
+ */
+
+package sirius.kernel.commons;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+public class HasherTest {
+
+    @Test
+    public void testMD5() {
+        assertEquals("b10a8db164e0754105b7a99be72e3fe5", Hasher.md5().hash("Hello World").toHexString());
+        assertEquals("sQqNsWTgdUEFt6mb5y4/5Q==", Hasher.md5().hash("Hello World").toBase64String());
+    }
+
+    @Test
+    public void testSHA() {
+        assertEquals("0a4d55a8d778e5022fab701977c5d840bbc486d0", Hasher.sha1().hash("Hello World").toHexString());
+        assertEquals("a591a6d40bf420404a011733cfb7b190d62c65bf0bcda32b57b277d9ad9f146e",
+                     Hasher.sha256().hash("Hello World").toHexString());
+        assertEquals(
+                "2c74fd17edafd80e8447b0d46741ee243b7eb74dd2149a0ab1b9246fb30382f27e853d8585719e0e67cbda0daa8f51671064615d645ae27acb15bfb1447f459b",
+                Hasher.sha512().hash("Hello World").toHexString());
+    }
+}

--- a/src/test/java/sirius/kernel/commons/LimitTest.java
+++ b/src/test/java/sirius/kernel/commons/LimitTest.java
@@ -8,9 +8,9 @@
 
 package sirius.kernel.commons;
 
-import com.google.common.collect.Lists;
 import org.junit.Test;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Stream;
 
@@ -27,7 +27,7 @@ public class LimitTest {
     }
 
     private void executeLimit(Limit limit, int expectedIterations, int... expected) {
-        List<Integer> result = Lists.newArrayList();
+        List<Integer> result = new ArrayList<>();
         int iterations = 0;
         for (int i = 1; i <= 10; i++) {
             iterations++;

--- a/src/test/java/sirius/kernel/commons/StreamsTest.java
+++ b/src/test/java/sirius/kernel/commons/StreamsTest.java
@@ -1,0 +1,48 @@
+/*
+ * Made with all the love in the world
+ * by scireum in Remshalden, Germany
+ *
+ * Copyright by scireum GmbH
+ * http://www.scireum.de - info@scireum.de
+ */
+
+package sirius.kernel.commons;
+
+import org.junit.Test;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+
+import static org.junit.Assert.assertEquals;
+
+public class StreamsTest {
+
+    @Test
+    public void transferTest() throws IOException {
+        String testString = "Hello from the other side...";
+
+        ByteArrayInputStream in = new ByteArrayInputStream(testString.getBytes(StandardCharsets.UTF_8));
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        Streams.transfer(in, out);
+
+        assertEquals(testString, new String(out.toByteArray(), StandardCharsets.UTF_8));
+    }
+
+    @Test
+    public void largeTransferTest() throws IOException {
+        StringBuilder builder = new StringBuilder();
+        for (int i = 0; i < 10_000; i++) {
+            builder.append("Hello World");
+        }
+
+        String testString = builder.toString();
+
+        ByteArrayInputStream in = new ByteArrayInputStream(testString.getBytes(StandardCharsets.UTF_8));
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        Streams.transfer(in, out);
+
+        assertEquals(testString, new String(out.toByteArray(), StandardCharsets.UTF_8));
+    }
+}

--- a/src/test/java/sirius/kernel/commons/TrieTest.java
+++ b/src/test/java/sirius/kernel/commons/TrieTest.java
@@ -1,8 +1,11 @@
 package sirius.kernel.commons;
 
-import com.google.common.collect.Sets;
 import org.junit.Before;
 import org.junit.Test;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashSet;
 
 import static org.junit.Assert.*;
 
@@ -49,11 +52,11 @@ public class TrieTest {
     @Test
     public void keySet() {
         assertEquals(7, trie.size());
-        assertEquals(Sets.newHashSet("one", "on", "one1", "two", "three", "thrae", "th"), trie.keySet());
-        assertEquals(Sets.newHashSet("one", "on", "one1", "two", "three", "thrae", "th"),
+        assertEquals(new HashSet<>(Arrays.asList("one", "on", "one1", "two", "three", "thrae", "th")), trie.keySet());
+        assertEquals(new HashSet<>(Arrays.asList("one", "on", "one1", "two", "three", "thrae", "th")),
                      trie.getAllKeysBeginningWith(""));
-        assertEquals(Sets.newHashSet("one", "on", "one1"), trie.getAllKeysBeginningWith("on"));
-        assertEquals(Sets.newHashSet("three"), trie.getAllKeysBeginningWith("three"));
+        assertEquals(new HashSet<>(Arrays.asList("one", "on", "one1")), trie.getAllKeysBeginningWith("on"));
+        assertEquals(Collections.singleton("three"), trie.getAllKeysBeginningWith("three"));
         assertEquals(0, trie.getAllKeysBeginningWith("threee").size());
     }
 }

--- a/src/test/java/sirius/kernel/commons/ValuesTest.java
+++ b/src/test/java/sirius/kernel/commons/ValuesTest.java
@@ -8,9 +8,9 @@
 
 package sirius.kernel.commons;
 
-import com.google.common.collect.Lists;
 import org.junit.Test;
 
+import java.util.ArrayList;
 import java.util.List;
 
 import static org.junit.Assert.assertEquals;
@@ -27,7 +27,7 @@ public class ValuesTest {
     public void excelStyleColumns() {
         assertEquals("A", Values.of(new String[]{"A", "B", "C"}).at("A").asString());
         assertEquals("C", Values.of(new String[]{"A", "B", "C"}).at("C").asString());
-        List<String> test = Lists.newArrayList();
+        List<String> test = new ArrayList<>();
         for (int i = 1; i < 100; i++) {
             test.add(String.valueOf(i));
         }

--- a/src/test/java/sirius/kernel/health/ExceptionsTest.java
+++ b/src/test/java/sirius/kernel/health/ExceptionsTest.java
@@ -8,11 +8,12 @@
 
 package sirius.kernel.health;
 
-import org.apache.log4j.Level;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;
 import sirius.kernel.TestHelper;
+
+import java.util.logging.Level;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
@@ -36,7 +37,7 @@ public class ExceptionsTest {
     public void testDeprecatedMethodCallWarner() {
         LogHelper.clearMessages();
         caller();
-        assertTrue(LogHelper.hasMessage(Level.WARN,
+        assertTrue(LogHelper.hasMessage(Level.WARNING,
                                         Exceptions.DEPRECATION_LOG,
                                         "^The deprecated method 'sirius.kernel.health.ExceptionsTest.deprecatedMethod'"
                                         + " was called by 'sirius.kernel.health.ExceptionsTest.caller'"));

--- a/src/test/java/sirius/kernel/health/LogHelper.java
+++ b/src/test/java/sirius/kernel/health/LogHelper.java
@@ -8,9 +8,9 @@
 
 package sirius.kernel.health;
 
-import org.apache.log4j.Level;
 import sirius.kernel.di.std.Part;
 
+import java.util.logging.Level;
 import java.util.regex.Pattern;
 
 /**


### PR DESCRIPTION
log4j doesn't provide any benefit for us anymore and only adds to the complexity of the system. Therefore it was removed and we internally use JULI - which is there anyway and also support SLF4J in case a library uses it.

This change should remain mostly unnoticed by users of sirius. The only breaking change
are the Level names WARN (old) -> WARNING (new) and DEBUG (old) -> FINE (new).

We also removed as many calls to Google Guava as possible. Most of the calls were only benificial in the pre Java 8 world (no diamond operator). Others more troublesome as Hashing and ByteStreams was marked as unstable and now partially as deprecated  therefore these parts have been replaced.