### PR TITLE
Stops auto transforming GET requests into POST Requests and adds some methods to Outcall

### DIFF
--- a/src/main/java/sirius/kernel/xml/Outcall.java
+++ b/src/main/java/sirius/kernel/xml/Outcall.java
@@ -98,7 +98,6 @@ public class Outcall {
 
         connection = (HttpURLConnection) url.openConnection();
         connection.setDoInput(true);
-        connection.setDoOutput(true);
         connection.setConnectTimeout(DEFAULT_CONNECT_TIMEOUT);
         connection.setReadTimeout(DEFAULT_READ_TIMEOUT);
     }
@@ -167,6 +166,7 @@ public class Outcall {
      * @throws IOException if the method cannot be reset or if the requested method isn't valid for HTTP.
      */
     public Outcall markAsPostRequest() throws IOException {
+        connection.setDoOutput(true);
         connection.setRequestMethod(REQUEST_METHOD_POST);
         return this;
     }
@@ -178,7 +178,6 @@ public class Outcall {
      * @throws IOException if the method cannot be reset or if the requested method isn't valid for HTTP.
      */
     public Outcall onlyRequestHeaders() throws IOException {
-        connection.setDoOutput(false);
         connection.setDoInput(false);
         connection.setRequestMethod(REQUEST_METHOD_HEAD);
         return this;
@@ -235,10 +234,13 @@ public class Outcall {
     }
 
     /**
-     * Provides access to the input of the call.
+     * Provides access to a output stream that writes into this call.
+     * <p>
+     * Note that you need to call {@link #markAsPostRequest()} before calling this method.
      *
      * @return the stream of data sent to the call / url
      * @throws IOException in case of any IO error
+     * @throws java.net.ProtocolException if the method doesn't support output
      */
     public OutputStream getOutput() throws IOException {
         try {

--- a/src/main/java/sirius/kernel/xml/Outcall.java
+++ b/src/main/java/sirius/kernel/xml/Outcall.java
@@ -67,7 +67,7 @@ public class Outcall {
     private static final String REQUEST_METHOD_HEAD = "HEAD";
     private static final String HEADER_CONTENT_TYPE = "Content-Type";
     private static final String HEADER_CONTENT_DISPOSITION = "Content-Disposition";
-    private static final String HEADER_IF_MODIFIED_SINCE = "if-modified-since";
+    private static final String HEADER_IF_MODIFIED_SINCE = "If-Modified-Since";
     private static final String CONTENT_TYPE_FORM_URLENCODED = "application/x-www-form-urlencoded; charset=utf-8";
     private static final Pattern CHARSET_PATTERN = Pattern.compile("(?i)\\bcharset=\\s*\"?([^\\s;\"]*)");
     private static final Pattern CONTENT_DISPOSITION_FILENAME_PATTERN =
@@ -414,14 +414,10 @@ public class Outcall {
      * @return an Optional containing the file name given by the header, or Optional.empty if no file name is given
      */
     public Optional<String> parseFileNameFromContentDisposition() {
-        try {
-            Matcher matcher =
-                    CONTENT_DISPOSITION_FILENAME_PATTERN.matcher(connection.getHeaderField(HEADER_CONTENT_DISPOSITION));
-            if (matcher.find()) {
-                return Optional.ofNullable(matcher.group(2));
-            }
-        } catch (IllegalStateException | IndexOutOfBoundsException e) {
-            Exceptions.ignore(e);
+        Matcher matcher =
+                CONTENT_DISPOSITION_FILENAME_PATTERN.matcher(connection.getHeaderField(HEADER_CONTENT_DISPOSITION));
+        if (matcher.find()) {
+            return Optional.ofNullable(matcher.group(2));
         }
         return Optional.empty();
     }

--- a/src/main/java/sirius/kernel/xml/Outcall.java
+++ b/src/main/java/sirius/kernel/xml/Outcall.java
@@ -58,6 +58,7 @@ public class Outcall {
     private static final int DEFAULT_READ_TIMEOUT = (int) TimeUnit.MILLISECONDS.convert(5, TimeUnit.MINUTES);
 
     private static final String REQUEST_METHOD_POST = "POST";
+    private static final String REQUEST_METHOD_HEAD = "HEAD";
     private static final String HEADER_CONTENT_TYPE = "Content-Type";
     private static final String CONTENT_TYPE_FORM_URLENCODED = "application/x-www-form-urlencoded; charset=utf-8";
     private static final Pattern CHARSET_PATTERN = Pattern.compile("(?i)\\bcharset=\\s*\"?([^\\s;\"]*)");
@@ -121,6 +122,7 @@ public class Outcall {
 
     /**
      * Returns the average time to first byte across all outcalls.
+     *
      * @return the average TTFB across all outcalls
      */
     public static Average getTimeToFirstByte() {
@@ -166,6 +168,19 @@ public class Outcall {
      */
     public Outcall markAsPostRequest() throws IOException {
         connection.setRequestMethod(REQUEST_METHOD_POST);
+        return this;
+    }
+
+    /**
+     * Marks the request as HEAD request, only requesting headers.
+     *
+     * @return the outcall itself for fluent method calls
+     * @throws IOException if the method cannot be reset or if the requested method isn't valid for HTTP.
+     */
+    public Outcall onlyRequestHeaders() throws IOException {
+        connection.setDoOutput(false);
+        connection.setDoInput(false);
+        connection.setRequestMethod(REQUEST_METHOD_HEAD);
         return this;
     }
 
@@ -235,6 +250,16 @@ public class Outcall {
     }
 
     /**
+     * Provides access to the response code of the call.
+     *
+     * @return the response code of the call
+     * @throws IOException in case of any IO error
+     */
+    public int getResponseCode() throws IOException {
+        return connection.getResponseCode();
+    }
+
+    /**
      * Sets the header of the HTTP call.
      *
      * @param name  name of the header to set
@@ -244,6 +269,19 @@ public class Outcall {
     public Outcall setRequestProperty(String name, String value) {
         connection.setRequestProperty(name, value);
         return this;
+    }
+
+    /**
+     * Sets the value of the {@code ifModifiedSince} header of this connection.
+     * <p>
+     * The fetching of the object is skipped unless the object has been modified more recently than a certain time.
+     * If the object will not be returned because of this, the response code will be <tt>304</tt>.
+     *
+     * @param ifModifiedSince a date since when the object should be modified
+     * @throws IllegalStateException if already connected
+     */
+    public void setIfModifiedSince(long ifModifiedSince) {
+        connection.setIfModifiedSince(ifModifiedSince);
     }
 
     /**
@@ -335,6 +373,17 @@ public class Outcall {
     @Nullable
     public String getHeaderField(String name) {
         return connection.getHeaderField(name);
+    }
+
+    /**
+     * Returns the response header with the given name.
+     *
+     * @param name        the name of the header to fetch
+     * @param defaultDate a default value to return if the header field is missing or malformed.
+     * @return the value of the given header in the response or the given <tt>defaultDate</tt>
+     */
+    public long getHeaderFieldDate(String name, long defaultDate) {
+        return connection.getHeaderFieldDate(name, defaultDate);
     }
 
     /**

--- a/src/main/java/sirius/kernel/xml/Outcall.java
+++ b/src/main/java/sirius/kernel/xml/Outcall.java
@@ -430,14 +430,14 @@ public class Outcall {
     public Charset getContentEncoding() {
         String contentType = connection.getContentType();
         if (contentType == null) {
-            return charset;
+            return StandardCharsets.UTF_8;
         }
         try {
             Matcher m = CHARSET_PATTERN.matcher(contentType);
             if (m.find()) {
                 return Charset.forName(m.group(1).trim().toUpperCase());
             } else {
-                return charset;
+                return StandardCharsets.UTF_8;
             }
         } catch (Exception e) {
             Exceptions.ignore(e);


### PR DESCRIPTION
BREAKING: No longer provides access to outputstream for get requests

Previously this would work, as the request was transformed into POST from GET if you called getOutput on a GET connection. As we have an explicit method to transform a connection into a POST connection, we excpect this method to be called instead of relying on this auto transform (which is marked as backwards compatibility in the java API).

So to be save that this does not break things, you should search the accessors for Outcall.getOutput in your project and make sure that markAsPostRequest() is called before