### PR TITLE
Expands and tests JSON Util Class

### DIFF
--- a/src/main/java/sirius/kernel/commons/Json.java
+++ b/src/main/java/sirius/kernel/commons/Json.java
@@ -9,6 +9,7 @@
 package sirius.kernel.commons;
 
 import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.core.JsonPointer;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.JsonNode;
@@ -371,6 +372,21 @@ public class Json {
      */
     public static Optional<JsonNode> tryGet(ObjectNode objectNode, String fieldName) {
         JsonNode node = objectNode.get(fieldName);
+        if (node == null || node.isNull()) {
+            return Optional.empty();
+        }
+        return Optional.of(node);
+    }
+
+    /**
+     * Tries to retrieve the {@link JsonNode} at the given pointer of the given {@link JsonNode}.
+     *
+     * @param jsonNode the node to retrieve the value from
+     * @param pointer  the pointer to the value to retrieve
+     * @return the value at the given pointer or an empty optional if the pointer does not exist or the node is null
+     */
+    public static Optional<JsonNode> tryGetAt(JsonNode jsonNode, JsonPointer pointer) {
+        JsonNode node = jsonNode.at(pointer);
         if (node == null || node.isNull()) {
             return Optional.empty();
         }

--- a/src/main/java/sirius/kernel/commons/Json.java
+++ b/src/main/java/sirius/kernel/commons/Json.java
@@ -387,7 +387,7 @@ public class Json {
      */
     public static Optional<JsonNode> tryGetAt(JsonNode jsonNode, JsonPointer pointer) {
         JsonNode node = jsonNode.at(pointer);
-        if (node == null || node.isNull()) {
+        if (node == null || node.isNull() || node.isMissingNode()) {
             return Optional.empty();
         }
         return Optional.of(node);

--- a/src/main/java/sirius/kernel/commons/Json.java
+++ b/src/main/java/sirius/kernel/commons/Json.java
@@ -346,4 +346,34 @@ public class Json {
         }
         return Optional.of((ArrayNode) node);
     }
+
+    /**
+     * Tries to retrieve the {@link JsonNode} at the given index of the given {@link ArrayNode}.
+     *
+     * @param arrayNode the node to retrieve the value from
+     * @param index     the index of the value to retrieve
+     * @return the value at the given index or an empty optional if the index is out of bounds or the node is null
+     */
+    public static Optional<JsonNode> tryGetAtIndex(ArrayNode arrayNode, int index) {
+        JsonNode node = arrayNode.get(index);
+        if (node == null || node.isNull()) {
+            return Optional.empty();
+        }
+        return Optional.of(node);
+    }
+
+    /**
+     * Tries to retrieve the {@link JsonNode} at the given field name of the given {@link ObjectNode}.
+     *
+     * @param objectNode the node to retrieve the value from
+     * @param fieldName  the field name of the value to retrieve
+     * @return the value at the given field name or an empty optional if the field does not exist or the node is null
+     */
+    public static Optional<JsonNode> tryGet(ObjectNode objectNode, String fieldName) {
+        JsonNode node = objectNode.get(fieldName);
+        if (node == null || node.isNull()) {
+            return Optional.empty();
+        }
+        return Optional.of(node);
+    }
 }

--- a/src/main/java/sirius/kernel/commons/Json.java
+++ b/src/main/java/sirius/kernel/commons/Json.java
@@ -9,7 +9,6 @@
 package sirius.kernel.commons;
 
 import com.fasterxml.jackson.core.JsonParser;
-import com.fasterxml.jackson.core.JsonPointer;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.JsonNode;
@@ -21,6 +20,7 @@ import sirius.kernel.health.Log;
 
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.stream.Stream;
 import java.util.stream.StreamSupport;
 
@@ -239,24 +239,58 @@ public class Json {
 
     /**
      * Retrieves the {@link ObjectNode} at the given index of the given {@link ArrayNode}.
+     * <p>
+     * If the index is out of bounds or the node is not an object, an empty object is returned.
      *
      * @param arrayNode the node to retrieve the object from
      * @param index     the index of the object to retrieve
-     * @return the object at the given index
+     * @return the object at the given index or an empty object if the index is out of bounds or the node is not an object
      */
     public static ObjectNode getObjectAtIndex(ArrayNode arrayNode, int index) {
-        return (ObjectNode) arrayNode.get(index);
+        return tryGetObjectAtIndex(arrayNode, index).orElseGet(Json::createObject);
+    }
+
+    /**
+     * Tries to retrieve the {@link ObjectNode} at the given index of the given {@link ArrayNode}.
+     *
+     * @param arrayNode the node to retrieve the object from
+     * @param index     the index of the object to retrieve
+     * @return the object at the given index or an empty object if the index is out of bounds or the node is not an object
+     */
+    public static Optional<ObjectNode> tryGetObjectAtIndex(ArrayNode arrayNode, int index) {
+        JsonNode node = arrayNode.get(index);
+        if (node == null || !node.isObject()) {
+            return Optional.empty();
+        }
+        return Optional.of((ObjectNode) node);
     }
 
     /**
      * Retrieves the {@link ObjectNode} at the given field name of the given {@link ObjectNode}.
+     * <p>
+     * If the field does not exist or is not an object, an empty object is returned.
      *
      * @param objectNode the node to retrieve the object from
      * @param fieldName  the field name of the object to retrieve
-     * @return the object at the given field name
+     * @return the object at the given field name or an empty object if the field does not exist or is not an object
      */
     public static ObjectNode getObject(ObjectNode objectNode, String fieldName) {
-        return objectNode.withObject(JsonPointer.SEPARATOR + fieldName);
+        return tryGetObject(objectNode, fieldName).orElseGet(Json::createObject);
+    }
+
+    /**
+     * Tries to retrieve the {@link ObjectNode} at the given field name of the given {@link ObjectNode}.
+     *
+     * @param objectNode the node to retrieve the object from
+     * @param fieldName  the field name of the object to retrieve
+     * @return the object at the given field name or an empty optional if the field does not exist or is not an object
+     */
+    public static Optional<ObjectNode> tryGetObject(ObjectNode objectNode, String fieldName) {
+        JsonNode node = objectNode.get(fieldName);
+        if (node == null || !node.isObject()) {
+            return Optional.empty();
+        }
+        return Optional.of((ObjectNode) node);
     }
 
     /**
@@ -267,17 +301,49 @@ public class Json {
      * @return the array at the given index
      */
     public static ArrayNode getArrayAtIndex(ArrayNode arrayNode, int index) {
-        return (ArrayNode) arrayNode.get(index);
+        return tryGetArrayAtIndex(arrayNode, index).orElseGet(Json::createArray);
+    }
+
+    /**
+     * Tries to retrieve the {@link ArrayNode} at the given index of the given {@link ArrayNode}.
+     *
+     * @param arrayNode the node to retrieve the array from
+     * @param index     the index of the array to retrieve
+     * @return the array at the given index or an empty optional if the index is out of bounds or the node is not an array
+     */
+    public static Optional<ArrayNode> tryGetArrayAtIndex(ArrayNode arrayNode, int index) {
+        JsonNode node = arrayNode.get(index);
+        if (node == null || !node.isArray()) {
+            return Optional.empty();
+        }
+        return Optional.of((ArrayNode) node);
     }
 
     /**
      * Retrieves the {@link ArrayNode} at the given field name of the given {@link ObjectNode}.
+     * <p>
+     * If the field does not exist or is not an array, an empty array is returned.
      *
      * @param objectNode the node to retrieve the array from
      * @param fieldName  the field name of the array to retrieve
-     * @return the array at the given field name
+     * @return the array at the given field name or an empty array if the field does not exist or is not an array
      */
     public static ArrayNode getArray(ObjectNode objectNode, String fieldName) {
-        return objectNode.withArray(JsonPointer.SEPARATOR + fieldName);
+        return tryGetArray(objectNode, fieldName).orElseGet(Json::createArray);
+    }
+
+    /**
+     * Tries to retrieve the {@link ArrayNode} at the given field name of the given {@link ObjectNode}.
+     *
+     * @param objectNode the node to retrieve the array from
+     * @param fieldName  the field name of the array to retrieve
+     * @return the array at the given field name or an empty optional if the field does not exist or is not an array
+     */
+    public static Optional<ArrayNode> tryGetArray(ObjectNode objectNode, String fieldName) {
+        JsonNode node = objectNode.get(fieldName);
+        if (node == null || !node.isArray()) {
+            return Optional.empty();
+        }
+        return Optional.of((ArrayNode) node);
     }
 }

--- a/src/test/kotlin/sirius/kernel/commons/JsonTest.kt
+++ b/src/test/kotlin/sirius/kernel/commons/JsonTest.kt
@@ -1,0 +1,236 @@
+/*
+ * Made with all the love in the world
+ * by scireum in Remshalden, Germany
+ *
+ * Copyright by scireum GmbH
+ * http://www.scireum.de - info@scireum.de
+ */
+
+package sirius.kernel.commons
+
+import com.fasterxml.jackson.core.JsonProcessingException
+import com.fasterxml.jackson.databind.JsonNode
+import com.fasterxml.jackson.databind.node.ArrayNode
+import com.fasterxml.jackson.databind.node.ObjectNode
+import org.junit.jupiter.api.Assertions.assertThrows
+import org.junit.jupiter.api.Test
+import java.util.*
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+
+class JsonTest {
+
+    @Test
+    fun `empty object is created properly`() {
+        val json: ObjectNode = Json.createObject()
+        assert(json.isEmpty)
+        assertEquals(0, json.size())
+        assertEquals("{}", Json.write(json))
+    }
+
+    @Test
+    fun `empty array is created properly`() {
+        val json: ArrayNode = Json.createArray()
+        assert(json.isEmpty)
+        assertEquals(0, json.size())
+        assertEquals("[]", Json.write(json))
+    }
+
+    @Test
+    fun `valid object is parsed properly`() {
+        val json = """{ "foo": 123, "bar": "baz" }"""
+        val node = Json.parseObject(json)
+        assertEquals(2, node.size())
+        assertEquals(123, node["foo"].asInt())
+        assertEquals("baz", node["bar"].asText())
+    }
+
+    @Test
+    fun `nearly valid object is parsed leniently according to mapper settings`() {
+        val json = """{ foo: 123, bar: 'baz' }"""
+        val node = Json.parseObject(json)
+        assertEquals(2, node.size())
+        assertEquals(123, node["foo"].asInt())
+        assertEquals("baz", node["bar"].asText())
+    }
+
+    @Test
+    fun `exception is thrown when parsing invalid object`() {
+        val invalidJson = "[1, 2, 3]"
+        assertThrows(JsonProcessingException::class.java) {
+            Json.tryParseObject(invalidJson)
+        }
+    }
+
+    @Test
+    fun `valid array is parsed properly`() {
+        val json = "[1, 2, 3]"
+        val array = Json.parseArray(json)
+        assertEquals(3, array.size())
+        assertEquals(1, array[0].asInt())
+        assertEquals(2, array[1].asInt())
+        assertEquals(3, array[2].asInt())
+    }
+
+    @Test
+    fun `exception is thrown when parsing invalid array`() {
+        val invalidJson = """{ "foo": 123, "bar": "baz" }"""
+        assertThrows(JsonProcessingException::class.java) {
+            Json.tryParseArray(invalidJson)
+        }
+    }
+
+    @Test
+    fun `valid object is written properly`() {
+        val node = Json.createObject().put("foo", 123).put("bar", "baz")
+        val json = Json.write(node)
+        assertEquals("""{"foo":123,"bar":"baz"}""", json)
+    }
+
+    @Test
+    fun `valid array is written properly`() {
+        val node = Json.createArray().add(1).add(2).add(3)
+        val json = Json.write(node)
+        assertEquals("[1,2,3]", json)
+    }
+
+    @Test
+    fun `valid object is pretty printed properly`() {
+        val node = Json.createObject().put("foo", 123).put("bar", "baz")
+        val prettyJson = Json.writePretty(node)
+        assertEquals("{\n  \"foo\" : 123,\n  \"bar\" : \"baz\"\n}", prettyJson)
+    }
+
+    @Test
+    fun `valid array can be converted to java list`() {
+        val array = Json.createArray().add(1).add(2).add(3)
+        val list = Json.convertToList(array, Int::class.java)
+        assertEquals(mutableListOf(1, 2, 3), list)
+    }
+
+    @Test
+    fun `valid object can be converted to java map`() {
+        val node = Json.createObject().put("foo", 123).put("bar", "baz")
+        val map = Json.convertToMap(node)
+        assertEquals(mutableMapOf("foo" to 123, "bar" to "baz"), map)
+    }
+
+    @Test
+    fun `entries of array can be streamed properly`() {
+        val array = Json.createArray().add(1).add(2).add(3)
+        val list = mutableListOf<Int>()
+        Json.streamEntries(array).forEach { list.add(it.asInt()) }
+        assertEquals(mutableListOf(1, 2, 3), list)
+    }
+
+    @Test
+    fun `nested object is cloned properly`() {
+        val node = Json.createObject().put("foo", 123).put("bar", "baz")
+        node.withArray("array").add(1).add(2).add(3)
+
+        val clone = Json.clone(node)
+        assertEquals(node.size(), clone.size())
+        assertEquals(node.get("foo"), clone.get("foo"))
+        assertEquals(node.get("bar"), clone.get("bar"))
+        assertEquals(node.get("array"), clone.get("array"))
+        assertEquals(node.get("array").isArray, clone.get("array").isArray)
+        assertEquals(node.get("array").size(), clone.get("array").size())
+    }
+
+    @Test
+    fun `tryGetObjectAtIndex works as expected`() {
+        val json = """[ { "name": "Alice", "age": 30 }, 123 ]"""
+        val node = Json.parseArray(json)
+
+        val presentObject: Optional<ObjectNode> = Json.tryGetObjectAtIndex(node, 0)
+        assertTrue(presentObject.isPresent)
+        assertEquals("Alice", presentObject.get().get("name").asText())
+
+        val notAnObject: Optional<ObjectNode> = Json.tryGetObjectAtIndex(node, 1)
+        assertTrue(!notAnObject.isPresent)
+
+        val missingObject: Optional<ObjectNode> = Json.tryGetObjectAtIndex(node, 2)
+        assertTrue(!missingObject.isPresent)
+    }
+
+    @Test
+    fun `tryGetObject works as expected`() {
+        val json = """{ "foo": { "name": "Alice", "age": 30 }, "bar": 123 }"""
+        val node = Json.parseObject(json)
+
+        val presentObject: Optional<ObjectNode> = Json.tryGetObject(node, "foo")
+        assertTrue(presentObject.isPresent)
+        assertEquals("Alice", presentObject.get().get("name").asText())
+
+        val notAnObject: Optional<ObjectNode> = Json.tryGetObject(node, "bar")
+        assertTrue(!notAnObject.isPresent)
+
+        val missingObject: Optional<ObjectNode> = Json.tryGetObject(node, "baz")
+        assertTrue(!missingObject.isPresent)
+    }
+
+    @Test
+    fun `tryGetArrayAtIndex works as expected`() {
+        val json = """[ [1, 2, 3], 123 ]"""
+        val node = Json.parseArray(json)
+
+        val presentArray: Optional<ArrayNode> = Json.tryGetArrayAtIndex(node, 0)
+        assertTrue(presentArray.isPresent)
+        assertEquals(3, presentArray.get().size())
+
+        val notAnArray: Optional<ArrayNode> = Json.tryGetArrayAtIndex(node, 1)
+        assertTrue(!notAnArray.isPresent)
+
+        val missingArray: Optional<ArrayNode> = Json.tryGetArrayAtIndex(node, 2)
+        assertTrue(!missingArray.isPresent)
+    }
+
+    @Test
+    fun `tryGetArray works as expected`() {
+        val json = """{ "foo": [1, 2, 3], "bar": 123 }"""
+        val node = Json.parseObject(json)
+
+        val presentArray: Optional<ArrayNode> = Json.tryGetArray(node, "foo")
+        assertTrue(presentArray.isPresent)
+        assertEquals(3, presentArray.get().size())
+
+        val notAnArray: Optional<ArrayNode> = Json.tryGetArray(node, "bar")
+        assertTrue(!notAnArray.isPresent)
+
+        val missingArray: Optional<ArrayNode> = Json.tryGetArray(node, "baz")
+        assertTrue(!missingArray.isPresent)
+    }
+
+    @Test
+    fun `tryGetAtIndex works as expected`() {
+        val json = """[1, null]"""
+        val node = Json.parseArray(json)
+
+        val presentValue: Optional<JsonNode> = Json.tryGetAtIndex(node, 0)
+        assertTrue(presentValue.isPresent)
+        assertEquals(1, presentValue.get().asInt())
+
+        val nullValue: Optional<JsonNode> = Json.tryGetAtIndex(node, 1)
+        assertTrue(!nullValue.isPresent)
+
+        val missingValue: Optional<JsonNode> = Json.tryGetAtIndex(node, 2)
+        assertTrue(!missingValue.isPresent)
+    }
+
+    @Test
+    fun `tryGet works as expected`() {
+        val json = """{ "foo": 1, "bar": null }"""
+        val node = Json.parseObject(json)
+
+        val presentValue: Optional<JsonNode> = Json.tryGet(node, "foo")
+        assertTrue(presentValue.isPresent)
+        assertEquals(1, presentValue.get().asInt())
+
+        val nullValue: Optional<JsonNode> = Json.tryGet(node, "bar")
+        assertTrue(!nullValue.isPresent)
+
+        val missingValue: Optional<JsonNode> = Json.tryGet(node, "baz")
+        assertTrue(!missingValue.isPresent)
+    }
+}

--- a/src/test/kotlin/sirius/kernel/commons/JsonTest.kt
+++ b/src/test/kotlin/sirius/kernel/commons/JsonTest.kt
@@ -244,10 +244,10 @@ class JsonTest {
         assertTrue(presentValue.isPresent)
         assertEquals("Alice", presentValue.get().asText())
 
-        val nullValue: Optional<JsonNode> = Json.tryGet(node, "bar")
+        val nullValue: Optional<JsonNode> = Json.tryGetAt(node, JsonPointer.valueOf("/bar"))
         assertTrue(!nullValue.isPresent)
 
-        val missingValue: Optional<JsonNode> = Json.tryGet(node, "baz")
+        val missingValue: Optional<JsonNode> = Json.tryGetAt(node, JsonPointer.valueOf("/baz"))
         assertTrue(!missingValue.isPresent)
     }
 }

--- a/src/test/kotlin/sirius/kernel/commons/JsonTest.kt
+++ b/src/test/kotlin/sirius/kernel/commons/JsonTest.kt
@@ -8,6 +8,7 @@
 
 package sirius.kernel.commons
 
+import com.fasterxml.jackson.core.JsonPointer
 import com.fasterxml.jackson.core.JsonProcessingException
 import com.fasterxml.jackson.databind.JsonNode
 import com.fasterxml.jackson.databind.node.ArrayNode
@@ -226,6 +227,22 @@ class JsonTest {
         val presentValue: Optional<JsonNode> = Json.tryGet(node, "foo")
         assertTrue(presentValue.isPresent)
         assertEquals(1, presentValue.get().asInt())
+
+        val nullValue: Optional<JsonNode> = Json.tryGet(node, "bar")
+        assertTrue(!nullValue.isPresent)
+
+        val missingValue: Optional<JsonNode> = Json.tryGet(node, "baz")
+        assertTrue(!missingValue.isPresent)
+    }
+
+    @Test
+    fun `tryGetAt works as expected`() {
+        val json = """{ "foo": [ { "name": "Alice", "age": 30 } ], "bar": null }"""
+        val node = Json.parseObject(json)
+
+        val presentValue: Optional<JsonNode> = Json.tryGetAt(node, JsonPointer.valueOf("/foo/0/name"))
+        assertTrue(presentValue.isPresent)
+        assertEquals("Alice", presentValue.get().asText())
 
         val nullValue: Optional<JsonNode> = Json.tryGet(node, "bar")
         assertTrue(!nullValue.isPresent)


### PR DESCRIPTION
The different methods now all provide a try-variant that return an empty optional when no fitting array/object node could be retrieved. The functionality of the methods without the try-prefix is changed so they fall back to an empty array/node when the try-variant didn't find a result. This replaces the old usage of withArray/withObject that actually added the array/object to the parent the retrieval was called on.

Fixes: SIRI-736