### PR TITLE
Makes Amount serialized as number in json

### DIFF
--- a/src/main/java/sirius/kernel/commons/Amount.java
+++ b/src/main/java/sirius/kernel/commons/Amount.java
@@ -241,6 +241,7 @@ public class Amount extends Number implements Comparable<Amount>, Serializable {
      * @return the internally used <tt>BigDecimal</tt>
      */
     @Nullable
+    @JsonValue
     public BigDecimal getAmount() {
         return value;
     }
@@ -915,7 +916,6 @@ public class Amount extends Number implements Comparable<Amount>, Serializable {
      * @return the amount formatted in a language independent matter and rounded to two decimal digits or an empty
      * string if the underlying amount is empty
      */
-    @JsonValue
     public String toMachineString() {
         if (isEmpty()) {
             return "";


### PR DESCRIPTION
- previous attempt using toMachineString indeed worked in some cases (in combination with Json#getValueAmount), but using the BigDecimal representation will make Jackson handle all cases properly