### PR TITLE
BREAKING: Upgrades to Java 18

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -17,7 +17,7 @@ clone:
 
 steps:
   - name: compile
-    image: scireum/sirius-build-jdk17
+    image: scireum/sirius-build-jdk18
     commands:
       - mvn clean compile
     volumes: *scireum_volumes
@@ -28,7 +28,7 @@ steps:
         - push
 
   - name: cron_unit_tests
-    image: scireum/sirius-build-jdk17
+    image: scireum/sirius-build-jdk18
     commands:
       - mvn clean test
     volumes: *scireum_volumes
@@ -37,7 +37,7 @@ steps:
       - cron
 
   - name: test
-    image: scireum/sirius-build-jdk17
+    image: scireum/sirius-build-jdk18
     commands:
       - mvn clean test -Dtest.excluded.groups=nightly
     volumes: *scireum_volumes
@@ -59,7 +59,7 @@ steps:
         - cron
 
   - name: deploy
-    image: scireum/sirius-build-jdk17
+    image: scireum/sirius-build-jdk18
     commands:
       - sed -i 's/DEVELOPMENT-SNAPSHOT/${DRONE_TAG}/g' pom.xml
       - mvn clean deploy -DskipTests
@@ -69,7 +69,7 @@ steps:
       - tag
 
   - name: sonar
-    image: scireum/sirius-build-jdk17
+    image: scireum/sirius-build-jdk18
     commands:
       - sed -i 's/DEVELOPMENT-SNAPSHOT/${DRONE_TAG}/g' pom.xml
       - mvn clean org.jacoco:jacoco-maven-plugin:prepare-agent test org.jacoco:jacoco-maven-plugin:report sonar:sonar -Dsonar.projectKey=${DRONE_REPO_NAME}

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.scireum</groupId>
         <artifactId>sirius-parent</artifactId>
-        <version>9.1.0</version>
+        <version>10.0.0</version>
     </parent>
     <artifactId>sirius-kernel</artifactId>
     <name>SIRIUS kernel</name>

--- a/src/main/java/sirius/kernel/commons/Exec.java
+++ b/src/main/java/sirius/kernel/commons/Exec.java
@@ -120,12 +120,12 @@ public class Exec {
     /**
      * Executes the given command and returns a transcript of stderr and stdout
      *
-     * @param command the command to execute
+     * @param cmdarray array containing the command to call and its arguments
      * @return the transcript of stderr and stdout produced by the executed command
      * @throws ExecException in case the external program fails or returns an exit code other than 0.
      */
-    public static String exec(String command) throws ExecException {
-        return exec(command, false);
+    public static String exec(String[] cmdarray) throws ExecException {
+        return exec(cmdarray, false);
     }
 
     /**
@@ -133,32 +133,32 @@ public class Exec {
      * <p>
      * This is using a default operation timeout of five minutes - after which it is logged as hanging.
      *
-     * @param command         the command to execute
+     * @param cmdarray        array containing the command to call and its arguments
      * @param ignoreExitCodes if an exit code other than 0 should result in an exception being thrown
      * @return the transcript of stderr and stdout produced by the executed command
      * @throws ExecException in case the external program fails
      */
-    public static String exec(String command, boolean ignoreExitCodes) throws ExecException {
-        return exec(command, ignoreExitCodes, Duration.ofMinutes(5));
+    public static String exec(String[] cmdarray, boolean ignoreExitCodes) throws ExecException {
+        return exec(cmdarray, ignoreExitCodes, Duration.ofMinutes(5));
     }
 
     /**
      * Executes the given command and returns a transcript of stderr and stdout.
      *
-     * @param command         the command to execute
+     * @param cmdarray        array containing the command to call and its arguments
      * @param ignoreExitCodes if an exit code other than 0 should result in an exception being thrown
      * @param opTimeout       the duration after which the execution should be logged as hanging
      * @return the transcript of stderr and stdout produced by the executed command
      * @throws ExecException in case the external program fails
      */
-    public static String exec(String command, boolean ignoreExitCodes, Duration opTimeout) throws ExecException {
-        return exec(command, ignoreExitCodes, opTimeout, null);
+    public static String exec(String[] cmdarray, boolean ignoreExitCodes, Duration opTimeout) throws ExecException {
+        return exec(cmdarray, ignoreExitCodes, opTimeout, null);
     }
 
     /**
      * Executes the given command and returns a transcript of stderr and stdout.
      *
-     * @param command         the command to execute
+     * @param cmdarray        array containing the command to call and its arguments
      * @param ignoreExitCodes if an exit code other than 0 should result in an exception being thrown
      * @param opTimeout       the duration after which the execution should be logged as hanging
      * @param directory       the working directory of the subprocess,
@@ -166,11 +166,11 @@ public class Exec {
      * @return the transcript of stderr and stdout produced by the executed command
      * @throws ExecException in case the external program fails
      */
-    public static String exec(String command, boolean ignoreExitCodes, Duration opTimeout, @Nullable File directory)
+    public static String exec(String[] cmdarray, boolean ignoreExitCodes, Duration opTimeout, @Nullable File directory)
             throws ExecException {
         StringBuilder logger = new StringBuilder();
-        try (Operation op = new Operation(() -> command, opTimeout)) {
-            Process p = Runtime.getRuntime().exec(command, null, directory);
+        try (Operation op = new Operation(() -> Strings.join(" ", cmdarray), opTimeout)) {
+            Process p = Runtime.getRuntime().exec(cmdarray, null, directory);
             Semaphore completionSynchronizer = new Semaphore(2);
             StreamEater errEater = StreamEater.eat(p.getErrorStream(), logger, completionSynchronizer);
             StreamEater outEater = StreamEater.eat(p.getInputStream(), logger, completionSynchronizer);


### PR DESCRIPTION
**BREAKING**: `Exec.exec()` has been modified to mirror the behavior of `Runtime.exec`, which expects an array containing the command and arguments to execute instead of a string with commands and arguments split by whitespaces.

Fixes: SIRI-567