### PR TITLE
No longer disables doInput for 'HEAD' requests

### DIFF
--- a/src/main/java/sirius/kernel/xml/Outcall.java
+++ b/src/main/java/sirius/kernel/xml/Outcall.java
@@ -190,7 +190,6 @@ public class Outcall {
      * @throws IOException if the method cannot be reset or if the requested method isn't valid for HTTP.
      */
     public Outcall markAsHeadRequest() throws IOException {
-        connection.setDoInput(false);
         connection.setRequestMethod(REQUEST_METHOD_HEAD);
         return this;
     }


### PR DESCRIPTION
As the java api only returns headers if doInput is set to true, so it can then assign an EmptyInputStream to the input...