### PR TITLE
SIRI-586 fix usages of get() and getRaw() for automatic translations.

### DIFF
--- a/src/main/java/sirius/kernel/settings/Extension.java
+++ b/src/main/java/sirius/kernel/settings/Extension.java
@@ -59,29 +59,14 @@ public class Extension extends Settings implements Comparable<Extension> {
         }
     }
 
-    /**
-     * Returns the {@link Value} defined for the given key.
-     * <p>
-     * In contrast to {@link #get(String)} this will not perform an automatic translation
-     * if the value starts with a dollar sign.
-     *
-     * @param path the access path to retrieve the value
-     * @return the value wrapping the contents for the given path. This will never by <tt>null</tt>,
-     * but might be empty: {@link Value#isNull()}
-     */
-    @Nonnull
-    public Value getRaw(String path) {
-        return super.get(path);
-    }
-
     @Override
     @Nonnull
     public Value get(String path) {
         // This method will be removed soon so that the original behaviour of Settings.get takes its place.
         // Automatic translation will then be replaced by manual using getTranslatedString.
-        Value value = super.get(path);
-        if (!Sirius.isProd() && value.isFilled() && value.is(String.class)) {
-            if (value.asString().startsWith("$") && !value.startsWith("${")) {
+        Value value = getRaw(path);
+        if (value.isFilled() && value.is(String.class)) {
+            if (!Sirius.isProd() && value.asString().startsWith("$") && !value.startsWith("${")) {
                 Log.SYSTEM.WARN(
                         "Extension.get with automatic translation was used for %s of %s for key %s\n%s\n\nThis has been deprecated. use getTranslatedString as automatic translation will be disabled.",
                         getId(),
@@ -116,10 +101,10 @@ public class Extension extends Settings implements Comparable<Extension> {
      * <tt>default</tt> which provides a value, this is used.
      * <p>
      * Returning a {@link Value} instead of a plain object provides lots of conversion methods on the one hand
-     * and also guarantees a non null result on the other hand, since a <tt>Value</tt> can be empty.
+     * and also guarantees a non-null result on the other hand, since a <tt>Value</tt> can be empty.
      *
      * @param path the access path to retrieve the value
-     * @return the value wrapping the contents for the given path. This will never by <tt>null</tt>.
+     * @return the value wrapping the contents for the given path. This will never be <tt>null</tt>.
      * @throws sirius.kernel.health.HandledException if no value was found for the given <tt>path</tt>
      */
     @Nonnull
@@ -140,11 +125,11 @@ public class Extension extends Settings implements Comparable<Extension> {
     /**
      * Creates a new instance of the class which is named in <tt>classProperty</tt>
      * <p>
-     * Tries to lookup the value for <tt>classProperty</tt>, fetches the corresponding class and creates a new
+     * Tries to look up the value for <tt>classProperty</tt>, fetches the corresponding class and creates a new
      * instance for it.
      * <p>
      * Returning a {@link Value} instead of a plain object provides lots of conversion methods on the one hand
-     * and also guarantees a non null result on the other hand, since a <tt>Value</tt> can be empty.
+     * and also guarantees a non-null result on the other hand, since a <tt>Value</tt> can be empty.
      *
      * @param classProperty the property which is used to retrieve the class name
      * @return a new instance of the given class
@@ -207,9 +192,9 @@ public class Extension extends Settings implements Comparable<Extension> {
     }
 
     /**
-     * Determined if this extension is an artifically created default extension.
+     * Determined if this extension is an artificially created default extension.
      *
-     * @return <tt>true</tt> if this is an artifically created default extension used by
+     * @return <tt>true</tt> if this is an artificially created default extension used by
      * {@link ExtendedSettings#getExtension(String, String)} if nothing was found
      */
     public boolean isDefault() {

--- a/src/main/java/sirius/kernel/settings/Settings.java
+++ b/src/main/java/sirius/kernel/settings/Settings.java
@@ -66,7 +66,7 @@ public class Settings {
      * Creates a new wrapper for the given config.
      *
      * @param config the config to wrap
-     * @param strict determines if the config is strict. A strict config will log an error if an unkown path is
+     * @param strict determines if the config is strict. A strict config will log an error if an unknown path is
      *               requested
      */
     public Settings(Config config, boolean strict) {
@@ -94,7 +94,7 @@ public class Settings {
      * but might be empty: {@link Value#isNull()}
      */
     @Nonnull
-    public Value get(String path) {
+    public Value getRaw(String path) {
         try {
             return Value.of(getConfig().getAnyRef(path));
         } catch (ConfigException e) {
@@ -104,6 +104,21 @@ public class Settings {
 
             return Value.EMPTY;
         }
+    }
+
+    /**
+     * Returns the {@link Value} defined for the given key.
+     * <p>
+     * Note that if this config is <tt>strict</tt>, an error is logged if the requested path does not exist. However,
+     * no exception will be thrown.
+     *
+     * @param path the access path to retrieve the value
+     * @return the value wrapping the contents for the given path. This will never be <tt>null</tt>,
+     * but might be empty: {@link Value#isNull()}
+     */
+    @Nonnull
+    public Value get(String path) {
+        return getRaw(path);
     }
 
     /**
@@ -309,7 +324,7 @@ public class Settings {
     @SuppressWarnings("unchecked")
     @Nonnull
     public String getTranslatedString(String key, @Nullable String lang) {
-        Value value = get(key);
+        Value value = getRaw(key);
         if (value.isFilled() && value.is(String.class)) {
             return NLS.smartGet(value.asString(), lang);
         }


### PR DESCRIPTION
- the underlying problem is, that in Settings#getTranslatedString() with an Extension we called get() which will already autotranslate with a warning.
- moves the sirius.isProd(() one if later, so otherwise we do not translate
- fix some typos

- fixes: SIRI-586