### PR TITLE
Simplifies method call with overloaded method

### DIFF
--- a/src/main/java/sirius/kernel/nls/NLS.java
+++ b/src/main/java/sirius/kernel/nls/NLS.java
@@ -1082,7 +1082,7 @@ public class NLS {
             }
         }
         if (Boolean.class.equals(clazz) || boolean.class.equals(clazz)) {
-            return (V) Boolean.valueOf(Boolean.parseBoolean(value));
+            return (V) Boolean.valueOf(value);
         }
 
         return parseDatesFromMachineString(clazz, value);


### PR DESCRIPTION
The overloaded method for a string does the exact same thing we did with two calls.