### PR TITLE
Enhances parsing of strings into integer/longs

### DIFF
--- a/src/main/java/sirius/kernel/commons/Doubles.java
+++ b/src/main/java/sirius/kernel/commons/Doubles.java
@@ -50,7 +50,7 @@ public class Doubles {
     }
 
     /**
-     * Determines if the given number is zero (or very very close to).
+     * Determines if the given number is zero (or very, very close to).
      * <p>
      * Determines if the given number is zero or less than {@link #EPSILON} away from it. This is used to make up for
      * rounding errors which are in the nature of floating point numbers.

--- a/src/main/java/sirius/kernel/nls/NLS.java
+++ b/src/main/java/sirius/kernel/nls/NLS.java
@@ -1229,10 +1229,12 @@ public class NLS {
                 return result;
             }
 
-            return getDecimalFormat(language).parse(value).doubleValue();
-        } catch (ParseException exception) {
-            Exceptions.ignore(exception);
-            return Double.valueOf(value);
+            try {
+                return getDecimalFormat(language).parse(value).doubleValue();
+            } catch (ParseException exception) {
+                Exceptions.ignore(exception);
+                return Double.valueOf(value);
+            }
         } catch (NumberFormatException exception) {
             throw new IllegalArgumentException(fmtr("NLS.errInvalidDecimalNumber").set("value", value).format(),
                                                exception);

--- a/src/main/java/sirius/kernel/nls/NLS.java
+++ b/src/main/java/sirius/kernel/nls/NLS.java
@@ -14,6 +14,7 @@ import sirius.kernel.async.CallContext;
 import sirius.kernel.async.ExecutionPoint;
 import sirius.kernel.commons.AdvancedDateParser;
 import sirius.kernel.commons.Amount;
+import sirius.kernel.commons.Doubles;
 import sirius.kernel.commons.Explain;
 import sirius.kernel.commons.NumberFormat;
 import sirius.kernel.commons.Strings;
@@ -1025,14 +1026,14 @@ public class NLS {
     private static <V> V parseBasicTypesFromMachineString(Class<V> clazz, String value) {
         if (Integer.class.equals(clazz) || int.class.equals(clazz)) {
             try {
-                return (V) Integer.valueOf(value);
+                return (V) parseIntegerFromMachineString(value);
             } catch (NumberFormatException e) {
                 throw new IllegalArgumentException(fmtr("NLS.errInvalidNumber").set("value", value).format(), e);
             }
         }
         if (Long.class.equals(clazz) || long.class.equals(clazz)) {
             try {
-                return (V) Long.valueOf(value);
+                return (V) parseLongFromMachineString(value);
             } catch (NumberFormatException e) {
                 throw new IllegalArgumentException(fmtr("NLS.errInvalidNumber").set("value", value).format(), e);
             }
@@ -1064,6 +1065,26 @@ public class NLS {
         }
 
         return parseDatesFromMachineString(clazz, value);
+    }
+
+    private static Integer parseIntegerFromMachineString(String value) {
+        double valueAsDouble = Double.parseDouble(value);
+        int doubleAsInteger = (int) valueAsDouble;
+        if (Doubles.areEqual(valueAsDouble, doubleAsInteger)) {
+            return doubleAsInteger;
+        } else {
+            throw new NumberFormatException("Cannot parse decimal to integer");
+        }
+    }
+
+    private static Long parseLongFromMachineString(String value) {
+        double valueAsDouble = Double.parseDouble(value);
+        long doubleAsLong = (long) valueAsDouble;
+        if (Doubles.areEqual(valueAsDouble, doubleAsLong)) {
+            return doubleAsLong;
+        } else {
+            throw new NumberFormatException("Cannot parse decimal to long");
+        }
     }
 
     @SuppressWarnings("unchecked")
@@ -1136,14 +1157,14 @@ public class NLS {
     private static <V> V parseBasicTypesFromUserString(Class<V> clazz, String value, String language) {
         if (Integer.class.equals(clazz) || int.class.equals(clazz)) {
             try {
-                return (V) Integer.valueOf(value);
+                return (V) parseIntegerFromUser(value, language);
             } catch (NumberFormatException e) {
                 throw new IllegalArgumentException(fmtr("NLS.errInvalidNumber").set("value", value).format(), e);
             }
         }
         if (Long.class.equals(clazz) || long.class.equals(clazz)) {
             try {
-                return (V) Long.valueOf(value);
+                return (V) parseLongFromUser(value, language);
             } catch (NumberFormatException e) {
                 throw new IllegalArgumentException(fmtr("NLS.errInvalidNumber").set("value", value).format(), e);
             }
@@ -1167,6 +1188,38 @@ public class NLS {
             return (V) Boolean.valueOf(Boolean.parseBoolean(value));
         }
         return parseDatesFromUserString(clazz, value, language);
+    }
+
+    private static Integer parseIntegerFromUser(String value, String language) {
+        try {
+            Double valueAsDouble = parseDecimalNumberFromUser(value, language);
+            int doubleAsInteger = valueAsDouble.intValue();
+            if (Doubles.areEqual(valueAsDouble, doubleAsInteger)) {
+                return doubleAsInteger;
+            } else {
+                throw new IllegalArgumentException("Cannot parse decimal to integer");
+            }
+        } catch (IllegalArgumentException exception) {
+            // This exception is managed by the caller where an appropriate
+            // IllegalArgumentException is thrown instead
+            throw new NumberFormatException("Cannot parse value to integer.");
+        }
+    }
+
+    private static Long parseLongFromUser(String value, String language) {
+        try {
+            Double valueAsDouble = parseDecimalNumberFromUser(value, language);
+            long doubleAsLong = valueAsDouble.longValue();
+            if (Doubles.areEqual(valueAsDouble, doubleAsLong)) {
+                return doubleAsLong;
+            } else {
+                throw new IllegalArgumentException("Cannot parse decimal to long");
+            }
+        } catch (IllegalArgumentException exception) {
+            // This exception is managed by the caller where an appropriate
+            // IllegalArgumentException is thrown instead
+            throw new NumberFormatException("Cannot parse value to long.");
+        }
     }
 
     private static Double parseDecimalNumberFromUser(String value, String language) {

--- a/src/main/java/sirius/kernel/nls/NLS.java
+++ b/src/main/java/sirius/kernel/nls/NLS.java
@@ -1068,23 +1068,13 @@ public class NLS {
     }
 
     private static Integer parseIntegerFromMachineString(String value) {
-        double valueAsDouble = Double.parseDouble(value);
-        int doubleAsInteger = (int) valueAsDouble;
-        if (Doubles.areEqual(valueAsDouble, doubleAsInteger)) {
-            return doubleAsInteger;
-        } else {
-            throw new NumberFormatException("Cannot parse decimal to integer");
-        }
+        double valueAsDouble = parseMachineString(Double.class, value);
+        return (int) extractNonFactionalPart(valueAsDouble, true);
     }
 
     private static Long parseLongFromMachineString(String value) {
-        double valueAsDouble = Double.parseDouble(value);
-        long doubleAsLong = (long) valueAsDouble;
-        if (Doubles.areEqual(valueAsDouble, doubleAsLong)) {
-            return doubleAsLong;
-        } else {
-            throw new NumberFormatException("Cannot parse decimal to long");
-        }
+        double valueAsDouble = parseMachineString(Double.class, value);
+        return extractNonFactionalPart(valueAsDouble, false);
     }
 
     @SuppressWarnings("unchecked")
@@ -1193,12 +1183,7 @@ public class NLS {
     private static Integer parseIntegerFromUser(String value, String language) {
         try {
             Double valueAsDouble = parseDecimalNumberFromUser(value, language);
-            int doubleAsInteger = valueAsDouble.intValue();
-            if (Doubles.areEqual(valueAsDouble, doubleAsInteger)) {
-                return doubleAsInteger;
-            } else {
-                throw new IllegalArgumentException("Cannot parse decimal to integer");
-            }
+            return (int) extractNonFactionalPart(valueAsDouble, true);
         } catch (IllegalArgumentException exception) {
             // This exception is managed by the caller where an appropriate
             // IllegalArgumentException is thrown instead
@@ -1209,16 +1194,20 @@ public class NLS {
     private static Long parseLongFromUser(String value, String language) {
         try {
             Double valueAsDouble = parseDecimalNumberFromUser(value, language);
-            long doubleAsLong = valueAsDouble.longValue();
-            if (Doubles.areEqual(valueAsDouble, doubleAsLong)) {
-                return doubleAsLong;
-            } else {
-                throw new IllegalArgumentException("Cannot parse decimal to long");
-            }
+            return extractNonFactionalPart(valueAsDouble, false);
         } catch (IllegalArgumentException exception) {
             // This exception is managed by the caller where an appropriate
             // IllegalArgumentException is thrown instead
             throw new NumberFormatException("Cannot parse value to long.");
+        }
+    }
+
+    private static long extractNonFactionalPart(Double doubleValue, boolean integerExpected) {
+        long doubleAsLong = integerExpected ? doubleValue.intValue() : doubleValue.longValue();
+        if (Doubles.areEqual(doubleValue, doubleAsLong)) {
+            return doubleAsLong;
+        } else {
+            throw new NumberFormatException("Value with fraction detected, cannot extract only non-fractional part.");
         }
     }
 

--- a/src/test/java/sirius/kernel/nls/NLSSpec.groovy
+++ b/src/test/java/sirius/kernel/nls/NLSSpec.groovy
@@ -164,6 +164,32 @@ class NLSSpec extends BaseSpecification {
         "31,0000" | 31L
     }
 
+    def "parseUserString works for integers considering locale"() {
+        expect:
+        NLS.parseUserString(Integer.class, input, language) == output
+
+        where:
+        input       | language | output
+        "55.000,00" | "de"     | 55000
+        "56,000.00" | "en"     | 56000
+    }
+
+    def "parseUserString fails when expected"() {
+        when:
+        NLS.parseUserString(clazz, input) == output
+
+        then:
+        def error = thrown(expecteException)
+        error.message == expectedMessage
+
+        where:
+        input  | clazz | expecteException         | expectedMessage
+        "42,1" | Integer
+                .class | IllegalArgumentException | "Bitte geben Sie eine gültige Zahl ein. '42,1' ist ungültig."
+        "blub" | Double
+                .class | IllegalArgumentException | "Bitte geben Sie eine gültige Dezimalzahl ein. 'blub' ist ungültig."
+    }
+
     def "parseUserString for a LocalTime works"() {
         expect:
         NLS.parseUserString(LocalTime.class, input) == output
@@ -203,6 +229,22 @@ class NLSSpec extends BaseSpecification {
         input     | output
         "5"       | 5L
         "43.0000" | 43L
+    }
+
+    def "parseMachineString fails when expected"() {
+        when:
+        NLS.parseMachineString(clazz, input) == output
+
+        then:
+        def error = thrown(expecteException)
+        error.message == expectedMessage
+
+        where:
+        input  | clazz | expecteException         | expectedMessage
+        "42.1" | Integer
+                .class | IllegalArgumentException | "Bitte geben Sie eine gültige Zahl ein. '42.1' ist ungültig."
+        "blub" | Double
+                .class | IllegalArgumentException | "Bitte geben Sie eine gültige Dezimalzahl ein. 'blub' ist ungültig."
     }
 
     def "getMonthNameShort correctly appends the given symbol"() {

--- a/src/test/java/sirius/kernel/nls/NLSSpec.groovy
+++ b/src/test/java/sirius/kernel/nls/NLSSpec.groovy
@@ -12,11 +12,7 @@ import sirius.kernel.BaseSpecification
 import sirius.kernel.async.CallContext
 import sirius.kernel.commons.Amount
 
-import java.time.Instant
-import java.time.LocalDate
-import java.time.LocalDateTime
-import java.time.LocalTime
-import java.time.ZoneId
+import java.time.*
 
 class NLSSpec extends BaseSpecification {
 
@@ -148,6 +144,26 @@ class NLSSpec extends BaseSpecification {
         NLS.parseUserString(Amount.class, input).toString() == "34,54"
     }
 
+    def "parseUserString works for integers"() {
+        expect:
+        NLS.parseUserString(Integer.class, input) == output
+
+        where:
+        input     | output
+        "42"      | 42
+        "77,0000" | 77
+    }
+
+    def "parseUserString works for longs"() {
+        expect:
+        NLS.parseUserString(Long.class, input) == output
+
+        where:
+        input     | output
+        "12"      | 12L
+        "31,0000" | 31L
+    }
+
     def "parseUserString for a LocalTime works"() {
         expect:
         NLS.parseUserString(LocalTime.class, input) == output
@@ -167,6 +183,26 @@ class NLSSpec extends BaseSpecification {
         input | output
         "0.1" | BigDecimal.ONE.divide(BigDecimal.TEN)
         "0.1" | new BigDecimal("0.1")
+    }
+
+    def "parseMachineString works for integers"() {
+        expect:
+        NLS.parseMachineString(Integer.class, input) == output
+
+        where:
+        input     | output
+        "23"      | 23
+        "90.0000" | 90
+    }
+
+    def "parseMachineString works for longs"() {
+        expect:
+        NLS.parseMachineString(Long.class, input) == output
+
+        where:
+        input     | output
+        "5"       | 5L
+        "43.0000" | 43L
     }
 
     def "getMonthNameShort correctly appends the given symbol"() {


### PR DESCRIPTION
By considering values with only zeros as after the decimal point (or a maximal epsilon of 0.000001d).

See added test cases for examples.

> [OX-9546](https://scireum.myjetbrains.com/youtrack/issue/OX-9546)
> [OX-9560](https://scireum.myjetbrains.com/youtrack/issue/OX-9560)