### PR TITLE
Provides an option to only read a node itself on xml parsing

### DIFF
--- a/src/main/java/sirius/kernel/xml/NoContentNodeHandler.java
+++ b/src/main/java/sirius/kernel/xml/NoContentNodeHandler.java
@@ -1,0 +1,21 @@
+/*
+ * Made with all the love in the world
+ * by scireum in Remshalden, Germany
+ *
+ * Copyright by scireum GmbH
+ * http://www.scireum.de - info@scireum.de
+ */
+
+package sirius.kernel.xml;
+
+/**
+ * Can be used to handle XML nodes without having the parser to read out the full content of the node, but only
+ * the node with attributes. See {@link NodeHandler#ignoreContent()} for an example.
+ */
+public abstract class NoContentNodeHandler implements NodeHandler {
+
+    @Override
+    public boolean ignoreContent() {
+        return true;
+    }
+}

--- a/src/main/java/sirius/kernel/xml/NodeHandler.java
+++ b/src/main/java/sirius/kernel/xml/NodeHandler.java
@@ -31,6 +31,7 @@ public interface NodeHandler {
      * When set to true, this handler will receive: "&lt;root someAttribute="abc"&gt;" without the child content from:
      * <pre>
      * &lt;root someAttribute="abc"&gt;
+     *      someTextValue
      *      &lt;child>1&lt;/child&gt;
      *      ...
      *      &lt;child>10000000000&lt;/child&gt;

--- a/src/main/java/sirius/kernel/xml/NodeHandler.java
+++ b/src/main/java/sirius/kernel/xml/NodeHandler.java
@@ -16,9 +16,32 @@ package sirius.kernel.xml;
 public interface NodeHandler {
 
     /**
-     * Invoked once a complete subtree was parsed
+     * Invoked once a node was parsed. Depending on {@link #ignoreContent()} this will be the complete subtree or only
+     * the node itself.
      *
      * @param node the root node of the subtree parsed by the SAX parser
      */
     void process(StructuredNode node);
+
+    /**
+     * Determines if the content of an node shall be handled. It can be used for root nodes of large files. There we do
+     * not want to access the root node with all child nodes loaded into one node which would have a negative
+     * performance impact.
+     * <p>
+     * When set to true, this handler will receive: "&lt;root someAttribute="abc"&gt;" without the child content from:
+     * <pre>
+     * &lt;root someAttribute="abc"&gt;
+     *      &lt;child>1&lt;/child&gt;
+     *      ...
+     *      &lt;child>10000000000&lt;/child&gt;
+     * &lt;/root&gt;
+     *
+     * </pre>
+     * When set to false, root with all child nodes will be received.
+     *
+     * @return <tt>true</tt> if the content shall be ignored, <tt>false</tt> otherwise
+     */
+    default boolean ignoreContent() {
+        return false;
+    }
 }

--- a/src/main/java/sirius/kernel/xml/NodeHandler.java
+++ b/src/main/java/sirius/kernel/xml/NodeHandler.java
@@ -24,7 +24,7 @@ public interface NodeHandler {
     void process(StructuredNode node);
 
     /**
-     * Determines if the content of an node shall be handled. It can be used for root nodes of large files. There we do
+     * Determines if the content of a node shall be handled. It can be used for root nodes of large files. There we do
      * not want to access the root node with all child nodes loaded into one node which would have a negative
      * performance impact.
      * <p>

--- a/src/main/java/sirius/kernel/xml/SAX2DOMHandler.java
+++ b/src/main/java/sirius/kernel/xml/SAX2DOMHandler.java
@@ -62,6 +62,10 @@ class SAX2DOMHandler {
             document.appendChild(element);
         }
         currentNode = element;
+
+        if (nodeHandler.ignoreContent()) {
+            nodeHandler.process(StructuredNode.of(currentNode));
+        }
     }
 
     public Node getRoot() {

--- a/src/main/java/sirius/kernel/xml/XMLReader.java
+++ b/src/main/java/sirius/kernel/xml/XMLReader.java
@@ -117,7 +117,9 @@ public class XMLReader extends DefaultHandler {
         if (handler != null) {
             SAX2DOMHandler saxHandler = new SAX2DOMHandler(handler, documentBuilder.newDocument());
             saxHandler.createElement(name, attributes);
-            activeHandlers.add(saxHandler);
+            if (!handler.ignoreContent()) {
+                activeHandlers.add(saxHandler);
+            }
         }
 
         // Check if the user tried to interrupt parsing....


### PR DESCRIPTION
- defaults to old behaviour of reading the node with all content
