### PR TITLE
Prevents logging a wrong message.

### DIFF
--- a/src/main/java/sirius/kernel/cache/ManagedCache.java
+++ b/src/main/java/sirius/kernel/cache/ManagedCache.java
@@ -30,7 +30,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Optional;
-import java.util.function.BiFunction;
 import java.util.function.BiPredicate;
 import java.util.function.Predicate;
 

--- a/src/main/java/sirius/kernel/cache/ManagedCacheRemoverBuilder.java
+++ b/src/main/java/sirius/kernel/cache/ManagedCacheRemoverBuilder.java
@@ -8,8 +8,10 @@ import java.util.function.Function;
 import java.util.function.Predicate;
 
 class ManagedCacheRemoverBuilder<K, V, T> implements CacheRemoverBuilder<K, V, T> {
-    private final Cache<K, V> cache;
-    private final String discriminator;
+
+    private enum State {
+        FILTERED, REMOVED, UNDECIDED
+    }
 
     /**
      * The combined mapping/filter function up to now.
@@ -18,17 +20,9 @@ class ManagedCacheRemoverBuilder<K, V, T> implements CacheRemoverBuilder<K, V, T
      * marked as filtered via {@link #filter}. If it is marked as undecided, it should be processed further.
      */
     private final BiFunction<String, CacheEntry<K, V>, Tuple<T, State>> mapper;
+    private final Cache<K, V> cache;
+    private final String discriminator;
 
-    private enum State {
-        FILTERED, REMOVED, UNDECIDED
-    }
-
-    protected static <K, V> ManagedCacheRemoverBuilder<K, V, CacheEntry<K, V>> create(Cache<K, V> cache,
-                                                                                      String discriminator) {
-        return new ManagedCacheRemoverBuilder<>(cache,
-                                                discriminator,
-                                                (ignored, value) -> Tuple.create(value, State.UNDECIDED));
-    }
 
     private ManagedCacheRemoverBuilder(Cache<K, V> cache,
                                        String discriminator,
@@ -36,6 +30,13 @@ class ManagedCacheRemoverBuilder<K, V, T> implements CacheRemoverBuilder<K, V, T
         this.cache = cache;
         this.discriminator = discriminator;
         this.mapper = mapper;
+    }
+
+    protected static <K, V> ManagedCacheRemoverBuilder<K, V, CacheEntry<K, V>> create(Cache<K, V> cache,
+                                                                                      String discriminator) {
+        return new ManagedCacheRemoverBuilder<>(cache,
+                                                discriminator,
+                                                (ignored, value) -> Tuple.create(value, State.UNDECIDED));
     }
 
     @Override

--- a/src/main/java/sirius/kernel/commons/Streams.java
+++ b/src/main/java/sirius/kernel/commons/Streams.java
@@ -8,6 +8,7 @@
 
 package sirius.kernel.commons;
 
+import javax.annotation.Nonnull;
 import java.io.BufferedReader;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
@@ -36,7 +37,7 @@ public class Streams {
      * @return the total number of transferred bytes
      * @throws IOException in case of an IO error thrown by either the source or the destination
      */
-    public static long transfer(InputStream source, OutputStream destination) throws IOException {
+    public static long transfer(@Nonnull InputStream source, @Nonnull OutputStream destination) throws IOException {
         byte[] buffer = new byte[8192];
         long transferredBytes = 0;
         int readBytes = 0;
@@ -55,7 +56,7 @@ public class Streams {
      * @return the number of bytes read
      * @throws IOException in case of an IO error while reading from the source
      */
-    public static long exhaust(InputStream source) throws IOException {
+    public static long exhaust(@Nonnull InputStream source) throws IOException {
         byte[] buffer = new byte[8192];
         long totalBytes = 0;
         int readBytes = 0;
@@ -66,7 +67,16 @@ public class Streams {
         return totalBytes;
     }
 
-    public static byte[] toByteArray(InputStream source) throws IOException {
+    /**
+     * Converts the given input stream into a <tt>byte[]</tt>.
+     * <p>
+     * Please be aware that this will load the entire contents of the given stream into heap memory.
+     *
+     * @param source the source to read from
+     * @return all contents which have been read from the stream
+     * @throws IOException in case of an IO error while reading
+     */
+    public static byte[] toByteArray(@Nonnull InputStream source) throws IOException {
         ByteArrayOutputStream destination = new ByteArrayOutputStream();
         transfer(source, destination);
         return destination.toByteArray();
@@ -80,7 +90,7 @@ public class Streams {
      * @return the total number of transferred bytes
      * @throws IOException in case of an IO error thrown by either the source or the destination
      */
-    public static long transfer(Reader source, Writer destination) throws IOException {
+    public static long transfer(@Nonnull Reader source, @Nonnull Writer destination) throws IOException {
         char[] buffer = new char[4096];
         long transferredBytes = 0;
         int readBytes = 0;
@@ -92,13 +102,27 @@ public class Streams {
         return transferredBytes;
     }
 
-    public static String readToString(Reader reader) throws IOException {
+    /**
+     * Reads the whole contents of the given reader into a <tt>String</tt>.
+     *
+     * @param reader the source to read from
+     * @return all contents which have been read from the given source
+     * @throws IOException in case of an IO error while reading
+     */
+    public static String readToString(@Nonnull Reader reader) throws IOException {
         StringWriter destination = new StringWriter();
         transfer(reader, destination);
         return destination.toString();
     }
 
-    public static List<String> readLines(Reader reader) throws IOException {
+    /**
+     * Reads the contents of the given reader and returns a list of lines.
+     *
+     * @param reader the reader to read from
+     * @return a list of lines which have been read (as determined by {@link BufferedReader#readLine()}.
+     * @throws IOException in case of an IO error while reading
+     */
+    public static List<String> readLines(@Nonnull Reader reader) throws IOException {
         List<String> result = new ArrayList<>();
         BufferedReader bufferedReader = new BufferedReader(reader);
         String line;

--- a/src/main/java/sirius/kernel/di/std/RegisterLoadAction.java
+++ b/src/main/java/sirius/kernel/di/std/RegisterLoadAction.java
@@ -78,7 +78,7 @@ public class RegisterLoadAction implements ClassLoadAction {
         }
 
         // Warn if the classes list can (and should) be omitted...
-        if (registeredClasses.equals(detectedClasses)) {
+        if (!registeredClasses.isEmpty() && registeredClasses.equals(detectedClasses)) {
             Injector.LOG.WARN(
                     "%s wears a @Register with a list of classes which are already auto-detected. Consider removing the classes list...",
                     clazz.getName());

--- a/src/main/java/sirius/kernel/info/Module.java
+++ b/src/main/java/sirius/kernel/info/Module.java
@@ -12,7 +12,6 @@ import sirius.kernel.commons.Hasher;
 import sirius.kernel.commons.Strings;
 import sirius.kernel.nls.NLS;
 
-import java.nio.charset.StandardCharsets;
 import java.time.LocalDate;
 import java.util.concurrent.ThreadLocalRandom;
 
@@ -70,9 +69,7 @@ public class Module {
      * @return a unique version string per release or instance
      */
     public String getUniqueVersionString() {
-        return Hasher.md5()
-                     .hash(fix(vcs, RANDOM_REPLACEMENT) + fix(build, RANDOM_REPLACEMENT))
-                     .toHexString();
+        return Hasher.md5().hash(fix(vcs, RANDOM_REPLACEMENT) + fix(build, RANDOM_REPLACEMENT)).toHexString();
     }
 
     /**

--- a/src/main/java/sirius/kernel/nls/NLS.java
+++ b/src/main/java/sirius/kernel/nls/NLS.java
@@ -15,7 +15,6 @@ import sirius.kernel.async.ExecutionPoint;
 import sirius.kernel.commons.AdvancedDateParser;
 import sirius.kernel.commons.Amount;
 import sirius.kernel.commons.Explain;
-import sirius.kernel.commons.Lambdas;
 import sirius.kernel.commons.NumberFormat;
 import sirius.kernel.commons.Strings;
 import sirius.kernel.commons.Value;
@@ -52,6 +51,7 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.TreeMap;
+import java.util.stream.Collectors;
 
 /**
  * Native Language Support used by the framework.
@@ -208,7 +208,7 @@ public class NLS {
                                            .getStringList("nls.languages")
                                            .stream()
                                            .map(String::toLowerCase)
-                                           .collect(Lambdas.into(new LinkedHashSet<>()));
+                                           .collect(Collectors.toCollection(LinkedHashSet::new));
             } catch (Exception e) {
                 Exceptions.handle(e);
             }

--- a/src/main/java/sirius/kernel/settings/ConfigValueAnnotationProcessor.java
+++ b/src/main/java/sirius/kernel/settings/ConfigValueAnnotationProcessor.java
@@ -38,14 +38,14 @@ public class ConfigValueAnnotationProcessor implements FieldAnnotationProcessor 
         ConfigValue val = field.getAnnotation(ConfigValue.class);
         String key = val.value();
 
-        if (!Sirius.getSettings().injectValueFromConfig(object, field, key)) {
-            if (field.get(object) == null && !field.isAnnotationPresent(Nullable.class)) {
-                Injector.LOG.WARN("Cannot fill %s of %s with the config value '%s'."
-                                  + " Add a Nullable annotation if this is expected, in order to suppress this warning.",
-                                  key,
-                                  field.getDeclaringClass().getName(),
-                                  field.getName());
-            }
+        if (!Sirius.getSettings().injectValueFromConfig(object, field, key)
+            && field.get(object) == null
+            && !field.isAnnotationPresent(Nullable.class)) {
+            Injector.LOG.WARN("Cannot fill %s of %s with the config value '%s'."
+                              + " Add a Nullable annotation if this is expected, in order to suppress this warning.",
+                              key,
+                              field.getDeclaringClass().getName(),
+                              field.getName());
         }
     }
 }

--- a/src/main/java/sirius/kernel/timer/EndOfDayTask.java
+++ b/src/main/java/sirius/kernel/timer/EndOfDayTask.java
@@ -9,6 +9,7 @@
 package sirius.kernel.timer;
 
 import sirius.kernel.commons.Timeout;
+import sirius.kernel.di.std.AutoRegister;
 import sirius.kernel.di.std.Register;
 
 /**
@@ -29,6 +30,7 @@ import sirius.kernel.di.std.Register;
  * the next task. If a single task has the possibility of running for a long period (e.g. greater than one hour),
  * the task itself should protect the system (e.g. by limiting its runtime via {@link Timeout}.
  */
+@AutoRegister
 public interface EndOfDayTask {
 
     /**

--- a/src/main/java/sirius/kernel/timer/EveryMinute.java
+++ b/src/main/java/sirius/kernel/timer/EveryMinute.java
@@ -18,5 +18,6 @@ import sirius.kernel.di.std.AutoRegister;
  * {@link sirius.kernel.timer.TimedTask#runTimer()} is invoked once every minute (however no assumptions about the
  * exact length of the interval should be made - it will be "about" a minute, not exactly one minute).
  */
+@AutoRegister
 public interface EveryMinute extends TimedTask {
 }

--- a/src/main/java/sirius/kernel/xml/Outcall.java
+++ b/src/main/java/sirius/kernel/xml/Outcall.java
@@ -20,7 +20,6 @@ import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.io.OutputStream;
 import java.io.OutputStreamWriter;
-import java.io.StringWriter;
 import java.io.UnsupportedEncodingException;
 import java.net.HttpURLConnection;
 import java.net.URL;

--- a/src/main/java/sirius/kernel/xml/SOAPFaultException.java
+++ b/src/main/java/sirius/kernel/xml/SOAPFaultException.java
@@ -10,12 +10,23 @@ package sirius.kernel.xml;
 
 import java.net.URL;
 
+/**
+ * Wraps a SOAP fault as <tt>Exception</tt>.
+ */
 public class SOAPFaultException extends RuntimeException {
 
-    private String action;
-    private URL endpoint;
-    private String faultCode;
+    private final String action;
+    private final URL endpoint;
+    private final String faultCode;
 
+    /**
+     * Creates a new exception which wraps the given SOAP fault.
+     *
+     * @param action            the action which was attempted
+     * @param effectiveEndpoint the effective endpoint which has been addressed
+     * @param faultCode         the code of the fault that occured
+     * @param faultMessage      the message of the fault
+     */
     public SOAPFaultException(String action, URL effectiveEndpoint, String faultCode, String faultMessage) {
         super(faultMessage);
         this.action = action;


### PR DESCRIPTION
If we failed to auto-detect any parts and the
programmer also didn't specify any, theres is
no need to complain that "an empty list" was
specified - we rather have to report that no
parts could be discovered (which is done below).