### PR TITLE
Prevents overuse of Redis via coherent caches

### DIFF
--- a/src/main/java/sirius/kernel/cache/CacheCoherence.java
+++ b/src/main/java/sirius/kernel/cache/CacheCoherence.java
@@ -46,14 +46,4 @@ public interface CacheCoherence {
      * @param testInput     the input used by the predicate in order to determine which entities to remove
      */
     void removeAll(Cache<String, ?> cache, String discriminator, String testInput);
-
-    /**
-     * Notifies the other nodes about a put on this node.
-     * <p>
-     * The other nodes will remove the key from their cache.
-     *
-     * @param cache the cache into which a value was put
-     * @param key   the key for which put was called
-     */
-    void signalPut(Cache<String, ?> cache, String key);
 }

--- a/src/main/java/sirius/kernel/cache/CacheManager.java
+++ b/src/main/java/sirius/kernel/cache/CacheManager.java
@@ -253,20 +253,6 @@ public class CacheManager {
     }
 
     /**
-     * Notifies the other nodes about a put on this node.
-     * <p>
-     * The other nodes will remove the key from their cache.
-     *
-     * @param cache the cache into which a value was put
-     * @param key   the key for which put was called
-     */
-    public static void signalPut(CoherentCache<?> cache, String key) {
-        if (cacheCoherence != null) {
-            cacheCoherence.signalPut(cache, key);
-        }
-    }
-
-    /**
      * Notifies the other nodes about the delete handler to invoke.
      * <p>
      * This will invoke the delete handler previously registered via {@link Cache#addRemover(String, BiPredicate)}

--- a/src/main/java/sirius/kernel/cache/CoherentCache.java
+++ b/src/main/java/sirius/kernel/cache/CoherentCache.java
@@ -86,10 +86,4 @@ class CoherentCache<V> extends ManagedCache<String, V> {
 
         data.asMap().values().stream().filter(predicate).map(CacheEntry::getKey).forEach(this::remove);
     }
-
-    @Override
-    public void put(String key, V value) {
-        CacheManager.signalPut(this, key);
-        super.put(key, value);
-    }
 }


### PR DESCRIPTION
The change in the reverted commit was meant to flush an element from the cache on all nodes when it was newly loaded on a node. This actually resulted in a loop of Redis messages when an cached element was needed on multiple nodes and also made the caches for such elements quite ineffective.

Reverts changes of 92d5d86493a5677b510695efa6776e7cdf81bb1b

Fixes: SIRI-234