### PR TITLE
No longer blocks processes writing simultaneously in stderr + stdout

### DIFF
--- a/src/main/java/sirius/kernel/commons/Exec.java
+++ b/src/main/java/sirius/kernel/commons/Exec.java
@@ -63,17 +63,13 @@ public class Exec {
                 Thread.currentThread()
                       .setName(StreamEater.class.getSimpleName() + "-" + Thread.currentThread().getId());
                 String line = br.readLine();
-                synchronized (logger) {
-                    while (line != null) {
-                        logger.append(line);
-                        logger.append("\n");
-                        line = br.readLine();
-                    }
+                while (line != null) {
+                    logger.append(line);
+                    logger.append("\n");
+                    line = br.readLine();
                 }
             } catch (IOException e) {
-                synchronized (logger) {
-                    logger.append(NLS.toUserString(e));
-                }
+                logger.append(NLS.toUserString(e));
                 exHolder.set(e);
             } finally {
                 this.completionSynchronizer.release();

--- a/src/main/java/sirius/kernel/commons/Exec.java
+++ b/src/main/java/sirius/kernel/commons/Exec.java
@@ -173,18 +173,17 @@ public class Exec {
             throws ExecException {
         StringBuilder logger = new StringBuilder();
         try (Operation op = new Operation(() -> command, opTimeout)) {
-            Process p = Runtime.getRuntime().exec(parseCommandToArray(command), null, directory);
-            Semaphore completionSynchronizer = new Semaphore(2);
-            StreamEater errEater = StreamEater.eat(p.getErrorStream(), logger, completionSynchronizer);
+            Process p = new ProcessBuilder().command(parseCommandToArray(command))
+                                            .directory(directory)
+                                            .redirectErrorStream(true)
+                                            .start();
+            Semaphore completionSynchronizer = new Semaphore(1);
             StreamEater outEater = StreamEater.eat(p.getInputStream(), logger, completionSynchronizer);
             doExec(ignoreExitCodes, logger, p);
 
             // Wait for the stream eaters to complete...
-            completionSynchronizer.acquire(2);
+            completionSynchronizer.acquire(1);
 
-            if (errEater.exHolder.get() != null) {
-                throw new ExecException(errEater.exHolder.get(), logger.toString());
-            }
             if (outEater.exHolder.get() != null) {
                 throw new ExecException(outEater.exHolder.get(), logger.toString());
             }


### PR DESCRIPTION
By using the new `ProcessBuilder#redirectErrorStream` to redirect the stderr output into the stdout. This way, we only need to read a single stream.

The cause for the blockage was that `StreamEater` is reading the lines inside a synchronized block, whilst only writing should be synchronized. 

Although we could solve it there, we will use new Java functionality which spare us from reading 2 streams and synchronized methods at all.

Fixes: OX-8549