### PR TITLE
Permits to use temporary synchronizers in the Tasks framework.

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -81,7 +81,7 @@ steps:
     settings:
       webhook: https://memoio.com/endpoint/hook/4b17b22e54124c53ab2e550cf3311461cba7c66a1e3756fa8d17e7dc17a48dbb
       channel: scireum-dev
-      template: "{{Repo.Name}}: {{Build.Tag}}"
+      template: "A new version is available: **{{Repo.Name}}**: {{Build.Tag}}"
     when:
       event:
         - tag

--- a/src/main/java/sirius/kernel/async/ExecutionBuilder.java
+++ b/src/main/java/sirius/kernel/async/ExecutionBuilder.java
@@ -56,7 +56,7 @@ public class ExecutionBuilder {
         boolean fork;
 
         /**
-         * What to do if the we drop the task because the system is overloaded
+         * What to do if we drop the task because the system is overloaded
          */
         Runnable dropHandler;
 
@@ -71,7 +71,7 @@ public class ExecutionBuilder {
         Future promise = new Future();
 
         /**
-         * Contains the inertnally computed task number
+         * Contains the internally computed task number
          */
         long jobNumber;
 
@@ -82,7 +82,7 @@ public class ExecutionBuilder {
         Average durationAverage;
 
         /**
-         * If a synchorinzer is present this can be used to limit the call frequency of a task
+         * If a synchronizer is present this can be used to limit the call frequency of a task
          */
         long intervalMinLength;
 

--- a/src/main/java/sirius/kernel/async/ExecutionBuilder.java
+++ b/src/main/java/sirius/kernel/async/ExecutionBuilder.java
@@ -202,11 +202,15 @@ public class ExecutionBuilder {
      * {@code synchronizer}.
      * <p>
      * If the execution is requested 'too early' the scheduler will put the task into a queue and defer its execution.
-     * If a task for the same synchronizer is deferred already, this task will be dropped completely.
+     * If a task for the same synchronizer is deferred already, this task will be dropped completely. Note, that the
+     * synchronizer is remembered internally. If a temporary synchronizer was used, <tt>forgetSynchronizer</tt> should
+     * be called to remove all tracking data from internal data
+     * structures.
      *
      * @param synchronizer            the object to synchronize on
      * @param minimalIntervalDuration the minimal duration of the interval
      * @return this for fluent builder calls.
+     * @see Tasks#forgetSynchronizer(String)
      */
     public ExecutionBuilder minInterval(Object synchronizer, Duration minimalIntervalDuration) {
         this.wrapper.intervalMinLength =

--- a/src/main/java/sirius/kernel/async/Tasks.java
+++ b/src/main/java/sirius/kernel/async/Tasks.java
@@ -135,6 +135,19 @@ public class Tasks implements Startable, Stoppable, Killable {
         return findExecutor(category);
     }
 
+    /**
+     * Removes a temporary <tt>synchronizer</tt> key which was created via <tt>ExecutionBuilder.minInterval</tt>.
+     *
+     * @param synchronizer the synchronizer to remove
+     * @return <tt>true</tt> if the synchronizer was known and has been removed, <tt>false</tt> if it wasn't known at
+     * all.
+     *
+     * @see ExecutionBuilder#minInterval(Object, Duration)
+     */
+    public boolean forgetSynchronizer(String synchronizer) {
+        return scheduleTable.remove(synchronizer) != null;
+    }
+
     /*
      * Executes a given TaskWrapper by fetching or creating the appropriate executor and submitting the wrapper.
      */

--- a/src/main/java/sirius/kernel/async/Tasks.java
+++ b/src/main/java/sirius/kernel/async/Tasks.java
@@ -394,13 +394,13 @@ public class Tasks implements Startable, Stoppable, Killable {
         for (Map.Entry<String, AsyncExecutor> e : executors.entrySet()) {
             AsyncExecutor exec = e.getValue();
             if (!exec.isTerminated()) {
-                blockUnitExecutorTerminates(e.getKey(), exec);
+                blockUntilExecutorTerminates(e.getKey(), exec);
             }
         }
         executors.clear();
     }
 
-    private void blockUnitExecutorTerminates(String name, AsyncExecutor exec) {
+    private void blockUntilExecutorTerminates(String name, AsyncExecutor exec) {
         LOG.INFO("Waiting for async executor '%s' to terminate...", name);
         try {
             if (!exec.awaitTermination(EXECUTOR_SHUTDOWN_WAIT.getSeconds(), TimeUnit.SECONDS)) {


### PR DESCRIPTION
We previously only supported static ones (e.g. for background loops).
Now, temporary one can be used, as forgetSynchronizer can be used
to remove them from internal data structures.