### PR TITLE
Defines alternative methods to Amount

### DIFF
--- a/src/main/java/sirius/kernel/commons/Amount.java
+++ b/src/main/java/sirius/kernel/commons/Amount.java
@@ -253,17 +253,16 @@ public class Amount implements Comparable<Amount> {
      *
      * @param supplier the supplier which is used to compute a value if there is no internal value
      * @return <tt>this</tt> if there is an internal value, the computed value of <tt>supplier</tt> otherwise
+     * @deprecated This method has been deprecated. Use <tt>orElseGet()</tt> instead.
      */
     @Nonnull
+    @Deprecated
     public Amount computeIfNull(Supplier<Amount> supplier) {
-        if (isEmpty()) {
-            return supplier.get();
-        }
-        return this;
+        return orElseGet(supplier);
     }
 
     /**
-     * Invokes the given consumer with the internal value is not empty.
+     * Invokes the given consumer if the internal value is not empty.
      *
      * @param consumer the consumer to execute
      */
@@ -293,6 +292,20 @@ public class Amount implements Comparable<Amount> {
     public Amount orElse(Amount amount) {
         if (isEmpty()) {
             return amount;
+        }
+        return this;
+    }
+
+    /**
+     * Computes a value using the provided supplier if the internal value is empty.
+     *
+     * @param supplier the supplier which is used to compute a value if there is no internal value
+     * @return <tt>this</tt> if there is an internal value, the computed value of <tt>supplier</tt> otherwise
+     */
+    @Nonnull
+    public Amount orElseGet(Supplier<Amount> supplier) {
+        if (isEmpty()) {
+            return supplier.get();
         }
         return this;
     }

--- a/src/main/java/sirius/kernel/commons/Amount.java
+++ b/src/main/java/sirius/kernel/commons/Amount.java
@@ -290,7 +290,7 @@ public class Amount implements Comparable<Amount> {
      * @param amount the alternative Amount to return
      * @return the original or alternative amount
      */
-    public Amount orElseGet(Amount amount) {
+    public Amount orElse(Amount amount) {
         if (isEmpty()) {
             return amount;
         }

--- a/src/main/java/sirius/kernel/commons/Amount.java
+++ b/src/main/java/sirius/kernel/commons/Amount.java
@@ -18,6 +18,7 @@ import java.math.BigDecimal;
 import java.math.MathContext;
 import java.math.RoundingMode;
 import java.text.DecimalFormat;
+import java.util.function.Consumer;
 import java.util.function.Supplier;
 
 /**
@@ -257,6 +258,41 @@ public class Amount implements Comparable<Amount> {
     public Amount computeIfNull(Supplier<Amount> supplier) {
         if (isEmpty()) {
             return supplier.get();
+        }
+        return this;
+    }
+
+    /**
+     * Invokes the given consumer with the internal value is not empty.
+     *
+     * @param consumer the consumer to execute
+     */
+    public void ifPresent(Consumer<Amount> consumer) {
+        if (isFilled()) {
+            consumer.accept(Amount.of(getAmount()));
+        }
+    }
+
+    /**
+     * Executes the given runnable if the internal value is empty.
+     *
+     * @param runnable the runnable to execute
+     */
+    public void ifEmpty(Runnable runnable) {
+        if (isEmpty()) {
+            runnable.run();
+        }
+    }
+
+    /**
+     * Returns the provided alternative {@link Amount} if the internal value is empty.
+     *
+     * @param amount the alternative Amount to return
+     * @return the original or alternative amount
+     */
+    public Amount orElseGet(Amount amount) {
+        if (isEmpty()) {
+            return amount;
         }
         return this;
     }

--- a/src/main/java/sirius/kernel/commons/Amount.java
+++ b/src/main/java/sirius/kernel/commons/Amount.java
@@ -269,7 +269,7 @@ public class Amount implements Comparable<Amount> {
      */
     public void ifPresent(Consumer<Amount> consumer) {
         if (isFilled()) {
-            consumer.accept(Amount.of(getAmount()));
+            consumer.accept(this);
         }
     }
 

--- a/src/test/java/sirius/kernel/commons/AmountSpec.groovy
+++ b/src/test/java/sirius/kernel/commons/AmountSpec.groovy
@@ -65,11 +65,11 @@ class AmountSpec extends BaseSpecification {
         Amount.of(19) == Amount.TEN.multiplyPercent(Amount.TEN)
     }
 
-    def "fill and computeIfNull are only evaluated if no value is present"() {
+    def "fill and orElseGet are only evaluated if no value is present"() {
         expect:
         Amount.TEN == Amount.NOTHING.fill(Amount.TEN)
         Amount.TEN == Amount.TEN.fill(Amount.ONE)
-        Amount.NOTHING.computeIfNull(new Supplier<Amount>() {
+        Amount.NOTHING.orElseGet(new Supplier<Amount>() {
             @Override
             Amount get() {
                 return Amount.TEN


### PR DESCRIPTION
void ifPresent(consumer)
void ifEmpty(runnable)
Amount orElse(amount)
Amount orElseGet(supplier) -> making computeIfNull deprecated