### PR TITLE
Added question mark check to URLBuilder

### DIFF
--- a/src/main/java/sirius/kernel/commons/URLBuilder.java
+++ b/src/main/java/sirius/kernel/commons/URLBuilder.java
@@ -63,12 +63,13 @@ public class URLBuilder {
     /**
      * Adds a path part to the url.
      * <p>
-     * Once the first parameter has been added, the path can no longer be modified. If the path itself contains
-     * parameters the questionMark {@link Monoflop} will be toggled.
+     * Once the first parameter has been added, the path can no longer be modified. Also the part itself can (but
+     * shouldn't) contain parameters, usually led by a initial question mark.
      *
      * @param uriPartsToAdd the uri part to add. This should not contain a leading '/' as it is added automatically. If
      *                      an array (vararg) is given, all components are appended to the internal {@link
-     *                      StringBuilder} without any additional characters.
+     *                      StringBuilder} without any additional characters. If this contains a '?' to add parameters,
+     *                      no more parts can be added.
      * @return the builder itself for fluent method calls
      */
     public URLBuilder addPart(@Nonnull String... uriPartsToAdd) {

--- a/src/main/java/sirius/kernel/commons/URLBuilder.java
+++ b/src/main/java/sirius/kernel/commons/URLBuilder.java
@@ -39,10 +39,6 @@ public class URLBuilder {
      * @param baseURL the base url to stat with in a form like <tt>http://somehost.com</tt>
      */
     public URLBuilder(@Nonnull String baseURL) {
-        if (baseURL.contains("?")) {
-            questionMark.toggle();
-        }
-
         url = new StringBuilder();
         if (baseURL.endsWith("/")) {
             url.append(baseURL, 0, baseURL.length() - 1);
@@ -58,10 +54,6 @@ public class URLBuilder {
      * @param host     the host to target.
      */
     public URLBuilder(@Nonnull String protocol, @Nonnull String host) {
-        if (host.contains("?")) {
-            questionMark.toggle();
-        }
-
         url = new StringBuilder();
         url.append(protocol);
         url.append("://");
@@ -87,6 +79,8 @@ public class URLBuilder {
                             "Cannot add '%s'! Parameters where already added to: '%s'.",
                             uriPart,
                             url));
+                } else if (uriPart.contains("?")) {
+                    questionMark.toggle();
                 }
                 url.append(uriPart);
             }

--- a/src/main/java/sirius/kernel/commons/URLBuilder.java
+++ b/src/main/java/sirius/kernel/commons/URLBuilder.java
@@ -64,7 +64,7 @@ public class URLBuilder {
      * Adds a path part to the url.
      * <p>
      * Once the first parameter has been added, the path can no longer be modified. Also the part itself can (but
-     * shouldn't) contain parameters, usually led by a initial question mark.
+     * shouldn't) contain parameters, usually led by an initial question mark.
      *
      * @param uriPartsToAdd the uri part to add. This should not contain a leading '/' as it is added automatically. If
      *                      an array (vararg) is given, all components are appended to the internal {@link

--- a/src/main/java/sirius/kernel/commons/URLBuilder.java
+++ b/src/main/java/sirius/kernel/commons/URLBuilder.java
@@ -39,6 +39,10 @@ public class URLBuilder {
      * @param baseURL the base url to stat with in a form like <tt>http://somehost.com</tt>
      */
     public URLBuilder(@Nonnull String baseURL) {
+        if (baseURL.contains("?")) {
+            questionMark.toggle();
+        }
+
         url = new StringBuilder();
         if (baseURL.endsWith("/")) {
             url.append(baseURL, 0, baseURL.length() - 1);
@@ -54,6 +58,10 @@ public class URLBuilder {
      * @param host     the host to target.
      */
     public URLBuilder(@Nonnull String protocol, @Nonnull String host) {
+        if (host.contains("?")) {
+            questionMark.toggle();
+        }
+
         url = new StringBuilder();
         url.append(protocol);
         url.append("://");

--- a/src/main/java/sirius/kernel/commons/URLBuilder.java
+++ b/src/main/java/sirius/kernel/commons/URLBuilder.java
@@ -63,7 +63,8 @@ public class URLBuilder {
     /**
      * Adds a path part to the url.
      * <p>
-     * Once the first parameter has been added, the path can no longer be modified.
+     * Once the first parameter has been added, the path can no longer be modified. If the path itself contains
+     * parameters the questionMark {@link Monoflop} will be toggled.
      *
      * @param uriPartsToAdd the uri part to add. This should not contain a leading '/' as it is added automatically. If
      *                      an array (vararg) is given, all components are appended to the internal {@link


### PR DESCRIPTION
If adding a baseURL oder host containing a question mark the question mark monoflop will be toggled for following parameters to be added correctly with an ampersand.