### PR TITLE
BREAKING: Removes deprecated methods from NLS

### DIFF
--- a/src/main/java/sirius/kernel/nls/NLS.java
+++ b/src/main/java/sirius/kernel/nls/NLS.java
@@ -44,14 +44,10 @@ import java.time.temporal.ChronoField;
 import java.time.temporal.ChronoUnit;
 import java.time.temporal.Temporal;
 import java.util.Calendar;
-import java.util.Collections;
-import java.util.LinkedHashSet;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Optional;
-import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
-import java.util.stream.Collectors;
 
 /**
  * Native Language Support used by the framework.
@@ -84,7 +80,6 @@ public class NLS {
     private static final Babelfish blubb = new Babelfish();
 
     private static String defaultLanguage;
-    private static Set<String> supportedLanguages;
 
     private static final DateTimeFormatter MACHINE_DATE_TIME_FORMAT =
             DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss", Locale.ENGLISH);
@@ -190,70 +185,6 @@ public class NLS {
     @Nullable
     public static String getSystemLanguage() {
         return Locale.getDefault().getLanguage().toLowerCase();
-    }
-
-    /**
-     * Returns a list of two-letter codes enumerating all supported languages. Provided via the config in
-     * {@code nls.languages}
-     *
-     * @return a list of supported language codes
-     * @deprecated This is now controlled via ScopeInfo in sirius-web as there is no system-wide truth
-     */
-    @Deprecated(forRemoval = true)
-    public static Set<String> getSupportedLanguages() {
-        if (supportedLanguages == null && Sirius.getSettings() != null) {
-            try {
-                supportedLanguages = Sirius.getSettings()
-                                           .getStringList("nls.languages")
-                                           .stream()
-                                           .map(String::toLowerCase)
-                                           .collect(Collectors.toCollection(LinkedHashSet::new));
-            } catch (Exception e) {
-                Exceptions.handle(e);
-            }
-        }
-        // Returns the default language or (for very early access we default to en)
-        return supportedLanguages == null ?
-               Collections.singleton("en") :
-               Collections.unmodifiableSet(supportedLanguages);
-    }
-
-    /**
-     * Determines if the given language code is supported or not.
-     *
-     * @param twoLetterLanguageCode the language as two-letter code
-     * @return <tt>true</tt> if the language is listed in <tt>nls.languages</tt>, <tt>false</tt> otherwise.
-     * @deprecated This is now controlled via ScopeInfo in sirius-web as there is no system-wide truth
-     */
-    @Deprecated(forRemoval = true)
-    public static boolean isSupportedLanguage(String twoLetterLanguageCode) {
-        return getSupportedLanguages().contains(twoLetterLanguageCode);
-    }
-
-    /**
-     * Checks if the given language is supported. Returns the default language otherwise.
-     * <p>
-     * Note that if the given lang is empty or <tt>null</tt>, this method will also return <tt>null</tt> as a call
-     * to {@link sirius.kernel.async.CallContext#setLang(String)} with <tt>null</tt> as parameter won't change
-     * the language at all.
-     *
-     * @param lang the language to check
-     * @return <tt>lang</tt> if it was a supported language or the defaultLanguage otherwise, unless an empty string
-     * was passed in, in which case <tt>null</tt> is returned.
-     * @deprecated This is now controlled via ScopeInfo in sirius-web as there is no system-wide truth
-     */
-    @Nullable
-    @Deprecated(forRemoval = true)
-    public static String makeLang(@Nullable String lang) {
-        if (Strings.isEmpty(lang)) {
-            return null;
-        }
-        String langAsLowerCase = lang.toLowerCase();
-        if (getSupportedLanguages().contains(langAsLowerCase)) {
-            return langAsLowerCase;
-        } else {
-            return getDefaultLanguage();
-        }
     }
 
     /**

--- a/src/main/java/sirius/kernel/nls/NLS.java
+++ b/src/main/java/sirius/kernel/nls/NLS.java
@@ -67,7 +67,6 @@ import java.util.concurrent.ConcurrentHashMap;
  * <b>Configuration</b>
  * <ul>
  * <li><b>nls.defaultLanguage:</b> Sets the two-letter code used as default language</li>
- * <li><b>nls.language:</b> Sets an array of two-letter codes which enumerate all supported languages</li>
  * </ul>
  *
  * @see Babelfish

--- a/src/main/java/sirius/kernel/nls/NLS.java
+++ b/src/main/java/sirius/kernel/nls/NLS.java
@@ -74,7 +74,7 @@ import java.util.concurrent.ConcurrentHashMap;
  */
 
 @SuppressWarnings("squid:S1192")
-@Explain("String literales here have different semantics and are therefore duplicated.")
+@Explain("String literals here have different semantics and are therefore duplicated.")
 public class NLS {
 
     private static final Babelfish blubb = new Babelfish();
@@ -443,7 +443,6 @@ public class NLS {
 
     /**
      * Creates a formatted using the pattern supplied by the translation value for the given <tt>property</tt>.
-     * smasmassm
      *
      * @param property the property to used to retrieve a translated pattern
      * @param lang     a two-letter language code for which the translation is requested
@@ -1091,7 +1090,7 @@ public class NLS {
      * @param lang  the two-letter code of the language which format should be used
      * @param <V>   the target type be be parsed
      * @return an instance of <tt>clazz</tt> representing the parsed string or <tt>null</tt> if value was empty.
-     * @throws IllegalArgumentException if the given input was not well formed or if instances of <tt>clazz</tt>
+     * @throws IllegalArgumentException if the given input was not well-formed or if instances of <tt>clazz</tt>
      *                                  cannot be created. The thrown exception has a translated error message which
      *                                  can be directly presented to the user.
      */
@@ -1161,11 +1160,11 @@ public class NLS {
     }
 
     /**
-     * If there is exactly one "." in the pattern and no "," and we have less then 3 digits behind the "." we treat this
+     * If there is exactly one "." in the pattern and no "," and we have less than 3 digits behind the "." we treat this
      * as english decimal format and not as german grouping separator.
      *
      * @param value the parsed value or <tt>null</tt> if the format doesn't match
-     * @return <tt>true</tt> if the format being used is a english / technical one and not a german one where "." is the
+     * @return <tt>true</tt> if the format being used is an english / technical one and not a german one where "." is the
      * thousand separator
      */
     private static Double tryParseMachineFormat(String value) {
@@ -1235,9 +1234,9 @@ public class NLS {
      *
      * @param clazz  the expected class of the value to be parsed
      * @param string the string to be parsed
-     * @param <V>    the target type be be parsed
+     * @param <V>    the target type to be parsed
      * @return an instance of <tt>clazz</tt> representing the parsed string or <tt>null</tt> if value was empty.
-     * @throws IllegalArgumentException if the given input was not well formed or if instances of <tt>clazz</tt>
+     * @throws IllegalArgumentException if the given input was not well-formed or if instances of <tt>clazz</tt>
      *                                  cannot be created. The thrown exception has a translated error message which
      *                                  can be directly presented to the user.
      */
@@ -1246,11 +1245,11 @@ public class NLS {
     }
 
     /**
-     * Converts a given time range in milliseconds to a human readable format using the current language
+     * Converts a given time range in milliseconds to a human-readable format using the current language
      *
      * @param duration       the duration in milliseconds
      * @param includeSeconds determines whether to include seconds or to ignore everything below minutes
-     * @param includeMillis  determines whether to include milli seconds or to ignore everything below seconds
+     * @param includeMillis  determines whether to include milliseconds or to ignore everything below seconds
      * @return a string representation of the given duration in days, hours, minutes and,
      * if enabled, seconds and milliseconds
      */

--- a/src/main/resources/component-kernel.conf
+++ b/src/main/resources/component-kernel.conf
@@ -69,10 +69,6 @@ nls {
 
     # Sets the default language as two-letter code
     defaultLanguage = en
-
-    # Enumerates all supported languages as two-letter codes. These are language for which translations for
-    # NLS are present.
-    languages = [en, de]
 }
 
 # Contains settings for the dependency injector


### PR DESCRIPTION
This is now handled via scopes in sirius-web, so these methods are no longer needed.

Fixes: SIRI-445