### PR TITLE
Preserves whitespaces when outputting XML.

### DIFF
--- a/src/main/java/sirius/kernel/xml/AbstractStructuredOutput.java
+++ b/src/main/java/sirius/kernel/xml/AbstractStructuredOutput.java
@@ -8,6 +8,8 @@
 
 package sirius.kernel.xml;
 
+import sirius.kernel.nls.NLS;
+
 import javax.annotation.CheckReturnValue;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
@@ -155,6 +157,22 @@ public abstract class AbstractStructuredOutput implements StructuredOutput {
      * @param value the value of the property
      */
     protected abstract void writeProperty(String name, Object value);
+
+    /**
+     * Creates the string representation to be used when outputting the given value.
+     *
+     * @param value the value to represent
+     * @return the machine-readable string representation of the value
+     */
+    protected String transformToStringRepresentation(Object value) {
+        // We preserve strings here, as NLS.toMachineString performs an implicit trim which might be
+        // unwanted here.
+        if (value instanceof String) {
+            return (String) value;
+        } else {
+            return NLS.toMachineString(value);
+        }
+    }
 
     @Override
     public StructuredOutput beginObject(String name, Attribute... attributes) {

--- a/src/main/java/sirius/kernel/xml/XMLStructuredOutput.java
+++ b/src/main/java/sirius/kernel/xml/XMLStructuredOutput.java
@@ -11,7 +11,6 @@ package sirius.kernel.xml;
 import org.xml.sax.SAXException;
 import org.xml.sax.helpers.AttributesImpl;
 import sirius.kernel.health.Exceptions;
-import sirius.kernel.nls.NLS;
 
 import javax.annotation.CheckReturnValue;
 import javax.annotation.Nonnull;
@@ -273,7 +272,7 @@ public class XMLStructuredOutput extends AbstractStructuredOutput {
         try {
             transformerHandler.startElement("", "", name, null);
             if (value != null) {
-                String val = NLS.toMachineString(value);
+                String val = transformToStringRepresentation(value);
                 transformerHandler.characters(val.toCharArray(), 0, val.length());
             }
             transformerHandler.endElement("", "", name);
@@ -406,7 +405,7 @@ public class XMLStructuredOutput extends AbstractStructuredOutput {
     public StructuredOutput text(Object text) {
         try {
             if (text != null) {
-                String val = NLS.toMachineString(text);
+                String val = transformToStringRepresentation(text);
                 transformerHandler.characters(val.toCharArray(), 0, val.length());
             }
         } catch (SAXException e) {


### PR DESCRIPTION
As we pushed all output through NLS.toMachineString, an implicit
trim() was performed. This might be unwanted and thus string literals
are kept as they are.