### PR TITLE
Manually disconnects before reading the request properties for a redirect

### DIFF
--- a/src/main/java/sirius/kernel/xml/Outcall.java
+++ b/src/main/java/sirius/kernel/xml/Outcall.java
@@ -265,6 +265,8 @@ public class Outcall {
         connection.setDoInput(true);
         connection.setConnectTimeout(previousConnection.getConnectTimeout());
         connection.setReadTimeout(previousConnection.getReadTimeout());
+        // We need to manually disconnect as the request properties can not be read when connected
+        previousConnection.disconnect();
         previousConnection.getRequestProperties().forEach((name, values) -> {
             for (String value : values) {
                 connection.setRequestProperty(name, value);


### PR DESCRIPTION
Fixes: OX-7404


This is only temporary, as an overhaul of Outcall is already on the way