### PR TITLE
Enhances parsing of strings into integer/longs

### DIFF
--- a/src/main/java/sirius/kernel/commons/Doubles.java
+++ b/src/main/java/sirius/kernel/commons/Doubles.java
@@ -50,7 +50,7 @@ public class Doubles {
     }
 
     /**
-     * Determines if the given number is zero (or very very close to).
+     * Determines if the given number is zero (or very, very close to).
      * <p>
      * Determines if the given number is zero or less than {@link #EPSILON} away from it. This is used to make up for
      * rounding errors which are in the nature of floating point numbers.

--- a/src/main/java/sirius/kernel/nls/NLS.java
+++ b/src/main/java/sirius/kernel/nls/NLS.java
@@ -1027,14 +1027,14 @@ public class NLS {
     private static <V> V parseBasicTypesFromMachineString(Class<V> clazz, String value) {
         if (Integer.class.equals(clazz) || int.class.equals(clazz)) {
             try {
-                return (V) Integer.valueOf(value);
+                return (V) extractNonFractionalPart(() -> parseMachineString(Double.class, value), true);
             } catch (NumberFormatException e) {
                 throw new IllegalArgumentException(fmtr("NLS.errInvalidNumber").set("value", value).format(), e);
             }
         }
         if (Long.class.equals(clazz) || long.class.equals(clazz)) {
             try {
-                return (V) Long.valueOf(value);
+                return (V) extractNonFractionalPart(() -> parseMachineString(Double.class, value), false);
             } catch (NumberFormatException e) {
                 throw new IllegalArgumentException(fmtr("NLS.errInvalidNumber").set("value", value).format(), e);
             }
@@ -1138,14 +1138,14 @@ public class NLS {
     private static <V> V parseBasicTypesFromUserString(Class<V> clazz, String value, String language) {
         if (Integer.class.equals(clazz) || int.class.equals(clazz)) {
             try {
-                return (V) Integer.valueOf(value);
+                return (V) extractNonFractionalPart(() -> parseDecimalNumberFromUser(value, language), true);
             } catch (NumberFormatException e) {
                 throw new IllegalArgumentException(fmtr("NLS.errInvalidNumber").set("value", value).format(), e);
             }
         }
         if (Long.class.equals(clazz) || long.class.equals(clazz)) {
             try {
-                return (V) Long.valueOf(value);
+                return (V) extractNonFractionalPart(() -> parseDecimalNumberFromUser(value, language), false);
             } catch (NumberFormatException e) {
                 throw new IllegalArgumentException(fmtr("NLS.errInvalidNumber").set("value", value).format(), e);
             }

--- a/src/main/java/sirius/kernel/nls/NLS.java
+++ b/src/main/java/sirius/kernel/nls/NLS.java
@@ -1136,15 +1136,15 @@ public class NLS {
     private static <V> V parseBasicTypesFromUserString(Class<V> clazz, String value, String language) {
         if (Integer.class.equals(clazz) || int.class.equals(clazz)) {
             try {
-                return (V) extractIntegerFromDouble(() -> parseDecimalNumberFromUser(value, language));
-            } catch (NumberFormatException e) {
+                return (V) Integer.valueOf(parseDecimalNumberFromUser(value, language).intValueExact());
+            } catch (NumberFormatException | ArithmeticException e) {
                 throw new IllegalArgumentException(fmtr("NLS.errInvalidNumber").set("value", value).format(), e);
             }
         }
         if (Long.class.equals(clazz) || long.class.equals(clazz)) {
             try {
-                return (V) extractLongFromDouble(() -> parseDecimalNumberFromUser(value, language));
-            } catch (NumberFormatException e) {
+                return (V) Long.valueOf(parseDecimalNumberFromUser(value, language).longValueExact());
+            } catch (NumberFormatException | ArithmeticException e) {
                 throw new IllegalArgumentException(fmtr("NLS.errInvalidNumber").set("value", value).format(), e);
             }
         }

--- a/src/main/java/sirius/kernel/nls/NLS.java
+++ b/src/main/java/sirius/kernel/nls/NLS.java
@@ -1178,10 +1178,12 @@ public class NLS {
                 return result;
             }
 
-            return getDecimalFormat(language).parse(value).doubleValue();
-        } catch (ParseException exception) {
-            Exceptions.ignore(exception);
-            return Double.valueOf(value);
+            try {
+                return getDecimalFormat(language).parse(value).doubleValue();
+            } catch (ParseException exception) {
+                Exceptions.ignore(exception);
+                return Double.valueOf(value);
+            }
         } catch (NumberFormatException exception) {
             throw new IllegalArgumentException(fmtr("NLS.errInvalidDecimalNumber").set("value", value).format(),
                                                exception);

--- a/src/main/java/sirius/kernel/nls/NLS.java
+++ b/src/main/java/sirius/kernel/nls/NLS.java
@@ -1025,15 +1025,15 @@ public class NLS {
     private static <V> V parseBasicTypesFromMachineString(Class<V> clazz, String value) {
         if (Integer.class.equals(clazz) || int.class.equals(clazz)) {
             try {
-                return (V) extractIntegerFromDouble(() -> parseMachineString(Double.class, value));
-            } catch (NumberFormatException e) {
+                return (V) Integer.valueOf(parseMachineString(BigDecimal.class, value).intValueExact());
+            } catch (NumberFormatException | ArithmeticException e) {
                 throw new IllegalArgumentException(fmtr("NLS.errInvalidNumber").set("value", value).format(), e);
             }
         }
         if (Long.class.equals(clazz) || long.class.equals(clazz)) {
             try {
-                return (V) extractLongFromDouble(() -> parseMachineString(Double.class, value));
-            } catch (NumberFormatException e) {
+                return (V) Long.valueOf(parseMachineString(BigDecimal.class, value).longValueExact());
+            } catch (NumberFormatException | ArithmeticException e) {
                 throw new IllegalArgumentException(fmtr("NLS.errInvalidNumber").set("value", value).format(), e);
             }
         }

--- a/src/main/java/sirius/kernel/nls/NLS.java
+++ b/src/main/java/sirius/kernel/nls/NLS.java
@@ -14,7 +14,6 @@ import sirius.kernel.async.CallContext;
 import sirius.kernel.async.ExecutionPoint;
 import sirius.kernel.commons.AdvancedDateParser;
 import sirius.kernel.commons.Amount;
-import sirius.kernel.commons.Doubles;
 import sirius.kernel.commons.Explain;
 import sirius.kernel.commons.NumberFormat;
 import sirius.kernel.commons.Strings;
@@ -49,7 +48,6 @@ import java.util.Locale;
 import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.ConcurrentHashMap;
-import java.util.function.DoubleSupplier;
 
 /**
  * Native Language Support used by the framework.
@@ -1187,49 +1185,6 @@ public class NLS {
         } catch (NumberFormatException exception) {
             throw new IllegalArgumentException(fmtr("NLS.errInvalidDecimalNumber").set("value", value).format(),
                                                exception);
-        }
-    }
-
-    /**
-     * Extracts the integer part of a double value, if it contains non fraction.
-     * <p>
-     * The fraction is detected by checking if the absolute difference of the double value
-     * and its integer or long part are not higher than {@link Doubles#EPSILON}.
-     *
-     * @param doubleProvider the supplier responsible to deliver a double value
-     * @return the non-fraction part
-     * @throws NumberFormatException if the value cannot be converted or contains a fraction
-     */
-    private static Integer extractIntegerFromDouble(DoubleSupplier doubleProvider) {
-        long value = extractLongFromDouble(doubleProvider);
-        if (value >= Integer.MIN_VALUE && value <= Integer.MAX_VALUE) {
-            return (int) value;
-        }
-        throw new NumberFormatException("Number does not fit in an integer");
-    }
-
-    /**
-     * Extracts the long part of a double value, if it contains non fraction.
-     * <p>
-     * The fraction is detected by checking if the absolute difference of the double value
-     * and its integer or long part are not higher than {@link Doubles#EPSILON}.
-     *
-     * @param doubleProvider the supplier responsible to deliver a double value
-     * @return the non-fraction part
-     * @throws NumberFormatException if the value cannot be converted or contains a fraction
-     */
-    private static Long extractLongFromDouble(DoubleSupplier doubleProvider) {
-        try {
-            double value = doubleProvider.getAsDouble();
-            long valueAsLong = (long) value;
-            if (Doubles.areEqual(value, valueAsLong)) {
-                return valueAsLong;
-            } else {
-                throw new NumberFormatException("Double value contains fraction.");
-            }
-        } catch (IllegalArgumentException exception) {
-            Exceptions.ignore(exception);
-            throw new NumberFormatException("Cannot parse value as double.");
         }
     }
 

--- a/src/main/java/sirius/kernel/nls/NLS.java
+++ b/src/main/java/sirius/kernel/nls/NLS.java
@@ -1149,10 +1149,10 @@ public class NLS {
             }
         }
         if (Float.class.equals(clazz) || float.class.equals(clazz)) {
-            return (V) Float.valueOf((float) parseDecimalNumberFromUser(value, language).doubleValue());
+            return (V) Float.valueOf(parseDecimalNumberFromUser(value, language).floatValue());
         }
         if (Double.class.equals(clazz) || double.class.equals(clazz)) {
-            return (V) parseDecimalNumberFromUser(value, language);
+            return (V) Double.valueOf(parseDecimalNumberFromUser(value, language).doubleValue());
         }
         if (Amount.class.equals(clazz)) {
             return (V) Amount.of(parseDecimalNumberFromUser(value, language));
@@ -1169,18 +1169,18 @@ public class NLS {
         return parseDatesFromUserString(clazz, value, language);
     }
 
-    private static Double parseDecimalNumberFromUser(String value, String language) {
+    private static BigDecimal parseDecimalNumberFromUser(String value, String language) {
         try {
             Double result = tryParseMachineFormat(value);
             if (result != null) {
-                return result;
+                return BigDecimal.valueOf(result);
             }
 
             try {
-                return getDecimalFormat(language).parse(value).doubleValue();
+                return BigDecimal.valueOf(getDecimalFormat(language).parse(value).doubleValue());
             } catch (ParseException exception) {
                 Exceptions.ignore(exception);
-                return Double.valueOf(value);
+                return BigDecimal.valueOf(Double.valueOf(value));
             }
         } catch (NumberFormatException exception) {
             throw new IllegalArgumentException(fmtr("NLS.errInvalidDecimalNumber").set("value", value).format(),

--- a/src/test/java/sirius/kernel/nls/NLSSpec.groovy
+++ b/src/test/java/sirius/kernel/nls/NLSSpec.groovy
@@ -12,11 +12,7 @@ import sirius.kernel.BaseSpecification
 import sirius.kernel.async.CallContext
 import sirius.kernel.commons.Amount
 
-import java.time.Instant
-import java.time.LocalDate
-import java.time.LocalDateTime
-import java.time.LocalTime
-import java.time.ZoneId
+import java.time.*
 
 class NLSSpec extends BaseSpecification {
 
@@ -148,6 +144,52 @@ class NLSSpec extends BaseSpecification {
         NLS.parseUserString(Amount.class, input).toString() == "34,54"
     }
 
+    def "parseUserString works for integers"() {
+        expect:
+        NLS.parseUserString(Integer.class, input) == output
+
+        where:
+        input     | output
+        "42"      | 42
+        "77,0000" | 77
+    }
+
+    def "parseUserString works for longs"() {
+        expect:
+        NLS.parseUserString(Long.class, input) == output
+
+        where:
+        input     | output
+        "12"      | 12L
+        "31,0000" | 31L
+    }
+
+    def "parseUserString works for integers considering locale"() {
+        expect:
+        NLS.parseUserString(Integer.class, input, language) == output
+
+        where:
+        input       | language | output
+        "55.000,00" | "de"     | 55000
+        "56,000.00" | "en"     | 56000
+    }
+
+    def "parseUserString fails when expected"() {
+        when:
+        NLS.parseUserString(clazz, input) == output
+
+        then:
+        def error = thrown(expecteException)
+        error.message == expectedMessage
+
+        where:
+        input  | clazz | expecteException         | expectedMessage
+        "42,1" | Integer
+                .class | IllegalArgumentException | "Bitte geben Sie eine gültige Zahl ein. '42,1' ist ungültig."
+        "blub" | Double
+                .class | IllegalArgumentException | "Bitte geben Sie eine gültige Dezimalzahl ein. 'blub' ist ungültig."
+    }
+
     def "parseUserString for a LocalTime works"() {
         expect:
         NLS.parseUserString(LocalTime.class, input) == output
@@ -167,6 +209,42 @@ class NLSSpec extends BaseSpecification {
         input | output
         "0.1" | BigDecimal.ONE.divide(BigDecimal.TEN)
         "0.1" | new BigDecimal("0.1")
+    }
+
+    def "parseMachineString works for integers"() {
+        expect:
+        NLS.parseMachineString(Integer.class, input) == output
+
+        where:
+        input     | output
+        "23"      | 23
+        "90.0000" | 90
+    }
+
+    def "parseMachineString works for longs"() {
+        expect:
+        NLS.parseMachineString(Long.class, input) == output
+
+        where:
+        input     | output
+        "5"       | 5L
+        "43.0000" | 43L
+    }
+
+    def "parseMachineString fails when expected"() {
+        when:
+        NLS.parseMachineString(clazz, input) == output
+
+        then:
+        def error = thrown(expecteException)
+        error.message == expectedMessage
+
+        where:
+        input  | clazz | expecteException         | expectedMessage
+        "42.1" | Integer
+                .class | IllegalArgumentException | "Bitte geben Sie eine gültige Zahl ein. '42.1' ist ungültig."
+        "blub" | Double
+                .class | IllegalArgumentException | "Bitte geben Sie eine gültige Dezimalzahl ein. 'blub' ist ungültig."
     }
 
     def "getMonthNameShort correctly appends the given symbol"() {

--- a/src/test/java/sirius/kernel/nls/NLSSpec.groovy
+++ b/src/test/java/sirius/kernel/nls/NLSSpec.groovy
@@ -183,11 +183,13 @@ class NLSSpec extends BaseSpecification {
         error.message == expectedMessage
 
         where:
-        input  | clazz | expecteException         | expectedMessage
-        "42,1" | Integer
-                .class | IllegalArgumentException | "Bitte geben Sie eine gültige Zahl ein. '42,1' ist ungültig."
-        "blub" | Double
-                .class | IllegalArgumentException | "Bitte geben Sie eine gültige Dezimalzahl ein. 'blub' ist ungültig."
+        input        | clazz | expecteException         | expectedMessage
+        "42,1"       | Integer
+                .class       | IllegalArgumentException | "Bitte geben Sie eine gültige Zahl ein. '42,1' ist ungültig."
+        "2999999999" | Integer
+                .class       | IllegalArgumentException | "Bitte geben Sie eine gültige Zahl ein. '2999999999' ist ungültig."
+        "blub"       | Double
+                .class       | IllegalArgumentException | "Bitte geben Sie eine gültige Dezimalzahl ein. 'blub' ist ungültig."
     }
 
     def "parseUserString for a LocalTime works"() {
@@ -240,11 +242,13 @@ class NLSSpec extends BaseSpecification {
         error.message == expectedMessage
 
         where:
-        input  | clazz | expecteException         | expectedMessage
-        "42.1" | Integer
-                .class | IllegalArgumentException | "Bitte geben Sie eine gültige Zahl ein. '42.1' ist ungültig."
-        "blub" | Double
-                .class | IllegalArgumentException | "Bitte geben Sie eine gültige Dezimalzahl ein. 'blub' ist ungültig."
+        input        | clazz | expecteException         | expectedMessage
+        "42.1"       | Integer
+                .class       | IllegalArgumentException | "Bitte geben Sie eine gültige Zahl ein. '42.1' ist ungültig."
+        "2999999999" | Integer
+                .class       | IllegalArgumentException | "Bitte geben Sie eine gültige Zahl ein. '2999999999' ist ungültig."
+        "blub"       | Double
+                .class       | IllegalArgumentException | "Bitte geben Sie eine gültige Dezimalzahl ein. 'blub' ist ungültig."
     }
 
     def "getMonthNameShort correctly appends the given symbol"() {


### PR DESCRIPTION
By considering values with only zeros after the decimal point.

Examples:
`NLS.parseUserString(Integer.class, "10,0")` -> OK
`NLS.parseUserString(Integer.class, "10,5")` -> Fail
`NLS.parseMachineString(Integer.class, "10.0")` -> OK
`NLS.parseMachineString(Integer.class, "10.5")` -> Fail

See added test cases for examples.

> [OX-9546](https://scireum.myjetbrains.com/youtrack/issue/OX-9546)
> [OX-9560](https://scireum.myjetbrains.com/youtrack/issue/OX-9560)
> [SE-12268](https://scireum.myjetbrains.com/youtrack/issue/SE-12268/Shop-spezifische-Attribute-Fehlermeldungen-besser-abfangen)