### PR TITLE
SIRI-336: Synchronizes logger access for StreamEaters in Exec

### DIFF
--- a/src/main/java/sirius/kernel/commons/Exec.java
+++ b/src/main/java/sirius/kernel/commons/Exec.java
@@ -61,10 +61,12 @@ public class Exec {
                 Thread.currentThread()
                       .setName(StreamEater.class.getSimpleName() + "-" + Thread.currentThread().getId());
                 String line = br.readLine();
-                while (line != null) {
-                    logger.append(line);
-                    logger.append("\n");
-                    line = br.readLine();
+                synchronized (logger) {
+                    while (line != null) {
+                        logger.append(line);
+                        logger.append("\n");
+                        line = br.readLine();
+                    }
                 }
             } catch (IOException e) {
                 logger.append(NLS.toUserString(e));

--- a/src/main/java/sirius/kernel/commons/Exec.java
+++ b/src/main/java/sirius/kernel/commons/Exec.java
@@ -25,8 +25,6 @@ import java.util.concurrent.Semaphore;
 /**
  * A robust wrapper around calls to external programs.
  */
-@SuppressWarnings("squid:S1149")
-@Explain("We actually need the thread safety probided by StringBuffer here, as we start 2 threads per call.")
 public class Exec {
 
     /**
@@ -43,11 +41,11 @@ public class Exec {
     private static class StreamEater implements Runnable {
 
         private final InputStream stream;
-        private final StringBuffer logger;
+        private final StringBuilder logger;
         private final ValueHolder<IOException> exHolder = new ValueHolder<>(null);
         private final Semaphore completionSynchronizer;
 
-        StreamEater(InputStream stream, StringBuffer log, Semaphore completionSynchronizer)
+        StreamEater(InputStream stream, StringBuilder log, Semaphore completionSynchronizer)
                 throws InterruptedException {
             this.stream = stream;
             this.logger = log;
@@ -86,7 +84,7 @@ public class Exec {
          * @param completionSynchronizer a semaphore where a permit is acquired and released once all output hase been processed
          * @return a new stream eater which is already running in a separate thread
          */
-        static StreamEater eat(InputStream stream, StringBuffer logger, Semaphore completionSynchronizer)
+        static StreamEater eat(InputStream stream, StringBuilder logger, Semaphore completionSynchronizer)
                 throws InterruptedException {
             StreamEater eater = new StreamEater(stream, logger, completionSynchronizer);
             new Thread(eater).start();
@@ -168,7 +166,7 @@ public class Exec {
      */
     public static String exec(String command, boolean ignoreExitCodes, Duration opTimeout, @Nullable File directory)
             throws ExecException {
-        StringBuffer logger = new StringBuffer();
+        StringBuilder logger = new StringBuilder();
         try (Operation op = new Operation(() -> command, opTimeout)) {
             Process p = Runtime.getRuntime().exec(command, null, directory);
             Semaphore completionSynchronizer = new Semaphore(2);
@@ -191,7 +189,7 @@ public class Exec {
         }
     }
 
-    private static void doExec(boolean ignoreExitCodes, StringBuffer logger, Process p) throws ExecException {
+    private static void doExec(boolean ignoreExitCodes, StringBuilder logger, Process p) throws ExecException {
         try {
             int code = p.waitFor();
             if (code != 0 && !ignoreExitCodes) {

--- a/src/main/java/sirius/kernel/commons/Exec.java
+++ b/src/main/java/sirius/kernel/commons/Exec.java
@@ -69,7 +69,9 @@ public class Exec {
                     }
                 }
             } catch (IOException e) {
-                logger.append(NLS.toUserString(e));
+                synchronized (logger) {
+                    logger.append(NLS.toUserString(e));
+                }
                 exHolder.set(e);
             } finally {
                 this.completionSynchronizer.release();


### PR DESCRIPTION
Ensures that the StreamEaters take turns when writing to the logger, which prevents mixing up their messages.
We had problems with parts of error messages being logged within the body of a JSON object that we parse from the log output, resulting in syntax errors.

e.g.:
```
{
    "streams": [
        {
            "index": 1,
            "closed_captions": 0,
            "has_b_frames": 1,
[json @ 0x7fb79d009a00] 15 invalid UTF-8 sequence(s) found in string 'BlahBlahBlubb', replaced with '�'            "pix_fmt": "yuv420p",

            "level": 40,
            "color_range": "tv",
            "color_space": "bt709",
            "color_transfer": "bt709",
            "color_primaries": "bt709",
            "chroma_location": "left",
            "refs": 1,
            "is_avc": "true",
            "nal_length_size": "4",
             ...
```

Fixes: SIRI-336