### PR TITLE
Properly serializes and deserializes dates and times in JSON

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -76,6 +76,10 @@
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
         </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.datatype</groupId>
+            <artifactId>jackson-datatype-jsr310</artifactId>
+        </dependency>
         <!-- Required, as the version provided by docker-compose-rule-core has security issues -->
         <dependency>
             <groupId>org.yaml</groupId>

--- a/src/main/java/sirius/kernel/commons/Json.java
+++ b/src/main/java/sirius/kernel/commons/Json.java
@@ -17,7 +17,6 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
 import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
-import com.fasterxml.jackson.databind.util.StdDateFormat;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import sirius.kernel.health.Exceptions;
 import sirius.kernel.health.Log;
@@ -60,7 +59,6 @@ public class Json {
             new ObjectMapper().configure(JsonParser.Feature.ALLOW_UNQUOTED_FIELD_NAMES, true)
                               .configure(JsonParser.Feature.ALLOW_SINGLE_QUOTES, true)
                               .disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS)
-                              .setDateFormat(new StdDateFormat().withColonInTimeZone(true))
                               .registerModule(new JavaTimeModule());
 
     private Json() {
@@ -573,8 +571,7 @@ public class Json {
 
     /**
      * Tries to read a {@link LocalDate} value from the given {@link JsonNode} at the given field name. JSON does
-     * not define a date format, so we fall back to ISO-8601 which is the default format e.g. used from
-     * Javascript using {@code JSON.stringify(new Date())}.
+     * not define a date format, so we fall back to ISO-8601.
      *
      * @param jsonNode  the node to retrieve the value from
      * @param fieldName the field name of the value to retrieve

--- a/src/test/kotlin/sirius/kernel/commons/JsonTest.kt
+++ b/src/test/kotlin/sirius/kernel/commons/JsonTest.kt
@@ -42,13 +42,11 @@ class JsonTest {
 
     @Test
     fun `valid object is parsed properly`() {
-        val json = """{"foo":123,"bar":"baz","date":"2023-01-01","time":"2023-01-01T13:37:00.123456"}"""
+        val json = """{"foo":123,"bar":"baz"}"""
         val node = Json.parseObject(json)
-        assertEquals(4, node.size())
+        assertEquals(2, node.size())
         assertEquals(123, node["foo"].asInt())
         assertEquals("baz", node["bar"].asText())
-        assertEquals(LocalDate.of(2023, 1, 1), Json.tryValueDate(node, "date").get())
-        assertEquals(LocalDateTime.of(2023, 1, 1, 13, 37, 0, 123456000), Json.tryValueDateTime(node, "time").get())
     }
 
     @Test
@@ -325,13 +323,24 @@ class JsonTest {
     }
 
     @Test
-    fun `tryValueDateTime reads JS Date stringify representation aka ISO-8601 from strings`() {
-        val json = """{ "jsJsonStringifyDate": "2023-05-10T09:00:00.000Z" }"""
-        val node = Json.parseObject(json)
+    fun `dates and times can be read properly`() {
 
-        val expected = LocalDateTime.of(2023, 5, 10, 9, 0, 0)
-        assertEquals(expected, Json.tryValueDateTime(node, "jsJsonStringifyDate").get())
-        assertTrue(Json.tryValueDateTime(node, "missingNode").isEmpty)
+        // JS Date stringify representation aka ISO-8601 from strings
+        val jsJson = """{ "jsJsonStringifyDate": "2023-01-01T13:37:00.000Z" }"""
+        val jsNode = Json.parseObject(jsJson)
+
+        val expectedJsDateTime = LocalDateTime.of(2023, 1, 1, 13, 37, 0, 0)
+        assertEquals(expectedJsDateTime, Json.tryValueDateTime(jsNode, "jsJsonStringifyDate").get())
+        assertTrue(Json.tryValueDateTime(jsNode, "missingNode").isEmpty)
+
+        // ISO-8601 String representations like generated via Json.write (Jackson -> Jackson)
+        val jacksonJson = """{"date":"2023-01-01","time":"2023-01-01T13:37:00.123456"}"""
+        val jacksonNode = Json.parseObject(jacksonJson)
+
+        val expectedJacksonDate = LocalDate.of(2023, 1, 1)
+        val expectedJacksonDateTime = LocalDateTime.of(2023, 1, 1, 13, 37, 0, 123456000)
+        assertEquals(expectedJacksonDate, Json.tryValueDate(jacksonNode, "date").get())
+        assertEquals(expectedJacksonDateTime, Json.tryValueDateTime(jacksonNode, "time").get())
     }
 
     @Test

--- a/src/test/kotlin/sirius/kernel/commons/JsonTest.kt
+++ b/src/test/kotlin/sirius/kernel/commons/JsonTest.kt
@@ -15,6 +15,7 @@ import com.fasterxml.jackson.databind.node.ArrayNode
 import com.fasterxml.jackson.databind.node.ObjectNode
 import org.junit.jupiter.api.Assertions.assertThrows
 import org.junit.jupiter.api.Test
+import java.time.LocalDate
 import java.time.LocalDateTime
 import java.util.*
 import kotlin.test.assertEquals
@@ -41,11 +42,13 @@ class JsonTest {
 
     @Test
     fun `valid object is parsed properly`() {
-        val json = """{ "foo": 123, "bar": "baz" }"""
+        val json = """{"foo":123,"bar":"baz","date":"2023-01-01","time":"2023-01-01T13:37:00.123456"}"""
         val node = Json.parseObject(json)
-        assertEquals(2, node.size())
+        assertEquals(4, node.size())
         assertEquals(123, node["foo"].asInt())
         assertEquals("baz", node["bar"].asText())
+        assertEquals(LocalDate.of(2023, 1, 1), Json.tryValueDate(node, "date").get())
+        assertEquals(LocalDateTime.of(2023, 1, 1, 13, 37, 0, 123456000), Json.tryValueDateTime(node, "time").get())
     }
 
     @Test
@@ -85,9 +88,15 @@ class JsonTest {
 
     @Test
     fun `valid object is written properly`() {
-        val node = Json.createObject().put("foo", 123).put("bar", "baz")
+        val date = LocalDate.now()
+        val time = LocalDateTime.now()
+        val node = Json.createObject()
+                .put("foo", 123)
+                .put("bar", "baz")
+                .putPOJO("date", date)
+                .putPOJO("time", time)
         val json = Json.write(node)
-        assertEquals("""{"foo":123,"bar":"baz"}""", json)
+        assertEquals("""{"foo":123,"bar":"baz","date":"$date","time":"$time"}""", json)
     }
 
     @Test


### PR DESCRIPTION
Solves the following error message when trying to convert ja JsonNode which contains a `LocalDate` or `LocalDateTime` to a JSON string:

> Java 8 date/time type java.time.LocalDate not supported by default: add Module "com.fasterxml.jackson.datatype:jackson-datatype-jsr310" to enable handling


Fixes: [SIRI-736](https://scireum.myjetbrains.com/youtrack/issue/SIRI-736)