### PR TITLE
BREAKING CHANGE: Fixes rounding of Amount.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -32,7 +32,7 @@
         <dependency>
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
-            <version>29.0-jre</version>
+            <version>30.1.1-jre</version>
         </dependency>
 
         <!-- JSR305 annotations like @Nonnull etc. -->

--- a/src/main/java/sirius/kernel/nls/NLS.java
+++ b/src/main/java/sirius/kernel/nls/NLS.java
@@ -835,7 +835,7 @@ public class NLS {
             return String.valueOf(data);
         }
         if (data instanceof Amount) {
-            return ((Amount) data).toString(NumberFormat.MACHINE_TWO_DECIMAL_PLACES).asString();
+            return ((Amount) data).toMachineString();
         }
         if (data instanceof BigDecimal) {
             return ((BigDecimal) data).toPlainString();

--- a/src/main/java/sirius/kernel/xml/XMLStructuredOutput.java
+++ b/src/main/java/sirius/kernel/xml/XMLStructuredOutput.java
@@ -11,6 +11,7 @@ package sirius.kernel.xml;
 import org.xml.sax.SAXException;
 import org.xml.sax.helpers.AttributesImpl;
 import sirius.kernel.health.Exceptions;
+import sirius.kernel.nls.NLS;
 
 import javax.annotation.CheckReturnValue;
 import javax.annotation.Nonnull;
@@ -33,7 +34,7 @@ import java.nio.charset.StandardCharsets;
  */
 public class XMLStructuredOutput extends AbstractStructuredOutput {
 
-    private TransformerHandler transformerHandler;
+    private final TransformerHandler transformerHandler;
     protected OutputStream out;
     private int opensCalled = 0;
 
@@ -272,7 +273,7 @@ public class XMLStructuredOutput extends AbstractStructuredOutput {
         try {
             transformerHandler.startElement("", "", name, null);
             if (value != null) {
-                String val = value.toString();
+                String val = NLS.toMachineString(value);
                 transformerHandler.characters(val.toCharArray(), 0, val.length());
             }
             transformerHandler.endElement("", "", name);
@@ -383,7 +384,7 @@ public class XMLStructuredOutput extends AbstractStructuredOutput {
     public StructuredOutput text(Object text) {
         try {
             if (text != null) {
-                String val = text.toString();
+                String val = NLS.toMachineString(text);
                 transformerHandler.characters(val.toCharArray(), 0, val.length());
             }
         } catch (SAXException e) {

--- a/src/main/resources/component-kernel.conf
+++ b/src/main/resources/component-kernel.conf
@@ -70,7 +70,8 @@ nls {
     # Sets the default language as two-letter code
     defaultLanguage = en
 
-    # Enumerates all supported languages as two-letter codes
+    # Enumerates all supported languages as two-letter codes. These are language for which translations for
+    # NLS are present.
     languages = [ en, de ]
 }
 

--- a/src/test/java/sirius/kernel/commons/AmountSpec.groovy
+++ b/src/test/java/sirius/kernel/commons/AmountSpec.groovy
@@ -3,6 +3,7 @@ package sirius.kernel.commons
 import sirius.kernel.BaseSpecification
 import sirius.kernel.async.CallContext
 
+import java.math.RoundingMode
 import java.util.function.Supplier
 
 class AmountSpec extends BaseSpecification {
@@ -83,11 +84,17 @@ class AmountSpec extends BaseSpecification {
         Amount.ONE_HUNDRED == Amount.TEN.percentageDifferenceOf(Amount.of(5))
         Amount.of(-50) == Amount.of(5).percentageDifferenceOf(Amount.TEN)
         Amount.of(0.5) == Amount.of(50).asDecimal()
-        Amount.ofMachineString("1.23") == Amount.ofMachineString("1.23223").round(NumberFormat.PERCENT)
         Amount.ONE_HUNDRED.getDigits() == 3
         Amount.ONE.getDigits() == 1
         Amount.ONE_HUNDRED.subtract(Amount.ONE).getDigits() == 2
         Amount.of(477).getDigits() == 3
+    }
+
+    def "rounding works as expected"() {
+        expect:
+        "1.23" == Amount.ofMachineString("1.23223").round(2, RoundingMode.HALF_UP).toMachineString()
+        "1.232" == Amount.ofMachineString("1.23223").round(3, RoundingMode.HALF_UP).toMachineString()
+        "1.2" == Amount.ofMachineString("1.23223").round(1, RoundingMode.HALF_UP).toMachineString()
     }
 
     def "formatting works as expected"() {


### PR DESCRIPTION
Previously, calling round didn't change the scale of the internal
number and was thus lost for all subsequent calls.

This meant that formatting this number didn't yield the expected result
as e.g. putting Amount(1.33333).round(3) into an XML response did
yield "1,33" or if getAmount() was used 1.33000 but not the expected
"1.333". This has now been fixed.

Also we no use the machine format when writing XML instead of the user
readable (this is the breaking change).