### PR TITLE
rename methods to avoid ambiguous calls

### DIFF
--- a/src/main/java/sirius/kernel/xml/SOAPClient.java
+++ b/src/main/java/sirius/kernel/xml/SOAPClient.java
@@ -313,16 +313,16 @@ public class SOAPClient {
     protected void createEnvelope(XMLStructuredOutput output,
                                   Consumer<XMLStructuredOutput> headBuilder,
                                   Consumer<XMLStructuredOutput> bodyBuilder) {
-        output.beginOutput(SOAP_NAMESPACE, TAG_SOAP_ENVELOPE, getNamespaceDefinitions().toArray(ATTRIBUTE_ARRAY));
+        output.beginNamespacedOutput(SOAP_NAMESPACE, TAG_SOAP_ENVELOPE, getNamespaceDefinitions().toArray(ATTRIBUTE_ARRAY));
         {
-            output.beginObject(SOAP_NAMESPACE, TAG_SOAP_HEADER);
+            output.beginNamespacedObject(SOAP_NAMESPACE, TAG_SOAP_HEADER);
             {
                 if (headBuilder != null) {
                     headBuilder.accept(output);
                 }
             }
             output.endObject();
-            output.beginObject(SOAP_NAMESPACE, TAG_SOAP_BODY);
+            output.beginNamespacedObject(SOAP_NAMESPACE, TAG_SOAP_BODY);
             {
                 bodyBuilder.accept(output);
             }

--- a/src/main/java/sirius/kernel/xml/XMLStructuredOutput.java
+++ b/src/main/java/sirius/kernel/xml/XMLStructuredOutput.java
@@ -90,7 +90,7 @@ public class XMLStructuredOutput extends AbstractStructuredOutput {
      * @param name      the name of the array
      * @return the output itself for fluent method calls
      */
-    public StructuredOutput beginArray(@Nonnull String namespace, @Nonnull String name) {
+    public StructuredOutput beginNamespacedArray(@Nonnull String namespace, @Nonnull String name) {
         return beginArray(namespace + ":" + name);
     }
 
@@ -111,7 +111,9 @@ public class XMLStructuredOutput extends AbstractStructuredOutput {
      * @param attributes the attributes to add to the object
      * @return the output itself for fluent method calls
      */
-    public StructuredOutput beginObject(@Nonnull String namespace, @Nonnull String name, Attribute... attributes) {
+    public StructuredOutput beginNamespacedObject(@Nonnull String namespace,
+                                                  @Nonnull String name,
+                                                  Attribute... attributes) {
         return beginObject(namespace + ":" + name, attributes);
     }
 
@@ -141,7 +143,7 @@ public class XMLStructuredOutput extends AbstractStructuredOutput {
      * @param name      the unqualified name
      * @return the output itself for fluent method calls
      */
-    public StructuredOutput beginResult(@Nonnull String namespace, @Nonnull String name) {
+    public StructuredOutput beginNamespacedResult(@Nonnull String namespace, @Nonnull String name) {
         return beginResult(namespace + ":" + name);
     }
 
@@ -194,7 +196,9 @@ public class XMLStructuredOutput extends AbstractStructuredOutput {
      * @param attr        the attributes for the root element
      * @return the output itself for fluent method calls
      */
-    public StructuredOutput beginOutput(@Nonnull String namespace, @Nonnull String rootElement, Attribute... attr) {
+    public StructuredOutput beginNamespacedOutput(@Nonnull String namespace,
+                                                  @Nonnull String rootElement,
+                                                  Attribute... attr) {
         return beginOutput(namespace + ":" + rootElement, attr);
     }
 
@@ -278,15 +282,19 @@ public class XMLStructuredOutput extends AbstractStructuredOutput {
     }
 
     /**
-     * Convenience method for {@link #property(String, Object)} prepending a namespace.
+     * Convenience method for {@link #property(String, Object, Attribute...)} prepending a namespace.
      *
-     * @param namespace the namespace
-     * @param name      the name of the property
-     * @param data      the value of the property
+     * @param namespace  the namespace
+     * @param name       the name of the property
+     * @param data       the value of the property
+     * @param attributes the attributes
      * @return the output itself for fluent method calls
      */
-    public StructuredOutput property(@Nonnull String namespace, @Nonnull String name, @Nullable Object data) {
-        return property(namespace + ":" + name, data);
+    public StructuredOutput namespacedProperty(@Nonnull String namespace,
+                                               @Nonnull String name,
+                                               @Nullable Object data,
+                                               Attribute... attributes) {
+        return property(namespace + ":" + name, data, attributes);
     }
 
     /**


### PR DESCRIPTION
if you called `property(String, String, Attribute)` previously, it resolved to `property(String, String, Object)` instead of `property(String, Object, Attribute...)`. Because the former was added recently, this broke some existing code :(