### PR TITLE
Defines a JS formatter

### DIFF
--- a/src/main/java/sirius/kernel/nls/Formatter.java
+++ b/src/main/java/sirius/kernel/nls/Formatter.java
@@ -227,11 +227,17 @@ public class Formatter {
      * @return <tt>this</tt> to permit fluent method chains
      */
     public Formatter setDirect(String property, String value) {
-        if (jsEncode && value != null) {
-            replacement.put(property, value.replace("'", "\\'").replace("\"", "\\\""));
+        if (jsEncode) {
+            replacement.put(property, escapeJS(value));
             return this;
         }
-        replacement.put(property, urlEncode ? Strings.urlEncode(value) : value);
+
+        if (urlEncode) {
+            replacement.put(property, Strings.urlEncode(value));
+            return this;
+        }
+
+        replacement.put(property, value);
         return this;
     }
 
@@ -411,6 +417,13 @@ public class Formatter {
         currentBlock = blocks.get(blocks.size() - 2);
         blocks.remove(blocks.size() - 1);
         return currentBlock;
+    }
+
+    private String escapeJS(String value) {
+        if (value == null) {
+            return value;
+        }
+        return value.replace("'", "\\'").replace("\"", "\\\"");
     }
 
     @Override

--- a/src/main/java/sirius/kernel/nls/Formatter.java
+++ b/src/main/java/sirius/kernel/nls/Formatter.java
@@ -46,6 +46,7 @@ import java.util.function.Function;
  */
 public class Formatter {
     private boolean urlEncode = false;
+    private boolean jsEncode = false;
     private final Map<String, String> replacement = new TreeMap<>();
     private Function<String, Optional<String>> parameterProvider;
     private boolean ignoreMissingParameters;
@@ -101,6 +102,21 @@ public class Formatter {
         Formatter result = new Formatter();
         result.pattern = pattern;
         result.urlEncode = true;
+        return result;
+    }
+
+    /**
+     * Creates a new formatter with auto JavaScript encoding turned on.
+     * <p>
+     * Any parameters passed to this formatter will have its single and double quotes encoded.
+     *
+     * @param pattern specifies the pattern to be used for creating the output
+     * @return <tt>this</tt> for fluently calling <tt>set</tt> methods.
+     */
+    public static Formatter createJSFormatter(String pattern) {
+        Formatter result = new Formatter();
+        result.pattern = pattern;
+        result.jsEncode = true;
         return result;
     }
 
@@ -211,6 +227,10 @@ public class Formatter {
      * @return <tt>this</tt> to permit fluent method chains
      */
     public Formatter setDirect(String property, String value) {
+        if (jsEncode && value != null) {
+            replacement.put(property, value.replace("'", "\\'").replace("\"", "\\\""));
+            return this;
+        }
         replacement.put(property, urlEncode ? Strings.urlEncode(value) : value);
         return this;
     }

--- a/src/test/java/sirius/kernel/nls/FormatterSpec.groovy
+++ b/src/test/java/sirius/kernel/nls/FormatterSpec.groovy
@@ -104,4 +104,13 @@ class FormatterSpec extends BaseSpecification {
         thrown(IllegalArgumentException)
     }
 
+    def "createJSFormatter works"() {
+        given:
+        def pattern = "foo = '\${foo}' bar = \"\${bar}\""
+        when:
+        def result = Formatter.createJSFormatter(pattern).set("foo", "d'or").set("bar", "\"buzz\"").format()
+        then:
+        result == "foo = 'd\\'or' bar = \"\\\"buzz\\\"\""
+    }
+
 }


### PR DESCRIPTION
Which escapes single and double-quotes, so they can be used in templates meant to generate JavaScript snippets.

**Example**

String = `value = '${foo}'`
foo = `d'Or`

Resulting string: `value = 'd\'Or'`

Fixes: [OX-9892](https://scireum.myjetbrains.com/youtrack/issue/OX-9892)