### PR TITLE
Deprecates Lambdas.into as it isn't idiomatic to the Stream/Collector API.

### DIFF
--- a/src/main/java/sirius/kernel/commons/Lambdas.java
+++ b/src/main/java/sirius/kernel/commons/Lambdas.java
@@ -47,7 +47,9 @@ public class Lambdas {
      * @param <T>        the type of the elements accepted by the collector
      * @param <C>        the type of the collection which is filled by the collector
      * @return a {@link java.util.stream.Collector} inserting all elements into the given collection
+     * @deprecated Replace with {@code stream.forEach(collection::add)}
      */
+    @Deprecated
     public static <T, C extends Collection<T>> Collector<T, ?, C> into(C collection) {
         return Collector.of(() -> collection,
                             Collection::add,

--- a/src/test/java/sirius/kernel/ScenarioSuite.java
+++ b/src/test/java/sirius/kernel/ScenarioSuite.java
@@ -21,7 +21,6 @@ import org.spockframework.runtime.SpecInfoBuilder;
 import org.spockframework.runtime.Sputnik;
 import org.spockframework.runtime.model.FeatureInfo;
 import org.spockframework.runtime.model.SpecInfo;
-import sirius.kernel.commons.Lambdas;
 import sirius.kernel.commons.Strings;
 
 import javax.annotation.Nonnull;
@@ -206,7 +205,7 @@ public class ScenarioSuite extends WildcardPatternSuite {
                                                          scenario.includes(),
                                                          scenario.excludes(),
                                                          tests))
-                     .collect(Lambdas.into(result));
+                     .forEach(result::add);
         }
 
         return result;


### PR DESCRIPTION
This method isn't idiomatic as this isn't a real collector (as it doesn't return a value).
Also, the same can be achieved via stream.forEach(collection::add);