### PR TITLE
SIRI-336: Ensures FIFO when logging ERR and OUT Streams of Executed Commands

### DIFF
--- a/src/main/java/sirius/kernel/commons/Exec.java
+++ b/src/main/java/sirius/kernel/commons/Exec.java
@@ -167,13 +167,13 @@ public class Exec {
         StringBuffer logger = new StringBuffer();
         try (Operation op = new Operation(() -> command, opTimeout)) {
             Process p = Runtime.getRuntime().exec(command, null, directory);
-            Semaphore completionSynchronizer = new Semaphore(2);
+            Semaphore completionSynchronizer = new Semaphore(1);
             StreamEater errEater = StreamEater.eat(p.getErrorStream(), logger, completionSynchronizer);
             StreamEater outEater = StreamEater.eat(p.getInputStream(), logger, completionSynchronizer);
             doExec(ignoreExitCodes, logger, p);
 
             // Wait for the stream eaters to complete...
-            completionSynchronizer.acquire(2);
+            completionSynchronizer.acquire();
 
             if (errEater.exHolder.get() != null) {
                 throw new ExecException(errEater.exHolder.get(), logger.toString());

--- a/src/main/java/sirius/kernel/commons/Exec.java
+++ b/src/main/java/sirius/kernel/commons/Exec.java
@@ -167,7 +167,7 @@ public class Exec {
         StringBuffer logger = new StringBuffer();
         try (Operation op = new Operation(() -> command, opTimeout)) {
             Process p = Runtime.getRuntime().exec(command, null, directory);
-            Semaphore completionSynchronizer = new Semaphore(1);
+            Semaphore completionSynchronizer = new Semaphore(1, true);
             StreamEater errEater = StreamEater.eat(p.getErrorStream(), logger, completionSynchronizer);
             StreamEater outEater = StreamEater.eat(p.getInputStream(), logger, completionSynchronizer);
             doExec(ignoreExitCodes, logger, p);


### PR DESCRIPTION
Ensures that the StreamEaters take turns when writing to the logger, which prevents mixing up their messages.
We had problems with parts of error messages being logged within the body of a JSON object that we parse from the log output, resulting in syntax errors.

e.g.:
```
{
    "streams": [
        {
            "index": 1,
            "closed_captions": 0,
            "has_b_frames": 1,
[json @ 0x7fb79d009a00] 15 invalid UTF-8 sequence(s) found in string 'BlahBlahBlubb', replaced with '�'            "pix_fmt": "yuv420p",

            "level": 40,
            "color_range": "tv",
            "color_space": "bt709",
            "color_transfer": "bt709",
            "color_primaries": "bt709",
            "chroma_location": "left",
            "refs": 1,
            "is_avc": "true",
            "nal_length_size": "4",
             ...
```

Fixes: SIRI-336