### PR TITLE
 Permits to add exception hints to a HandledException. 

### DIFF
--- a/src/main/java/sirius/kernel/cache/SizedCache.java
+++ b/src/main/java/sirius/kernel/cache/SizedCache.java
@@ -30,7 +30,11 @@ import java.util.function.Function;
  * the risk of an out-of-memory.
  *
  * @param <T> the type of object to be stored in the cache
+ * @deprecated This undermines the whole point of having central caches with a limited size. A local cache always brings
+ * the risk that we cannot control the amount of caches being created. Therefore, we loose both, cache efficiency and
+ * the size control. Therefore {@link ManagedCache} or {@link InlineCache} are better options.
  */
+@Deprecated
 public class SizedCache<T> {
 
     private final LoadingCache<String, T> cache;

--- a/src/main/java/sirius/kernel/health/ExceptionHint.java
+++ b/src/main/java/sirius/kernel/health/ExceptionHint.java
@@ -1,0 +1,57 @@
+/*
+ * Made with all the love in the world
+ * by scireum in Remshalden, Germany
+ *
+ * Copyright by scireum GmbH
+ * http://www.scireum.de - info@scireum.de
+ */
+
+package sirius.kernel.health;
+
+import javax.annotation.Nonnull;
+import java.util.Objects;
+
+/**
+ * Represents a processing hint which can be attached to a {@link HandledException}.
+ * <p>
+ * In some scenarios we want to attach additional infos to an exception being generated in order to retrieve them
+ * later. One case would be HTTP status codes in sirius-web. In order to ensure that the proper hint names are used
+ * and also to make them easily discoverable, we use this class to mark legal hint names.
+ */
+public class ExceptionHint {
+
+    private final String name;
+
+    /**
+     * Creates a new processing hint name.
+     * <p>
+     * Note that these are most probably kept around as constant to be used and referenced from a central place.
+     *
+     * @param name the name of the hint
+     */
+    public ExceptionHint(@Nonnull String name) {
+        this.name = name;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(name);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        ExceptionHint that = (ExceptionHint) o;
+        return name.equals(that.name);
+    }
+
+    @Override
+    public String toString() {
+        return name;
+    }
+}

--- a/src/main/java/sirius/kernel/health/HandledException.java
+++ b/src/main/java/sirius/kernel/health/HandledException.java
@@ -35,10 +35,10 @@ public class HandledException extends RuntimeException {
      *
      * @param message the message to be shown to the user
      * @param hints   any processing hints which have been specified so far
-     * @param ex      the exception to be attached
+     * @param cause   the exception which actually caused this error
      */
-    protected HandledException(String message, Map<ExceptionHint, Object> hints, Throwable ex) {
-        super(message, ex);
+    protected HandledException(String message, Map<ExceptionHint, Object> hints, Throwable cause) {
+        super(message, cause);
         this.hints = Collections.unmodifiableMap(hints);
     }
 

--- a/src/main/java/sirius/kernel/health/HandledException.java
+++ b/src/main/java/sirius/kernel/health/HandledException.java
@@ -8,6 +8,12 @@
 
 package sirius.kernel.health;
 
+import sirius.kernel.commons.Value;
+
+import java.io.Serial;
+import java.util.Collections;
+import java.util.Map;
+
 /**
  * An exception which has already been handled (logged and reacted upon) can be represented by
  * <tt>HandledException</tt>.
@@ -19,24 +25,31 @@ package sirius.kernel.health;
  */
 public class HandledException extends RuntimeException {
 
+    @Serial
     private static final long serialVersionUID = 4460968279048068701L;
+
+    private final transient Map<ExceptionHint, Object> hints;
 
     /**
      * Creates a new instance with the given message and no exception attached
      *
      * @param message the message to be shown to the user
+     * @param hints   any processing hints which have been specified so far
+     * @param ex      the exception to be attached
      */
-    protected HandledException(String message) {
-        super(message);
+    protected HandledException(String message, Map<ExceptionHint, Object> hints, Throwable ex) {
+        super(message, ex);
+        this.hints = Collections.unmodifiableMap(hints);
     }
 
     /**
-     * Created a new instance with the given message and exception attached
+     * Retrieves the hint which has previously been added.
      *
-     * @param message the message to be shown to the user
-     * @param e       the exception to be attached
+     * @param hint the name of the hint to fetch
+     * @return the hin value (which might be empty)
+     * @see Exceptions.ErrorHandler#hint(ExceptionHint, Object)
      */
-    protected HandledException(String message, Throwable e) {
-        super(message, e);
+    public Value getHint(ExceptionHint hint) {
+        return Value.of(hints.get(hint));
     }
 }


### PR DESCRIPTION
These can be added during the construction of the exception and
retrieved later to better control handling this error (e.g. by
generating a specific HTTP response code or the like).