### PR TITLE
No longer throws an error when an extension is not present

### DIFF
--- a/src/main/java/sirius/kernel/settings/ExtendedSettings.java
+++ b/src/main/java/sirius/kernel/settings/ExtendedSettings.java
@@ -120,9 +120,16 @@ public class ExtendedSettings extends Settings {
         if (result != null) {
             return result;
         }
+        if (!getConfig().hasPath(type)) {
+            if (strict) {
+                Extension.LOG.WARN("Unknown extension type requested: %s", type);
+            }
+            return null;
+        }
 
         ConfigObject cfg = getConfig().getConfig(type).root();
         ConfigObject def = (ConfigObject) cfg.get(Extension.DEFAULT);
+
         if (cfg.containsKey(Extension.DEFAULT)) {
             result = new Extension(type, Extension.DEFAULT, def, null);
             defaultsCache.put(type, result);
@@ -153,7 +160,8 @@ public class ExtendedSettings extends Settings {
 
         ConfigObject cfg = getConfig().getConfig(type).root();
         List<Extension> extensions = new ArrayList<>();
-        ConfigObject defaultObject = cfg.containsKey(Extension.DEFAULT) ? (ConfigObject) cfg.get(Extension.DEFAULT) : null;
+        ConfigObject defaultObject =
+                cfg.containsKey(Extension.DEFAULT) ? (ConfigObject) cfg.get(Extension.DEFAULT) : null;
 
         for (Map.Entry<String, ConfigValue> entry : cfg.entrySet()) {
             String key = entry.getKey();

--- a/src/test/java/sirius/kernel/settings/SettingsSpec.groovy
+++ b/src/test/java/sirius/kernel/settings/SettingsSpec.groovy
@@ -8,7 +8,7 @@
 
 package sirius.kernel.settings
 
-import com.typesafe.config.Config
+
 import sirius.kernel.BaseSpecification
 import sirius.kernel.Sirius
 

--- a/src/test/java/sirius/kernel/settings/SettingsSpec.groovy
+++ b/src/test/java/sirius/kernel/settings/SettingsSpec.groovy
@@ -8,6 +8,7 @@
 
 package sirius.kernel.settings
 
+import com.typesafe.config.Config
 import sirius.kernel.BaseSpecification
 import sirius.kernel.Sirius
 
@@ -31,4 +32,12 @@ class SettingsSpec extends BaseSpecification {
         keys == ["1", "2", "3"]
     }
 
+    def "no exception is thrown for retrieving a non-existent extension, even when settings are strict"() {
+        when:
+        def extension = Sirius.getSettings().getExtension("non-existent", "not-specified")
+        then:
+        extension == null
+        and:
+        noExceptionThrown()
+    }
 }


### PR DESCRIPTION
Fixes: SIRI-388

This is inline with the documentation which states:

> Note that this class will (in normal use-cases) never throws an exception. However, if it is created as strict, it will log an error if a requested config path does not exist.