### PR TITLE
Improves output of everyday timers in timer command

### DIFF
--- a/src/main/java/sirius/kernel/health/console/TimerCommand.java
+++ b/src/main/java/sirius/kernel/health/console/TimerCommand.java
@@ -9,13 +9,14 @@
 package sirius.kernel.health.console;
 
 import sirius.kernel.Sirius;
+import sirius.kernel.commons.Tuple;
 import sirius.kernel.commons.Values;
 import sirius.kernel.di.std.Part;
 import sirius.kernel.di.std.Register;
-import sirius.kernel.timer.EveryDay;
 import sirius.kernel.timer.Timers;
 
 import javax.annotation.Nonnull;
+import java.util.Comparator;
 import java.util.Set;
 
 /**
@@ -72,11 +73,14 @@ public class TimerCommand implements Command {
         output.blankLine();
         output.line("Daily Tasks");
         output.separator();
-        for (EveryDay task : ts.getDailyTasks()) {
-            output.apply("%30s: %2sh",
-                         task.getConfigKeyName(),
-                         Sirius.getSettings().getInt(Timers.TIMER_DAILY_PREFIX + task.getConfigKeyName()));
-        }
+
+        ts.getDailyTasks()
+          .stream()
+          .map(task -> Tuple.create(Sirius.getSettings().getInt(Timers.TIMER_DAILY_PREFIX + task.getConfigKeyName()),
+                                    task.getConfigKeyName()))
+          .sorted(Comparator.comparingInt(Tuple::getFirst))
+          .forEach(hourAndTask -> output.apply("%2sh: %s", hourAndTask.getFirst(), hourAndTask.getSecond()));
+
         output.separator();
     }
 


### PR DESCRIPTION
By sorting the list (according to the hour of day the tasks are executed at) and switching the hour and name around.

Before:

![image](https://user-images.githubusercontent.com/2427877/203346585-15b2cb10-241f-49b1-853a-324a4a8f7779.png)

After:

![image](https://user-images.githubusercontent.com/2427877/203346482-f4b11b31-2cce-4894-8686-9185fb81cd0e.png)
