### PR TITLE
More stable wiring / system startup.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -81,7 +81,7 @@
         <dependency>
             <groupId> org.yaml</groupId>
             <artifactId>snakeyaml</artifactId>
-            <version>1.32</version>
+            <version>1.33</version>
         </dependency>
     </dependencies>
 

--- a/src/main/java/sirius/kernel/di/Injector.java
+++ b/src/main/java/sirius/kernel/di/Injector.java
@@ -43,7 +43,7 @@ import java.util.regex.Pattern;
  * To process all annotations of a given Java object, {@link GlobalContext#wire(Object)} can be used. This will
  * be automatically called for each part which is auto-instantiated by a <tt>ClassLoadAction</tt>.
  * <p>
- * Also all annotations on static fields are processed on system startup. This is a simple trick to pass a
+ * Also, all annotations on static fields are processed on system startup. This is a simple trick to pass a
  * part to objects which are frequently created and destroyed.
  */
 public class Injector {


### PR DESCRIPTION
If a class cannot be loaded as a referenced class is missing, we simply ignore the class instead of crashing the startup.

This might be a class for a disabled framework which misses its driver or the like.

We now gracefully output errors during static wiring (which are pretty much expected if drivers are omitted):
![grafik](https://user-images.githubusercontent.com/875799/203501164-c2ba0750-9856-40d5-9164-679566ac660e.png)

but we report a proper warning, if the questionable part is enabled and actively used:
![grafik](https://user-images.githubusercontent.com/875799/203501242-f6ad6b44-9ff6-4426-b7f8-03c78515c526.png)
