### PR TITLE
Outcall timeout extension

### DIFF
--- a/src/main/java/sirius/kernel/xml/Outcall.java
+++ b/src/main/java/sirius/kernel/xml/Outcall.java
@@ -98,7 +98,7 @@ public class Outcall {
     @ConfigValue("http.outcall.timeouts.default.readTimeout")
     private static Duration defaultReadTimeout;
 
-    @ConfigValue("http.outcall.timeouts.connectTimeoutBlacklistDuration")
+    @ConfigValue("http.outcall.connectTimeoutBlacklistDuration")
     private static Duration connectTimeoutBlacklistDuration;
 
     private HttpClient client;

--- a/src/main/java/sirius/kernel/xml/Outcall.java
+++ b/src/main/java/sirius/kernel/xml/Outcall.java
@@ -344,16 +344,8 @@ public class Outcall {
     public Outcall withConfiguredTimeout(@Nonnull String configKey) {
         Extension extension = Sirius.getSettings().getExtension("http.outcall.timeouts", configKey);
 
-        if (extension != null) {
-            setConnectTimeout((int) extension.getConfig().getDuration("connectTimeout").toMillis());
-            setReadTimeout((int) extension.getConfig().getDuration("readTimeout").toMillis());
-        } else {
-            throw Exceptions.handle()
-                            .to(Log.SYSTEM)
-                            .withSystemErrorMessage("For the following config string no timeout configuration and "
-                                                    + "default block could be found: %s", configKey)
-                            .handle();
-        }
+        setConnectTimeout((int) extension.getConfig().getDuration("connectTimeout").toMillis());
+        setReadTimeout((int) extension.getConfig().getDuration("readTimeout").toMillis());
 
         return this;
     }

--- a/src/main/java/sirius/kernel/xml/Outcall.java
+++ b/src/main/java/sirius/kernel/xml/Outcall.java
@@ -21,6 +21,7 @@ import sirius.kernel.health.Exceptions;
 import sirius.kernel.health.Log;
 import sirius.kernel.health.Microtiming;
 import sirius.kernel.nls.NLS;
+import sirius.kernel.settings.Extension;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
@@ -341,19 +342,16 @@ public class Outcall {
      * @return this for fluent method calls
      */
     public Outcall withConfiguredTimeout(@Nonnull String configKey) {
-        Duration connectTimeout =
-                Sirius.getSettings().getDuration(Strings.apply("http.outcall.timeouts.%s.connectTimeout", configKey));
-        Duration readTimeout =
-                Sirius.getSettings().getDuration(Strings.apply("http.outcall.timeouts.%s.readTimeout", configKey));
+        Extension extension = Sirius.getSettings().getExtension("http.outcall.timeouts", configKey);
 
-        if (!connectTimeout.isZero() && !readTimeout.isZero()) {
-            setConnectTimeout((int) connectTimeout.toMillis());
-            setReadTimeout((int) readTimeout.toMillis());
+        if (extension != null) {
+            setConnectTimeout((int) extension.getConfig().getDuration("connectTimeout").toMillis());
+            setReadTimeout((int) extension.getConfig().getDuration("readTimeout").toMillis());
         } else {
             throw Exceptions.handle()
                             .to(Log.SYSTEM)
-                            .withSystemErrorMessage("A timeout configuration could not be found for config string: %s",
-                                                    configKey)
+                            .withSystemErrorMessage("For the following config string no timeout configuration and "
+                                                    + "default block could be found: %s", configKey)
                             .handle();
         }
 

--- a/src/main/java/sirius/kernel/xml/Outcall.java
+++ b/src/main/java/sirius/kernel/xml/Outcall.java
@@ -94,6 +94,13 @@ public class Outcall {
 
     @ConfigValue("http.outcall.defaultReadTimeout")
     private static Duration defaultReadTimeout;
+
+    @ConfigValue("http.outcall.interactive.connectTimeout")
+    private static Duration interactiveConnectTimeout;
+
+    @ConfigValue("http.outcall.interactive.readTimeout")
+    private static Duration interactiveReadTimeout;
+
     @ConfigValue("http.outcall.connectTimeoutBlacklistDuration")
     private static Duration connectTimeoutBlacklistDuration;
 
@@ -325,6 +332,14 @@ public class Outcall {
      */
     public void setReadTimeout(int timeoutMillis) {
         modifyRequest().timeout(Duration.ofMillis(timeoutMillis));
+    }
+
+    /**
+     * Sets the connect and read timeout to a interactively reasonable duration defined in http.outcall.interactive.*
+     */
+    public void setInteractive() {
+        setConnectTimeout((int) interactiveConnectTimeout.toMillis());
+        setReadTimeout((int) interactiveReadTimeout.toMillis());
     }
 
     /**

--- a/src/main/java/sirius/kernel/xml/Outcall.java
+++ b/src/main/java/sirius/kernel/xml/Outcall.java
@@ -66,9 +66,6 @@ import java.util.regex.Pattern;
  */
 public class Outcall {
 
-    private static final Duration DEFAULT_CONNECT_TIMEOUT = Duration.ofSeconds(30);
-    private static final Duration DEFAULT_READ_TIMEOUT = Duration.ofMinutes(5);
-
     private static final String REQUEST_METHOD_HEAD = "HEAD";
     private static final String HEADER_CONTENT_TYPE = "Content-Type";
     private static final String HEADER_CONTENT_DISPOSITION = "Content-Disposition";
@@ -92,6 +89,11 @@ public class Outcall {
      */
     private static final int TIMEOUT_BLACKLIST_HIGH_WATERMARK = 100;
 
+    @ConfigValue("http.outcall.defaultConnectTimeout")
+    private static Duration defaultConnectTimeout;
+
+    @ConfigValue("http.outcall.defaultReadTimeout")
+    private static Duration defaultReadTimeout;
     @ConfigValue("http.outcall.connectTimeoutBlacklistDuration")
     private static Duration connectTimeoutBlacklistDuration;
 
@@ -117,8 +119,8 @@ public class Outcall {
     public Outcall(URI uri) throws IOException {
         checkTimeoutBlacklist(uri);
 
-        clientBuilder = HttpClient.newBuilder().connectTimeout(DEFAULT_CONNECT_TIMEOUT);
-        requestBuilder = HttpRequest.newBuilder(uri).timeout(DEFAULT_READ_TIMEOUT);
+        clientBuilder = HttpClient.newBuilder().connectTimeout(defaultConnectTimeout);
+        requestBuilder = HttpRequest.newBuilder(uri).timeout(defaultReadTimeout);
     }
 
     /**
@@ -452,7 +454,7 @@ public class Outcall {
 
         Watch watch = Watch.start();
         try (Operation op = new Operation(() -> "Outcall to " + request.uri().getHost() + request.uri().getPath(),
-                                          client.connectTimeout().orElse(DEFAULT_CONNECT_TIMEOUT).plusSeconds(1))) {
+                                          client.connectTimeout().orElse(defaultConnectTimeout).plusSeconds(1))) {
             response = client.send(request, HttpResponse.BodyHandlers.ofInputStream());
         } catch (InterruptedException e) {
             Thread.currentThread().interrupt();

--- a/src/main/java/sirius/kernel/xml/SOAPClient.java
+++ b/src/main/java/sirius/kernel/xml/SOAPClient.java
@@ -92,6 +92,11 @@ public class SOAPClient {
      */
     public static final String NODE_FAULTSTRING = "faultstring";
 
+    /**
+     * Contains the config key of the timeouts defined in http.outcall.timeouts.soap.*.
+     */
+    public static final String SOAP_TIMEOUT_CONFIG_KEY = "soap";
+
     private final URL endpoint;
     private final BasicNamespaceContext namespaceContext = new BasicNamespaceContext();
     private List<Attribute> namespaceDefinitions;
@@ -292,6 +297,7 @@ public class SOAPClient {
         try (Operation op = new Operation(() -> Strings.apply("SOAP %s -> %s", action, effectiveEndpoint),
                                           Duration.ofSeconds(15))) {
             XMLCall call = XMLCall.to(effectiveEndpoint.toURI());
+            call.getOutcall().withConfiguredTimeout(SOAP_TIMEOUT_CONFIG_KEY);
             call.withNamespaceContext(namespaceContext);
             if (callEnhancer != null) {
                 callEnhancer.accept(call);

--- a/src/main/resources/component-kernel.conf
+++ b/src/main/resources/component-kernel.conf
@@ -109,32 +109,43 @@ cache {
 }
 
 http.outcall {
-    # Outcall (and also XMLCall and SOAPClient) use an internal mini-blacklist. Each host which ran into a
-    # connect timeout, is put onto a "blacklist" and no further connections will be attempted for the given
-    # amount of time as defined here.
+
+    # Contains the default timeouts. "default" will take effect in every call in which no other timeout is specified.
     #
-    # This hopefully prevents "cascading" failures e.g. if a page load itself triggers multiple requests
-    # (think of a shop system which tries to fetch prices for multiple items), the connect timeout might
-    # add up pretty quickly. Therefore, we only try once and then stop trying so that we can render the
-    # remaining part of the site (or at least fail gracefully).
+    # This timeouts can be expanded by new blocks in dependant projects. For the configuration to take effect, on an
+    # outcall the sirius.kernel.xml.Outcall.withConfiguredTimeout needs to be called with the defined block
+    # key as parameter.
+    timeouts {
 
-    # The default outcall connect timeout
-    defaultConnectTimeout = 30s
+        # Outcall (and also XMLCall and SOAPClient) use an internal mini-blacklist. Each host which ran into a
+        # connect timeout, is put onto a "blacklist" and no further connections will be attempted for the given
+        # amount of time as defined here.
+        #
+        # This hopefully prevents "cascading" failures e.g. if a page load itself triggers multiple requests
+        # (think of a shop system which tries to fetch prices for multiple items), the connect timeout might
+        # add up pretty quickly. Therefore, we only try once and then stop trying so that we can render the
+        # remaining part of the site (or at least fail gracefully).
+        #
+        # Set this value to 0 to disable blacklisting.
+        connectTimeoutBlacklistDuration = 10s
 
-    # The default outcall read timeout
-    defaultReadTimeout = 5m
+        # Defines the default timeouts which are set if no other timeout was configured
+        default {
+            # The default outcall connect timeout
+            connectTimeout = 30s
 
-    # Set this value to 0 to disable blacklisting.
-    connectTimeoutBlacklistDuration = 10s
+            # The default outcall read timeout
+            readTimeout = 5m
+        }
 
-    # Provides system wide settings for time-critical requests.
-    # E.g. for requests which a user is waiting on.
-    interactive {
-        # The default interactive outcall connect timeout
-        connectTimeout = 10s
+        # Defines the default soap timeouts
+        soap {
+            # The default soap outcall connect timeout
+            connectTimeout = 5s
 
-        # The default interactive outcall read timeout
-        readTimeout = 10s
+            # The default soap outcall read timeout
+            readTimeout = 5s
+        }
     }
 }
 

--- a/src/main/resources/component-kernel.conf
+++ b/src/main/resources/component-kernel.conf
@@ -126,6 +126,16 @@ http.outcall {
 
     # Set this value to 0 to disable blacklisting.
     connectTimeoutBlacklistDuration = 10s
+
+    # Provides system wide settings for time-critical requests.
+    # E.g. for requests which a user is waiting on.
+    interactive {
+        # The default interactive outcall connect timeout
+        connectTimeout = 10s
+
+        # The default interactive outcall read timeout
+        readTimeout = 10s
+    }
 }
 
 # Sets of the async execution system

--- a/src/main/resources/component-kernel.conf
+++ b/src/main/resources/component-kernel.conf
@@ -117,7 +117,13 @@ http.outcall {
     # (think of a shop system which tries to fetch prices for multiple items), the connect timeout might
     # add up pretty quickly. Therefore, we only try once and then stop trying so that we can render the
     # remaining part of the site (or at least fail gracefully).
-    #
+
+    # The default outcall connect timeout
+    defaultConnectTimeout = 30s
+
+    # The default outcall read timeout
+    defaultReadTimeout = 5m
+
     # Set this value to 0 to disable blacklisting.
     connectTimeoutBlacklistDuration = 10s
 }

--- a/src/main/resources/component-kernel.conf
+++ b/src/main/resources/component-kernel.conf
@@ -126,6 +126,8 @@ http.outcall {
     # This timeouts can be expanded by new blocks in dependant projects. For the configuration to take effect, on an
     # outcall the sirius.kernel.xml.Outcall.withConfiguredTimeout needs to be called with the defined block
     # key as parameter.
+    #
+    # NOTE: Please make sure to always define connect- and readTimeout in new blocks to avoid provoking a ConfigException.
     timeouts {
 
         # Defines the default timeouts which are set if no other timeout was configured

--- a/src/main/resources/component-kernel.conf
+++ b/src/main/resources/component-kernel.conf
@@ -109,6 +109,17 @@ cache {
 }
 
 http.outcall {
+    # Outcall (and also XMLCall and SOAPClient) use an internal mini-blacklist. Each host which ran into a
+    # connect timeout, is put onto a "blacklist" and no further connections will be attempted for the given
+    # amount of time as defined here.
+    #
+    # This hopefully prevents "cascading" failures e.g. if a page load itself triggers multiple requests
+    # (think of a shop system which tries to fetch prices for multiple items), the connect timeout might
+    # add up pretty quickly. Therefore, we only try once and then stop trying so that we can render the
+    # remaining part of the site (or at least fail gracefully).
+    #
+    # Set this value to 0 to disable blacklisting.
+    connectTimeoutBlacklistDuration = 10s
 
     # Contains the default timeouts. "default" will take effect in every call in which no other timeout is specified.
     #
@@ -116,18 +127,6 @@ http.outcall {
     # outcall the sirius.kernel.xml.Outcall.withConfiguredTimeout needs to be called with the defined block
     # key as parameter.
     timeouts {
-
-        # Outcall (and also XMLCall and SOAPClient) use an internal mini-blacklist. Each host which ran into a
-        # connect timeout, is put onto a "blacklist" and no further connections will be attempted for the given
-        # amount of time as defined here.
-        #
-        # This hopefully prevents "cascading" failures e.g. if a page load itself triggers multiple requests
-        # (think of a shop system which tries to fetch prices for multiple items), the connect timeout might
-        # add up pretty quickly. Therefore, we only try once and then stop trying so that we can render the
-        # remaining part of the site (or at least fail gracefully).
-        #
-        # Set this value to 0 to disable blacklisting.
-        connectTimeoutBlacklistDuration = 10s
 
         # Defines the default timeouts which are set if no other timeout was configured
         default {

--- a/src/main/resources/component-kernel.conf
+++ b/src/main/resources/component-kernel.conf
@@ -126,8 +126,6 @@ http.outcall {
     # This timeouts can be expanded by new blocks in dependant projects. For the configuration to take effect, on an
     # outcall the sirius.kernel.xml.Outcall.withConfiguredTimeout needs to be called with the defined block
     # key as parameter.
-    #
-    # NOTE: Please make sure to always define connect- and readTimeout in new blocks to avoid provoking a ConfigException.
     timeouts {
 
         # Defines the default timeouts which are set if no other timeout was configured


### PR DESCRIPTION
1. The outcall timeouts, which take effect by default, are now configurable.
2. Additionally there are now so called interactive timeouts, which are meant to be applied on time-critical calls. These are calls which a user is actively waiting for. A call can simply be set interactive by calling `setInteractive()` and it will use the interactive timeout defaults.
