### PR TITLE
SE-11264 Overrides existing headers in Outcalls

### DIFF
--- a/src/main/java/sirius/kernel/xml/Outcall.java
+++ b/src/main/java/sirius/kernel/xml/Outcall.java
@@ -188,7 +188,7 @@ public class Outcall {
             parameterString.append("=");
             parameterString.append(URLEncoder.encode(NLS.toMachineString(entry.getValue()), charset.name()));
         }
-        modifyRequest().header(HEADER_CONTENT_TYPE, CONTENT_TYPE_FORM_URLENCODED)
+        modifyRequest().setHeader(HEADER_CONTENT_TYPE, CONTENT_TYPE_FORM_URLENCODED)
                        .POST(HttpRequest.BodyPublishers.ofString(parameterString.toString(), charset));
 
         return this;
@@ -237,7 +237,7 @@ public class Outcall {
      * @return the outcall itself for fluent method calls
      */
     public Outcall setRequestProperty(String name, String value) {
-        modifyRequest().header(name, value);
+        modifyRequest().setHeader(name, value);
         return this;
     }
 


### PR DESCRIPTION
Before we switched to HttpClient, headers were always overridden when a header with the same name already existed. Now a new header is added every time `setRequestProperty` is called. This materialized as a bug in the JSONCall if instead of JSON, parameters were POSTed. The `JSON#to` method would set the `Content-Type` header to `application/json` and `Outcall#postData` would add a second `Content-Type` header with `application/x-www-form-urlencoded`, which led to an invalid request. This commit reverts to the previous behavior.