### PR TITLE
Marks some internals of BackgroundLoop as volatile.

### DIFF
--- a/src/main/java/sirius/kernel/async/BackgroundLoop.java
+++ b/src/main/java/sirius/kernel/async/BackgroundLoop.java
@@ -56,9 +56,9 @@ public abstract class BackgroundLoop {
 
     private Future loopExecuted = new Future();
     private volatile boolean enabled = true;
-    private long lastExecutionAttempt;
+    private volatile long lastExecutionAttempt;
     private String executionInfo = "-";
-    private boolean executing = false;
+    private volatile boolean executing = false;
 
     /**
      * Returns the name of the loop.


### PR DESCRIPTION
Otherwise the monitoring thread might see stale data and report false positives.