### PR TITLE
Adjusts regex to only match valid html tags starting with letters 

### DIFF
--- a/src/main/java/sirius/kernel/commons/Strings.java
+++ b/src/main/java/sirius/kernel/commons/Strings.java
@@ -575,7 +575,7 @@ public class Strings {
         return value;
     }
 
-    private static final Pattern DETECT_XML_REGEX = Pattern.compile("<[a-zA-Z0-9]+[^>]*>");
+    private static final Pattern DETECT_XML_REGEX = Pattern.compile("</?[a-zA-Z][^>]*>");
 
     /**
      * Determines if the given content contains XML tags.

--- a/src/main/java/sirius/kernel/commons/Strings.java
+++ b/src/main/java/sirius/kernel/commons/Strings.java
@@ -575,7 +575,11 @@ public class Strings {
         return value;
     }
 
-    private static final Pattern DETECT_XML_REGEX = Pattern.compile("</?[a-zA-Z][^>]*>");
+    /**
+     * Defines a regular expression to detect XML tags.
+     */
+    public static final String REGEX_XML_TAG = "</?[a-zA-Z][^>]*>";
+    private static final Pattern DETECT_XML_REGEX = Pattern.compile(REGEX_XML_TAG);
 
     /**
      * Determines if the given content contains XML tags.

--- a/src/main/java/sirius/kernel/commons/Strings.java
+++ b/src/main/java/sirius/kernel/commons/Strings.java
@@ -576,10 +576,9 @@ public class Strings {
     }
 
     /**
-     * Defines a regular expression to detect XML tags.
+     * Defines a pattern (regular expression) to detect XML tags.
      */
-    public static final String REGEX_XML_TAG = "</?[a-zA-Z][^>]*>";
-    private static final Pattern DETECT_XML_REGEX = Pattern.compile(REGEX_XML_TAG);
+    public static final Pattern PATTERN_DETECT_XML = Pattern.compile("</?[a-zA-Z][^>]*>");
 
     /**
      * Determines if the given content contains XML tags.
@@ -592,7 +591,7 @@ public class Strings {
             return false;
         }
 
-        return DETECT_XML_REGEX.matcher(content).find();
+        return PATTERN_DETECT_XML.matcher(content).find();
     }
 
     /**

--- a/src/test/java/sirius/kernel/commons/StringsTest.java
+++ b/src/test/java/sirius/kernel/commons/StringsTest.java
@@ -181,6 +181,7 @@ class StringsTest {
         assertTrue(Strings.probablyContainsXml("<br />"));
         assertTrue(Strings.probablyContainsXml("<br test=\"foo\">"));
         assertFalse(Strings.probablyContainsXml("foo having < 3 m, with >= 3 m"));
+        assertFalse(Strings.probablyContainsXml("foo having <3 m, with > 3 m"));
     }
 
     @Test


### PR DESCRIPTION
Fixes: [OX-10290](https://scireum.myjetbrains.com/youtrack/issue/OX-10290)