### PR TITLE
Deprecates methods related to language validation in NLS.

### DIFF
--- a/src/main/java/sirius/kernel/async/CallContext.java
+++ b/src/main/java/sirius/kernel/async/CallContext.java
@@ -9,7 +9,6 @@
 package sirius.kernel.async;
 
 import sirius.kernel.Sirius;
-import sirius.kernel.commons.Explain;
 import sirius.kernel.commons.Strings;
 import sirius.kernel.commons.Tuple;
 import sirius.kernel.commons.Value;
@@ -360,8 +359,6 @@ public class CallContext {
      *
      * @return a two-letter language code used for the current thread.
      */
-    @SuppressWarnings("deprecation")
-    @Explain("The replacement for NLS.getDefaultLanguage() is only available in sirius-web.")
     public String getLang() {
         if (lang == null) {
             invokeLazyLanguageInstaller();

--- a/src/main/java/sirius/kernel/async/CallContext.java
+++ b/src/main/java/sirius/kernel/async/CallContext.java
@@ -9,6 +9,7 @@
 package sirius.kernel.async;
 
 import sirius.kernel.Sirius;
+import sirius.kernel.commons.Explain;
 import sirius.kernel.commons.Strings;
 import sirius.kernel.commons.Tuple;
 import sirius.kernel.commons.Value;
@@ -359,6 +360,8 @@ public class CallContext {
      *
      * @return a two-letter language code used for the current thread.
      */
+    @SuppressWarnings("deprecation")
+    @Explain("The replacement for NLS.getDefaultLanguage() is only available in sirius-web.")
     public String getLang() {
         if (lang == null) {
             invokeLazyLanguageInstaller();

--- a/src/main/java/sirius/kernel/nls/NLS.java
+++ b/src/main/java/sirius/kernel/nls/NLS.java
@@ -131,7 +131,6 @@ public class NLS {
      * @return the language code of the default language
      */
     @Nonnull
-    @Deprecated
     public static String getDefaultLanguage() {
         if (defaultLanguage != null) {
             return defaultLanguage;
@@ -158,7 +157,6 @@ public class NLS {
      * @return the language code of the fallback language
      */
     @Nonnull
-    @Deprecated
     public static String getFallbackLanguage() {
         String fallback = CallContext.getCurrent().getFallbackLang();
         if (Strings.isEmpty(fallback)) {

--- a/src/main/java/sirius/kernel/nls/NLS.java
+++ b/src/main/java/sirius/kernel/nls/NLS.java
@@ -157,6 +157,7 @@ public class NLS {
      * @return the language code of the fallback language
      */
     @Nonnull
+    @Deprecated
     public static String getFallbackLanguage() {
         String fallback = CallContext.getCurrent().getFallbackLang();
         if (Strings.isEmpty(fallback)) {
@@ -201,6 +202,7 @@ public class NLS {
      *
      * @return a list of supported language codes
      */
+    @Deprecated
     public static Set<String> getSupportedLanguages() {
         if (supportedLanguages == null && Sirius.getSettings() != null) {
             try {
@@ -225,12 +227,13 @@ public class NLS {
      * @param twoLetterLanguageCode the language as two-letter code
      * @return <tt>true</tt> if the language is listed in <tt>nls.languages</tt>, <tt>false</tt> otherwise.
      */
+    @Deprecated
     public static boolean isSupportedLanguage(String twoLetterLanguageCode) {
         return getSupportedLanguages().contains(twoLetterLanguageCode);
     }
 
     /**
-     * Checks if the given language is supproted. Returns the default language otherwise.
+     * Checks if the given language is supported. Returns the default language otherwise.
      * <p>
      * Note that if the given lang is empty or <tt>null</tt>, this method will also return <tt>null</tt> as a call
      * to {@link sirius.kernel.async.CallContext#setLang(String)} with <tt>null</tt> as parameter won't change
@@ -241,6 +244,7 @@ public class NLS {
      * was passed in, in which case <tt>null</tt> is returned.
      */
     @Nullable
+    @Deprecated
     public static String makeLang(@Nullable String lang) {
         if (Strings.isEmpty(lang)) {
             return null;

--- a/src/main/java/sirius/kernel/nls/NLS.java
+++ b/src/main/java/sirius/kernel/nls/NLS.java
@@ -131,6 +131,7 @@ public class NLS {
      * @return the language code of the default language
      */
     @Nonnull
+    @Deprecated
     public static String getDefaultLanguage() {
         if (defaultLanguage != null) {
             return defaultLanguage;


### PR DESCRIPTION
These will be replaced by an appropriate solution in UserManager of sirius-web (see https://github.com/scireum/sirius-web/pull/864)

Fixes: SIRI-368