### PR TITLE
Provides Value.tryAppend which only appends to a non-empty Value + Improvement for Outcall

### DIFF
--- a/src/main/java/sirius/kernel/commons/Amount.java
+++ b/src/main/java/sirius/kernel/commons/Amount.java
@@ -852,8 +852,7 @@ public class Amount implements Comparable<Amount>, Serializable {
      *               the decimal format symbols and rounding mode
      * @return a <tt>Value</tt> containing the string representation according to the given format
      * or an empty <tt>Value</tt> if <tt>this</tt> is empty.
-     * @see Value#append(String, Object)
-     * @see Value#prepend(String, Object)
+     * @see Value#tryAppend(String, Object)
      */
     @Nonnull
     public Value toString(@Nonnull NumberFormat format) {

--- a/src/main/java/sirius/kernel/commons/Value.java
+++ b/src/main/java/sirius/kernel/commons/Value.java
@@ -370,6 +370,31 @@ public class Value {
     }
 
     /**
+     * Returns a value which wraps {@code this + separator + suffix}
+     * <p>
+     * If this value is empty an empty value will be returned without appending the given suffix. If the given
+     * suffix is empty, this value is returned.
+     *
+     * @param separator the separator to be put in between the two. If the given value is <tt>null</tt>, "" is assumed
+     * @param suffix    the value to be appended to the current value.
+     * @return a <tt>Value</tt> representing the current value appended with the given value and separated
+     * with the given separator
+     */
+    @Nonnull
+    public Value tryAppend(@Nullable String separator, @Nullable Object suffix) {
+        if (Strings.isEmpty(suffix)) {
+            return this;
+        }
+        if (isEmptyString()) {
+            return Value.EMPTY;
+        }
+        if (separator == null) {
+            separator = "";
+        }
+        return Value.of(this + separator + suffix);
+    }
+
+    /**
      * Returns a value which wraps {@code value + separator + this}
      * <p>
      * If the current value is empty, the given value is returned (without the separator). If the given

--- a/src/test/java/sirius/kernel/commons/ValueSpec.groovy
+++ b/src/test/java/sirius/kernel/commons/ValueSpec.groovy
@@ -214,4 +214,22 @@ class ValueSpec extends BaseSpecification {
         then:
         noExceptionThrown()
     }
+
+    def "append properly handles empty/null"() {
+        expect:
+        Value.EMPTY.append(" ", "x") == "x"
+        and:
+        Value.of("x").append(" ", null).asString() == "x"
+        and:
+        Value.of("x").append(" ", "y").asString() == "x y"
+    }
+
+    def "tryAppend only emits an output if the value is filled"() {
+        expect:
+        Value.EMPTY.tryAppend(" ", "x").isEmptyString()
+        and:
+        Value.of("x").tryAppend(" ", null).asString() == "x"
+        and:
+        Value.of("x").tryAppend(" ", "y").asString() == "x y"
+    }
 }


### PR DESCRIPTION
This is especially useful in conjunction with Amount.toString etc. where
we don't want to append a unit on an empty string/value.

Also moves timeout blacklisting of Outcall to a more central place.