### PR TITLE
Displays loggers with default level as INFO instead of null

### DIFF
--- a/src/main/java/sirius/kernel/health/Log.java
+++ b/src/main/java/sirius/kernel/health/Log.java
@@ -378,6 +378,6 @@ public class Log {
      * @return the effective log level
      */
     public Level getLevel() {
-        return logger.getLevel();
+        return logger.getLevel() != null ? logger.getLevel() : Level.INFO;
     }
 }

--- a/src/main/java/sirius/kernel/health/console/LoggerCommand.java
+++ b/src/main/java/sirius/kernel/health/console/LoggerCommand.java
@@ -32,9 +32,8 @@ public class LoggerCommand implements Command {
             output.blankLine();
             output.line("Known loggers:");
             output.separator();
-            for (Log l : Log.getAllLoggers()) {
-                Level logLevel = l.getLevel() != null ? l.getLevel() : Level.INFO;
-                output.apply("%-30s %-10s", l.getName(), logLevel);
+            for (Log logger : Log.getAllLoggers()) {
+                output.apply("%-30s %-10s", logger.getName(), logger.getLevel());
             }
             output.separator();
         }

--- a/src/main/java/sirius/kernel/health/console/LoggerCommand.java
+++ b/src/main/java/sirius/kernel/health/console/LoggerCommand.java
@@ -33,7 +33,8 @@ public class LoggerCommand implements Command {
             output.line("Known loggers:");
             output.separator();
             for (Log l : Log.getAllLoggers()) {
-                output.apply("%-30s %-10s", l.getName(), l.getLevel());
+                Level logLevel = l.getLevel() != null ? l.getLevel() : Level.INFO;
+                output.apply("%-30s %-10s", l.getName(), logLevel);
             }
             output.separator();
         }


### PR DESCRIPTION
Before:
![Bildschirmfoto 2020-07-06 um 17 16 21](https://user-images.githubusercontent.com/2427877/86610368-87fd6700-bfad-11ea-9ab4-cab21d4ab854.png)

After:
![Bildschirmfoto 2020-07-06 um 17 22 06](https://user-images.githubusercontent.com/2427877/86610380-8b90ee00-bfad-11ea-9686-e962062d7673.png)
