### PR TITLE
Parses French Dates with "/" separators correctly

### DIFF
--- a/src/main/java/sirius/kernel/commons/AdvancedDateParser.java
+++ b/src/main/java/sirius/kernel/commons/AdvancedDateParser.java
@@ -68,7 +68,7 @@ public class AdvancedDateParser {
     private static final String DASH_DATE_SEPARATOR = "-";
 
     private final String lang;
-    private boolean parseBritishDate = false;
+    private boolean invertMonthAndDay = false;
     private Tokenizer tokenizer;
     private boolean startOfDay = false;
     private boolean startOfWeek = false;
@@ -94,14 +94,14 @@ public class AdvancedDateParser {
     /**
      * Creates a new parser for the given language to use.
      *
-     * @param lang             contains the two letter language code to obtain the translations for the available
-     *                         modifiers etc.
-     * @param parseBritishDate determines if british dates (DD/MM/YYYY) instead of american (MM/DD/YYYY) dates should
-     *                         be parsed.
+     * @param lang              contains the two letter language code to obtain the translations for the available
+     *                          modifiers etc.
+     * @param invertMonthAndDay determines if british dates (DD/MM/YYYY) instead of american (MM/DD/YYYY) dates should
+     *                          be parsed.
      */
-    public AdvancedDateParser(String lang, boolean parseBritishDate) {
+    public AdvancedDateParser(String lang, boolean invertMonthAndDay) {
         this.lang = lang;
-        this.parseBritishDate = parseBritishDate;
+        this.invertMonthAndDay = invertMonthAndDay;
     }
 
     /**
@@ -692,7 +692,7 @@ public class AdvancedDateParser {
             }
         }
 
-        if (parseBritishDate) {
+        if (invertMonthAndDay) {
             // The empire uses a format DD/MM/YYYY instead of the yankee version (MM/DD/YYYY), therefore
             // we have to flip month and day here...
             return buildDateAndParseTime(month, day, year);

--- a/src/main/java/sirius/kernel/nls/NLS.java
+++ b/src/main/java/sirius/kernel/nls/NLS.java
@@ -1189,9 +1189,10 @@ public class NLS {
 
     @SuppressWarnings("unchecked")
     private static <V> V parseDatesFromUserString(Class<V> clazz, String value, String lang) {
+        boolean invertMonthAndDay = "fr".equals(NLS.getCurrentLang());
         if (LocalDate.class.equals(clazz)) {
             try {
-                AdvancedDateParser parser = new AdvancedDateParser(lang);
+                AdvancedDateParser parser = new AdvancedDateParser(lang, invertMonthAndDay);
                 return (V) parser.parse(value).asDateTime().toLocalDate();
             } catch (ParseException e) {
                 throw new IllegalArgumentException(e.getMessage(), e);
@@ -1199,7 +1200,7 @@ public class NLS {
         }
         if (LocalDateTime.class.equals(clazz)) {
             try {
-                AdvancedDateParser parser = new AdvancedDateParser(lang);
+                AdvancedDateParser parser = new AdvancedDateParser(lang, invertMonthAndDay);
                 return (V) parser.parse(value).asDateTime();
             } catch (ParseException e) {
                 throw new IllegalArgumentException(e.getMessage(), e);
@@ -1207,7 +1208,7 @@ public class NLS {
         }
         if (ZonedDateTime.class.equals(clazz)) {
             try {
-                AdvancedDateParser parser = new AdvancedDateParser(lang);
+                AdvancedDateParser parser = new AdvancedDateParser(lang, invertMonthAndDay);
                 return (V) ZonedDateTime.from(parser.parse(value).asDateTime());
             } catch (ParseException e) {
                 throw new IllegalArgumentException(e.getMessage(), e);
@@ -1222,7 +1223,7 @@ public class NLS {
         }
         if (AdvancedDateParser.DateSelection.class.equals(clazz)) {
             try {
-                AdvancedDateParser parser = new AdvancedDateParser(lang);
+                AdvancedDateParser parser = new AdvancedDateParser(lang, invertMonthAndDay);
                 return (V) parser.parse(value);
             } catch (ParseException e) {
                 throw new IllegalArgumentException(e.getMessage(), e);


### PR DESCRIPTION
similar to British dates, Month and Day are inverted (DD/MM/YYYY) instead of following the US pattern (MM/DD/YYYY). A switch for when to use the correct parsing method for British dates already existed, so we simply activate it for French too.

Fixes: OX-7704