### PR TITLE
Upgrade to Java 18

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -17,7 +17,7 @@ clone:
 
 steps:
   - name: compile
-    image: scireum/sirius-build-jdk17
+    image: scireum/sirius-build-jdk18
     commands:
       - mvn clean compile
     volumes: *scireum_volumes
@@ -28,7 +28,7 @@ steps:
         - push
 
   - name: cron_unit_tests
-    image: scireum/sirius-build-jdk17
+    image: scireum/sirius-build-jdk18
     commands:
       - mvn clean test
     volumes: *scireum_volumes
@@ -37,7 +37,7 @@ steps:
       - cron
 
   - name: test
-    image: scireum/sirius-build-jdk17
+    image: scireum/sirius-build-jdk18
     commands:
       - mvn clean test -Dtest.excluded.groups=nightly
     volumes: *scireum_volumes
@@ -59,7 +59,7 @@ steps:
         - cron
 
   - name: deploy
-    image: scireum/sirius-build-jdk17
+    image: scireum/sirius-build-jdk18
     commands:
       - sed -i 's/DEVELOPMENT-SNAPSHOT/${DRONE_TAG}/g' pom.xml
       - mvn clean deploy -DskipTests
@@ -69,7 +69,7 @@ steps:
       - tag
 
   - name: sonar
-    image: scireum/sirius-build-jdk17
+    image: scireum/sirius-build-jdk18
     commands:
       - sed -i 's/DEVELOPMENT-SNAPSHOT/${DRONE_TAG}/g' pom.xml
       - mvn clean org.jacoco:jacoco-maven-plugin:prepare-agent test org.jacoco:jacoco-maven-plugin:report sonar:sonar -Dsonar.projectKey=${DRONE_REPO_NAME}

--- a/pom.xml
+++ b/pom.xml
@@ -49,6 +49,13 @@
             <version>1.7.32</version>
         </dependency>
 
+        <!-- scireum parsii -->
+        <dependency>
+            <groupId>com.scireum</groupId>
+            <artifactId>parsii</artifactId>
+            <version>5.0.1</version>
+        </dependency>
+
         <!-- Used to auto-start Docker environments. Excluding dependencies not required for docker-compose. -->
         <dependency>
             <groupId>com.palantir.docker.compose</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.scireum</groupId>
         <artifactId>sirius-parent</artifactId>
-        <version>9.1.0</version>
+        <version>10.0.0</version>
     </parent>
     <artifactId>sirius-kernel</artifactId>
     <name>SIRIUS kernel</name>

--- a/src/main/java/sirius/kernel/commons/CommandParser.java
+++ b/src/main/java/sirius/kernel/commons/CommandParser.java
@@ -1,0 +1,144 @@
+/*
+ * Made with all the love in the world
+ * by scireum in Remshalden, Germany
+ *
+ * Copyright by scireum GmbH
+ * http://www.scireum.de - info@scireum.de
+ */
+
+package sirius.kernel.commons;
+
+import parsii.tokenizer.LookaheadReader;
+
+import javax.annotation.Nullable;
+import java.io.StringReader;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * Parses command invocations as expected by {@link Runtime#exec(String[])}.
+ * <p>
+ * A command is a verb, followed by additional parameters (0..N). Parameters are separated by one or more
+ * whitespaces. If a parameter value itself contains whitespaces, it can be put into quotes:
+ * <tt>command arg1 arg2 "argument 3"</tt>.
+ */
+public class CommandParser {
+
+    private static final String[] EMPTY_STRING_ARRAY = new String[0];
+
+    private final String input;
+    private String command;
+    private List<String> args;
+
+    /**
+     * Creates a new command parser for the given input.
+     *
+     * @param input the command string to parse
+     */
+    public CommandParser(String input) {
+        this.input = input;
+    }
+
+    /**
+     * Extracts the command (the first token) of the given input.
+     *
+     * @return the actual name of the command or <tt>null</tt> if the input was empty
+     */
+    @Nullable
+    public String parseCommand() {
+        if (command == null) {
+            parse();
+        }
+
+        return command;
+    }
+
+    /**
+     * Obtains the list of arguments in the given string.
+     *
+     * @return the list of arguments in the input
+     */
+    public List<String> getArgs() {
+        if (args == null) {
+            parse();
+        }
+
+        return Collections.unmodifiableList(args);
+    }
+
+    /**
+     * Returns the arguments as array.
+     *
+     * @return the arguments as returend by {@link #getArgs()} readily converted into an array.
+     */
+    public String[] getArgArray() {
+        return getArgs().toArray(EMPTY_STRING_ARRAY);
+    }
+
+    private void parse() {
+        command = null;
+        args = new ArrayList<>();
+
+        if (Strings.isEmpty(input)) {
+            return;
+        }
+
+        LookaheadReader reader = new LookaheadReader(new StringReader(input));
+        skipWhitespace(reader);
+        while (!reader.current().isEndOfInput()) {
+            String token = parseToken(reader);
+
+            if (Strings.isFilled(token)) {
+                if (command == null) {
+                    command = token;
+                } else {
+                    args.add(token);
+                }
+            }
+            skipWhitespace(reader);
+        }
+    }
+
+    private void skipWhitespace(LookaheadReader reader) {
+        while (reader.current().isWhitespace()) {
+            reader.consume();
+        }
+    }
+
+    private String parseToken(LookaheadReader reader) {
+        if (reader.current().is('\"')) {
+            return parseEscapedToken(reader);
+        } else {
+            return parseNormalToken(reader);
+        }
+    }
+
+    private String parseNormalToken(LookaheadReader reader) {
+        StringBuilder current = new StringBuilder();
+
+        while (!reader.current().isEndOfInput() && !reader.current().isWhitespace()) {
+            current.append(reader.consume().getValue());
+        }
+
+        return current.toString();
+    }
+
+    private String parseEscapedToken(LookaheadReader reader) {
+        StringBuilder current = new StringBuilder();
+
+        reader.consume();
+        while (!reader.current().isEndOfInput() && !reader.current().is('\"')) {
+            if (reader.current().is('\\')) {
+                reader.consume();
+                if (!reader.current().isEndOfInput()) {
+                    current.append(reader.consume().getValue());
+                }
+            } else {
+                current.append(reader.consume().getValue());
+            }
+        }
+
+        return current.toString();
+    }
+}

--- a/src/main/java/sirius/kernel/commons/Exec.java
+++ b/src/main/java/sirius/kernel/commons/Exec.java
@@ -21,6 +21,7 @@ import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.io.Serial;
 import java.time.Duration;
+import java.util.ArrayList;
 import java.util.concurrent.Semaphore;
 
 /**
@@ -32,6 +33,7 @@ public class Exec {
      * Can be used to log errors and infos when executing external programs.
      */
     public static final Log LOG = Log.get("exec");
+    private static final String[] EMPTY_ARRAY = new String[0];
 
     private Exec() {
     }
@@ -170,7 +172,7 @@ public class Exec {
             throws ExecException {
         StringBuilder logger = new StringBuilder();
         try (Operation op = new Operation(() -> command, opTimeout)) {
-            Process p = Runtime.getRuntime().exec(command, null, directory);
+            Process p = Runtime.getRuntime().exec(parseCommandToArray(command), null, directory);
             Semaphore completionSynchronizer = new Semaphore(2);
             StreamEater errEater = StreamEater.eat(p.getErrorStream(), logger, completionSynchronizer);
             StreamEater outEater = StreamEater.eat(p.getInputStream(), logger, completionSynchronizer);
@@ -192,6 +194,14 @@ public class Exec {
         } catch (Exception e) {
             throw new ExecException(e, logger.toString());
         }
+    }
+
+    private static String[] parseCommandToArray(String command) {
+        ArrayList<String> commandList = new ArrayList<>();
+        CommandParser commandParser = new CommandParser(command);
+        commandList.add(commandParser.parseCommand());
+        commandList.addAll(commandParser.getArgs());
+        return commandList.toArray(EMPTY_ARRAY);
     }
 
     private static void doExec(boolean ignoreExitCodes, StringBuilder logger, Process p) throws ExecException {


### PR DESCRIPTION
- Upgrade to JDK 18
- Ports the CommandParser from sirius-web over, needed to parse command-lines into its commands and arguments, which is now required by `Runtime.exec`

Fixes: SIRI-567