### PR TITLE
Adds StructuredOutput.amountProperty

### DIFF
--- a/src/main/java/sirius/kernel/xml/AbstractStructuredOutput.java
+++ b/src/main/java/sirius/kernel/xml/AbstractStructuredOutput.java
@@ -188,6 +188,15 @@ public abstract class AbstractStructuredOutput implements StructuredOutput {
     protected abstract void writeProperty(String name, Object value);
 
     /**
+     * Writes formatted amounts. Must be implemented by subclasses to generate a property.
+     *
+     * @param name            the name of the property
+     * @param formattedAmount the amount formatted with either {@link Amount#toString(NumberFormat)}
+     *                        or {@link Amount#toSmartRoundedString(NumberFormat)}
+     */
+    protected abstract void writeAmountProperty(String name, String formattedAmount);
+
+    /**
      * Creates the string representation to be used when outputting the given value.
      *
      * @param value the value to represent
@@ -341,12 +350,17 @@ public abstract class AbstractStructuredOutput implements StructuredOutput {
             return property(name, null);
         }
 
-        if (smartRound) {
-            property(name, amount.toSmartRoundedString(numberFormat).getRoundedAmount());
-        } else {
-            property(name, amount.toString(numberFormat).getRoundedAmount());
+        if (getCurrentType() != ElementType.OBJECT && getCurrentType() != ElementType.ARRAY) {
+            throw new IllegalArgumentException("Invalid result structure. Cannot place a property here.");
         }
 
+        if (smartRound) {
+            writeAmountProperty(name, amount.toSmartRoundedString(numberFormat).asString());
+        } else {
+            writeAmountProperty(name, amount.toString(numberFormat).asString());
+        }
+
+        nesting.get(0).setEmpty(false);
         return this;
     }
 }

--- a/src/main/java/sirius/kernel/xml/AbstractStructuredOutput.java
+++ b/src/main/java/sirius/kernel/xml/AbstractStructuredOutput.java
@@ -8,6 +8,8 @@
 
 package sirius.kernel.xml;
 
+import sirius.kernel.commons.Amount;
+import sirius.kernel.commons.NumberFormat;
 import sirius.kernel.commons.Strings;
 import sirius.kernel.nls.NLS;
 
@@ -327,6 +329,24 @@ public abstract class AbstractStructuredOutput implements StructuredOutput {
     @Override
     public StructuredOutput nullsafeProperty(@Nonnull String name, @Nullable Object data) {
         property(name, data != null ? data : "");
+        return this;
+    }
+
+    @Override
+    public StructuredOutput amountProperty(@Nonnull String name,
+                                           @Nullable Amount amount,
+                                           @Nonnull NumberFormat numberFormat,
+                                           boolean smartRound) {
+        if (amount == null || Amount.NOTHING.equals(amount)) {
+            return property(name, null);
+        }
+
+        if (smartRound) {
+            property(name, amount.toSmartRoundedString(numberFormat).getRoundedAmount());
+        } else {
+            property(name, amount.toString(numberFormat).getRoundedAmount());
+        }
+
         return this;
     }
 }

--- a/src/main/java/sirius/kernel/xml/AbstractStructuredOutput.java
+++ b/src/main/java/sirius/kernel/xml/AbstractStructuredOutput.java
@@ -324,8 +324,8 @@ public abstract class AbstractStructuredOutput implements StructuredOutput {
     @Override
     public StructuredOutput property(String name, Object data) {
         validateResultStructure();
-        if (data instanceof Record record) {
-            object(name, record);
+        if (data instanceof Record castRecord) {
+            object(name, castRecord);
         } else {
             writeProperty(name, data);
         }

--- a/src/main/java/sirius/kernel/xml/AbstractStructuredOutput.java
+++ b/src/main/java/sirius/kernel/xml/AbstractStructuredOutput.java
@@ -358,7 +358,7 @@ public abstract class AbstractStructuredOutput implements StructuredOutput {
                                            @Nullable Amount amount,
                                            @Nonnull NumberFormat numberFormat,
                                            boolean smartRound) {
-        if (amount == null || Amount.NOTHING.equals(amount)) {
+        if (amount == null || amount.isEmpty()) {
             return property(name, null);
         }
 

--- a/src/main/java/sirius/kernel/xml/AbstractStructuredOutput.java
+++ b/src/main/java/sirius/kernel/xml/AbstractStructuredOutput.java
@@ -323,9 +323,7 @@ public abstract class AbstractStructuredOutput implements StructuredOutput {
 
     @Override
     public StructuredOutput property(String name, Object data) {
-        if (getCurrentType() != ElementType.OBJECT && getCurrentType() != ElementType.ARRAY) {
-            throw new IllegalArgumentException("Invalid result structure. Cannot place a property here.");
-        }
+        validateResultStructure();
         if (data instanceof Record record) {
             object(name, record);
         } else {
@@ -350,9 +348,7 @@ public abstract class AbstractStructuredOutput implements StructuredOutput {
             return property(name, null);
         }
 
-        if (getCurrentType() != ElementType.OBJECT && getCurrentType() != ElementType.ARRAY) {
-            throw new IllegalArgumentException("Invalid result structure. Cannot place a property here.");
-        }
+        validateResultStructure();
 
         if (smartRound) {
             writeAmountProperty(name, amount.toSmartRoundedString(numberFormat).asString());
@@ -362,5 +358,11 @@ public abstract class AbstractStructuredOutput implements StructuredOutput {
 
         nesting.get(0).setEmpty(false);
         return this;
+    }
+
+    private void validateResultStructure() {
+        if (getCurrentType() != ElementType.OBJECT && getCurrentType() != ElementType.ARRAY) {
+            throw new IllegalArgumentException("Invalid result structure. Cannot place a property here.");
+        }
     }
 }

--- a/src/main/java/sirius/kernel/xml/AbstractStructuredOutput.java
+++ b/src/main/java/sirius/kernel/xml/AbstractStructuredOutput.java
@@ -8,9 +8,12 @@
 
 package sirius.kernel.xml;
 
+import sirius.kernel.Sirius;
+import sirius.kernel.async.ExecutionPoint;
 import sirius.kernel.commons.Amount;
 import sirius.kernel.commons.NumberFormat;
 import sirius.kernel.commons.Strings;
+import sirius.kernel.health.Log;
 import sirius.kernel.nls.NLS;
 
 import javax.annotation.CheckReturnValue;
@@ -324,6 +327,7 @@ public abstract class AbstractStructuredOutput implements StructuredOutput {
     @Override
     public StructuredOutput property(String name, Object data) {
         validateResultStructure();
+        warnImproperAmountUsage(name, data);
         if (data instanceof Record castRecord) {
             object(name, castRecord);
         } else {
@@ -331,6 +335,16 @@ public abstract class AbstractStructuredOutput implements StructuredOutput {
         }
         nesting.get(0).setEmpty(false);
         return this;
+    }
+
+    protected void warnImproperAmountUsage(String name, Object data) {
+        if (!Sirius.isProd() && data instanceof Amount) {
+            Log.SYSTEM.WARN("""
+                                    Use StructuredOutput.amountProperty to output Amounts to guarantee proper numeric formatting.
+                                    Property name: '%s'
+                                    %s
+                                    """, name, ExecutionPoint.fastSnapshot());
+        }
     }
 
     @Override

--- a/src/main/java/sirius/kernel/xml/StructuredOutput.java
+++ b/src/main/java/sirius/kernel/xml/StructuredOutput.java
@@ -8,6 +8,9 @@
 
 package sirius.kernel.xml;
 
+import sirius.kernel.commons.Amount;
+import sirius.kernel.commons.NumberFormat;
+
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import java.util.Collection;
@@ -56,7 +59,8 @@ public interface StructuredOutput {
 
     /**
      * Outputs all record components of the given record as an object with the given name.
-     * @param name the name to use for the object
+     *
+     * @param name   the name to use for the object
      * @param object the record itself to output. Note that if <tt>object</tt> is <tt>null</tt>, nothing will be output
      * @return the output itself for fluent method calls
      */
@@ -70,6 +74,20 @@ public interface StructuredOutput {
      * @return the output itself for fluent method calls
      */
     StructuredOutput property(@Nonnull String name, @Nullable Object data);
+
+    /**
+     * Adds an Amount property to the current object.
+     *
+     * @param name         the name of the property
+     * @param amount       the {@link Amount value} of the property
+     * @param numberFormat the {@link NumberFormat} used to format the written output
+     * @param smartRound   smart round trailing zeros
+     * @return the output itself for fluent method calls
+     */
+    StructuredOutput amountProperty(@Nonnull String name,
+                                    @Nullable Amount amount,
+                                    @Nonnull NumberFormat numberFormat,
+                                    boolean smartRound);
 
     /**
      * Adds a property to the current object.

--- a/src/main/java/sirius/kernel/xml/XMLStructuredOutput.java
+++ b/src/main/java/sirius/kernel/xml/XMLStructuredOutput.java
@@ -284,6 +284,11 @@ public class XMLStructuredOutput extends AbstractStructuredOutput {
         }
     }
 
+    @Override
+    protected void writeAmountProperty(String name, String amount) {
+        writeProperty(name, amount);
+    }
+
     /**
      * Provides a convenient way for {@link #property(String, Object, Attribute...)} prepending a namespace.
      *


### PR DESCRIPTION
**BREAKING** which writes Amounts to StructuredOutput, formatting the output with the provided NumberFormat and giving the possibility to strip trailing zeros (smart round).

Marked as breaking since classes extending AbstractStructuredOutput must implement a new method.

Fixes: OX-8608