### PR TITLE
Always resolves the com.typesafe.config.Config object before it is accessed via Sirius' Settings

### DIFF
--- a/src/main/java/sirius/kernel/settings/Settings.java
+++ b/src/main/java/sirius/kernel/settings/Settings.java
@@ -65,7 +65,7 @@ public class Settings {
      *               requested
      */
     public Settings(Config config, boolean strict) {
-        this.config = config;
+        this.config = config.isResolved() ? config : config.resolve();
         this.strict = strict;
     }
 


### PR DESCRIPTION
This builds the config, resolving any references to parent configs.