### PR TITLE
Reverts removing the addTiming(String, long) method in the adapter 

### DIFF
--- a/src/main/java/sirius/kernel/async/BasicTaskContextAdapter.java
+++ b/src/main/java/sirius/kernel/async/BasicTaskContextAdapter.java
@@ -57,6 +57,11 @@ public class BasicTaskContextAdapter implements TaskContextAdapter {
     }
 
     @Override
+    public void addTiming(String counter, long millis) {
+        // Ignored by the default implementation.
+    }
+
+    @Override
     public void addTiming(String counter, long millis, boolean adminOnly) {
         // Ignored by the default implementation.
     }

--- a/src/main/java/sirius/kernel/async/TaskContextAdapter.java
+++ b/src/main/java/sirius/kernel/async/TaskContextAdapter.java
@@ -54,6 +54,14 @@ public interface TaskContextAdapter {
     void smartLogLimited(Supplier<Object> messageSupplier);
 
     /**
+     * Invoked if {@link sirius.kernel.async.TaskContext#addTiming(String, long)} is called in the attached context.
+     *
+     * @param counter the counter to increment
+     * @param millis  the current duration for the block being counted
+     */
+    void addTiming(String counter, long millis);
+
+    /**
      * Invoked if {@link sirius.kernel.async.TaskContext#addTiming(String, long, boolean)} is called in the attached context.
      *
      * @param counter   the counter to increment


### PR DESCRIPTION
as it is used extensively in all Batch-Jobs

- Fixes: SIRI-250