### PR TITLE
Only returns the error stream if it is non null, otherwise an excepti…

### DIFF
--- a/src/main/java/sirius/kernel/xml/Outcall.java
+++ b/src/main/java/sirius/kernel/xml/Outcall.java
@@ -120,10 +120,13 @@ public class Outcall {
         } catch (IOException e) {
             int statusCode = connection.getResponseCode();
             if (statusCode != 200) {
-                return connection.getErrorStream();
-            } else {
-                throw e;
+                InputStream errorStream = connection.getErrorStream();
+                if (errorStream != null) {
+                    return errorStream;
+                }
             }
+
+            throw e;
         }
     }
 


### PR DESCRIPTION
…on is probably more helpful.