### PR TITLE
Introduces local sized caches

### DIFF
--- a/src/main/java/sirius/kernel/cache/SizedCache.java
+++ b/src/main/java/sirius/kernel/cache/SizedCache.java
@@ -11,30 +11,99 @@ package sirius.kernel.cache;
 import com.google.common.cache.CacheBuilder;
 import com.google.common.cache.CacheLoader;
 import com.google.common.cache.LoadingCache;
+import sirius.kernel.Sirius;
 import sirius.kernel.health.Exceptions;
 
 import java.util.concurrent.ExecutionException;
 import java.util.function.Function;
 
+/**
+ * Defines a size limited mapping from key to values.
+ * <p>
+ * Items can be put in the cache by direct method or calculated from a value computer, either a default
+ * one provided when initializing the class and/or a custom one when getting an item.
+ * <p>
+ * The maximum size of the cache is given during initialization, either with a fixed value or by providing
+ * a configuration key where the value should be retrieved from.
+ * <p>
+ * Note that a {@link ManagedCache} is the preferred solution for most cases, but certain situations might
+ * require a pure local cache, such as a temporary big data load where cache polution is not desired.
+ * In such a case, this class will give the comfort and easy of use Map-like implementation eliminating
+ * the risk of an out-of-memory.
+ *
+ * @param <T> the type of object to be stored in the cache
+ */
 public class SizedCache<T> {
 
     private final LoadingCache<String, T> cache;
     private final boolean hasDefaultLoader;
 
-    public SizedCache(long maximumSize, Function<String, T> defaultLoader) {
+    /**
+     * Creates a sized cache with a maximum size and default value computer.
+     *
+     * @param maximumSize          the maximum size of the cache
+     * @param defaultValueComputer the default function called to compute the value of a missing entry
+     */
+    public SizedCache(long maximumSize, Function<String, T> defaultValueComputer) {
         this.cache = CacheBuilder.newBuilder().maximumSize(maximumSize).build(new CacheLoader<String, T>() {
             @Override
             public T load(String key) throws Exception {
-                return defaultLoader.apply(key);
+                if (defaultValueComputer == null) {
+                    return null;
+                }
+                return defaultValueComputer.apply(key);
             }
         });
-        this.hasDefaultLoader = true;
+        this.hasDefaultLoader = (defaultValueComputer != null);
     }
 
+    /**
+     * Creates a sized cache with a maximum size and default value computer.
+     *
+     * @param configKey            the name of a configuration key containing the maximum size of the cache
+     * @param defaultValueComputer the default function called to compute the value of a missing entry
+     */
+    public SizedCache(String configKey, Function<String, T> defaultValueComputer) {
+        this(obtainSizeFromConfig(configKey), defaultValueComputer);
+    }
+
+    /**
+     * Creates a sized cache with a maximum size.
+     *
+     * @param maximumSize the maximum size of the cache
+     */
     public SizedCache(long maximumSize) {
-        this(maximumSize, key -> null);
+        this(maximumSize, null);
     }
 
+    /**
+     * Creates a sized cache with a maximum size.
+     *
+     * @param configKey the name of a configuration key containing the maximum size of the cache
+     */
+    public SizedCache(String configKey) {
+        this(obtainSizeFromConfig(configKey), null);
+    }
+
+    private static long obtainSizeFromConfig(String configKey) {
+        long maximumSize = Sirius.getSettings().getInt(configKey);
+        if (maximumSize == 0) {
+            throw Exceptions.createHandled()
+                            .withSystemErrorMessage("Cannot initialize a sized cache from configuration key '%s'.",
+                                                    configKey)
+                            .handle();
+        }
+        return maximumSize;
+    }
+
+    /**
+     * Retrieves the value for a given key.
+     * <p>
+     * This method throws an {@link IllegalStateException} if no default value provider has been initialized.
+     *
+     * @param key the key to search
+     * @return the object associated with the key
+     */
     public T get(String key) {
         if (!hasDefaultLoader) {
             throw new IllegalStateException("Cache does not provide a default loader to compute data.");
@@ -42,21 +111,47 @@ public class SizedCache<T> {
         return cache.getUnchecked(key);
     }
 
-    public T get(String key, Function<String, T> loader) {
+    /**
+     * Retrieves the value for a given key.
+     *
+     * @param key           the key to search
+     * @param valueComputer the function called to compute the value of a missing entry
+     * @return the object associated with the key
+     */
+    public T get(String key, Function<String, T> valueComputer) {
         try {
-            return cache.get(key, () -> loader.apply(key));
+            return cache.get(key, () -> valueComputer.apply(key));
         } catch (ExecutionException e) {
             throw Exceptions.createHandled()
                             .error(e)
-                            .withSystemErrorMessage("Cannot compute value for a sized cache.")
+                            .withSystemErrorMessage("Cannot compute value for key '%s' in sized cache.", key)
                             .handle();
         }
     }
 
+    /**
+     * Checks if the given key is currently loaded in the cache.
+     *
+     * @param key the key to search
+     * @return <tt>true</tt> if the key is loaded in the cache, <tt>false</tt> otherwise
+     */
+    public boolean containsKey(String key) {
+        return (cache.getIfPresent(key) != null);
+    }
+
+    /**
+     * Inserts or replaces a value in the cache for the given key.
+     *
+     * @param key   the key to search
+     * @param value the object to be inserted or replaced for the provided key
+     */
     public void put(String key, T value) {
         cache.put(key, value);
     }
 
+    /**
+     * Clears all items loaded in the cache.
+     */
     public void clear() {
         cache.invalidateAll();
     }

--- a/src/main/java/sirius/kernel/cache/SizedCache.java
+++ b/src/main/java/sirius/kernel/cache/SizedCache.java
@@ -1,0 +1,63 @@
+/*
+ * Made with all the love in the world
+ * by scireum in Remshalden, Germany
+ *
+ * Copyright by scireum GmbH
+ * http://www.scireum.de - info@scireum.de
+ */
+
+package sirius.kernel.cache;
+
+import com.google.common.cache.CacheBuilder;
+import com.google.common.cache.CacheLoader;
+import com.google.common.cache.LoadingCache;
+import sirius.kernel.health.Exceptions;
+
+import java.util.concurrent.ExecutionException;
+import java.util.function.Function;
+
+public class SizedCache<T> {
+
+    private final LoadingCache<String, T> cache;
+    private final boolean hasDefaultLoader;
+
+    public SizedCache(long maximumSize, Function<String, T> defaultLoader) {
+        this.cache = CacheBuilder.newBuilder().maximumSize(maximumSize).build(new CacheLoader<String, T>() {
+            @Override
+            public T load(String key) throws Exception {
+                return defaultLoader.apply(key);
+            }
+        });
+        this.hasDefaultLoader = true;
+    }
+
+    public SizedCache(long maximumSize) {
+        this(maximumSize, key -> null);
+    }
+
+    public T get(String key) {
+        if (!hasDefaultLoader) {
+            throw new IllegalStateException("Cache does not provide a default loader to compute data.");
+        }
+        return cache.getUnchecked(key);
+    }
+
+    public T get(String key, Function<String, T> loader) {
+        try {
+            return cache.get(key, () -> loader.apply(key));
+        } catch (ExecutionException e) {
+            throw Exceptions.createHandled()
+                            .error(e)
+                            .withSystemErrorMessage("Cannot compute value for a sized cache.")
+                            .handle();
+        }
+    }
+
+    public void put(String key, T value) {
+        cache.put(key, value);
+    }
+
+    public void clear() {
+        cache.invalidateAll();
+    }
+}

--- a/src/main/java/sirius/kernel/cache/SizedCache.java
+++ b/src/main/java/sirius/kernel/cache/SizedCache.java
@@ -11,7 +11,6 @@ package sirius.kernel.cache;
 import com.google.common.cache.CacheBuilder;
 import com.google.common.cache.CacheLoader;
 import com.google.common.cache.LoadingCache;
-import sirius.kernel.Sirius;
 import sirius.kernel.health.Exceptions;
 
 import java.util.concurrent.ExecutionException;
@@ -23,8 +22,7 @@ import java.util.function.Function;
  * Items can be put in the cache by direct method or calculated from a value computer, either a default
  * one provided when initializing the class and/or a custom one when getting an item.
  * <p>
- * The maximum size of the cache is given during initialization, either with a fixed value or by providing
- * a configuration key where the value should be retrieved from.
+ * The maximum size of the cache is given during initialization.
  * <p>
  * Note that a {@link ManagedCache} is the preferred solution for most cases, but certain situations might
  * require a pure local cache, such as a temporary big data load where cache polution is not desired.
@@ -61,41 +59,12 @@ public class SizedCache<T> {
     }
 
     /**
-     * Creates a sized cache with a maximum size and default value computer.
-     *
-     * @param configKey            the name of a configuration key containing the maximum size of the cache
-     * @param defaultValueComputer the default function called to compute the value of a missing entry
-     */
-    public SizedCache(String configKey, Function<String, T> defaultValueComputer) {
-        this(obtainSizeFromConfig(configKey), defaultValueComputer);
-    }
-
-    /**
      * Creates a sized cache with a maximum size.
      *
      * @param maximumSize the maximum size of the cache
      */
     public SizedCache(long maximumSize) {
         this(maximumSize, null);
-    }
-
-    /**
-     * Creates a sized cache with a maximum size.
-     *
-     * @param configKey the name of a configuration key containing the maximum size of the cache
-     */
-    public SizedCache(String configKey) {
-        this(obtainSizeFromConfig(configKey), null);
-    }
-
-    private static long obtainSizeFromConfig(String configKey) {
-        if (!Sirius.getSettings().has(configKey)) {
-            throw Exceptions.createHandled()
-                            .withSystemErrorMessage("Cannot initialize a sized cache from configuration key '%s'.",
-                                                    configKey)
-                            .handle();
-        }
-        return Sirius.getSettings().getInt(configKey);
     }
 
     /**

--- a/src/test/java/sirius/kernel/cache/SizedCacheSpec.groovy
+++ b/src/test/java/sirius/kernel/cache/SizedCacheSpec.groovy
@@ -1,0 +1,97 @@
+/*
+ * Made with all the love in the world
+ * by scireum in Remshalden, Germany
+ *
+ * Copyright by scireum GmbH
+ * http://www.scireum.de - info@scireum.de
+ */
+
+package sirius.kernel.cache
+
+import sirius.kernel.BaseSpecification
+import sirius.kernel.health.HandledException
+
+class SizedCacheSpec extends BaseSpecification {
+
+    def valuecomputer = { key ->
+        return key.replace("key", "value")
+    }
+
+    def "contains key works"() {
+        given:
+        def cache = new SizedCache(2)
+
+        when:
+        cache.put("key1", "value1")
+        cache.put("key2", "value2")
+        cache.put("key3", "value3")
+
+        then:
+        cache.containsKey("key0") == false
+        cache.containsKey("key1") == false
+        cache.containsKey("key2") == true
+        cache.containsKey("key3") == true
+    }
+
+    def "get without computer works"() {
+        given:
+        def cache = new SizedCache(2)
+
+        when:
+        cache.put("key1", "value1")
+        cache.get("key1")
+
+        then:
+        thrown IllegalStateException
+    }
+
+    def "get with default computer works"() {
+        when:
+        def cache = new SizedCache(2, valuecomputer)
+
+        then:
+        cache.get("key1") == "value1"
+        cache.get("key2") == "value2"
+        cache.get("key3") == "value3"
+        cache.containsKey("key1") == false
+    }
+
+    def "get with inline computer works"() {
+        when:
+        def cache = new SizedCache(2)
+
+        then:
+        cache.get("key1", valuecomputer) == "value1"
+        cache.get("key2", valuecomputer) == "value2"
+        cache.get("key3", valuecomputer) == "value3"
+        cache.containsKey("key1") == false
+    }
+
+    def "init cache size from config works"() {
+        when:
+        def cache = new SizedCache("cache.invalid-cache-key")
+
+        then:
+        thrown HandledException
+
+        when:
+        cache = new SizedCache("cache.test-sized-cache", valuecomputer)
+
+        then:
+        cache.get("key1") == "value1"
+        cache.get("key2") == "value2"
+        cache.get("key3") == "value3"
+        cache.containsKey("key1") == false
+    }
+
+    def "cache cleanup works"() {
+        when:
+        def cache = new SizedCache(2)
+        cache.put("key1", "value1")
+
+        then:
+        cache.containsKey("key1") == true
+        cache.clear()
+        cache.containsKey("key1") == false
+    }
+}

--- a/src/test/java/sirius/kernel/cache/SizedCacheSpec.groovy
+++ b/src/test/java/sirius/kernel/cache/SizedCacheSpec.groovy
@@ -75,23 +75,6 @@ class SizedCacheSpec extends BaseSpecification {
         cache.containsKey("key1") == false
     }
 
-    def "init cache size from config works"() {
-        when:
-        def cache = new SizedCache("cache.invalid-cache-key")
-
-        then:
-        thrown HandledException
-
-        when:
-        cache = new SizedCache("cache.test-sized-cache", valuecomputer)
-
-        then:
-        cache.get("key1") == "value1"
-        cache.get("key2") == "value2"
-        cache.get("key3") == "value3"
-        cache.containsKey("key1") == false
-    }
-
     def "cache cleanup works"() {
         when:
         def cache = new SizedCache(2)

--- a/src/test/java/sirius/kernel/cache/SizedCacheSpec.groovy
+++ b/src/test/java/sirius/kernel/cache/SizedCacheSpec.groovy
@@ -17,6 +17,14 @@ class SizedCacheSpec extends BaseSpecification {
         return key.replace("key", "value")
     }
 
+    def "minimum cache size works"() {
+        when:
+        def cache = new SizedCache(-1)
+
+        then:
+        thrown IllegalArgumentException
+    }
+
     def "contains key works"() {
         given:
         def cache = new SizedCache(2)

--- a/src/test/resources/component-test-kernel.conf
+++ b/src/test/resources/component-test-kernel.conf
@@ -23,6 +23,8 @@ cache {
         ttl = 1 seconds
         maxSize = 100
     }
+
+    test-sized-cache = 2
 }
 
 test-configs {

--- a/src/test/resources/component-test-kernel.conf
+++ b/src/test/resources/component-test-kernel.conf
@@ -23,8 +23,6 @@ cache {
         ttl = 1 seconds
         maxSize = 100
     }
-
-    test-sized-cache = 2
 }
 
 test-configs {


### PR DESCRIPTION
This rather simple class enables one to create a local cache limited by the amount of entries in it. By local I really mean local, without any framework-based lifetime. See it as a sort of `Map<String, Object>` with a maximum size.
Based on LoadingCache but eliminating all boiler plate necessary to use it.

It can be initialized with a default value computer used by the `get(key)` method, or a computer can be provided ad-hoc in the `get(key, loader)`.

See the test cases for various usage scenarios.