### PR TITLE
JSON: Allows correctly fetching array node from constructed json tree

### DIFF
--- a/src/test/kotlin/sirius/kernel/commons/JsonTest.kt
+++ b/src/test/kotlin/sirius/kernel/commons/JsonTest.kt
@@ -216,9 +216,39 @@ class JsonTest {
     }
 
     @Test
+    fun `tryGetArrayAtIndex works with arrays as POJO Nodes`() {
+        val node = Json.createArray().addPOJO(listOf(1, 2, 3)).add(123)
+
+        val presentArray: Optional<ArrayNode> = Json.tryGetArrayAtIndex(node, 0)
+        assertTrue(presentArray.isPresent)
+        assertEquals(3, presentArray.get().size())
+
+        val notAnArray: Optional<ArrayNode> = Json.tryGetArrayAtIndex(node, 1)
+        assertTrue(!notAnArray.isPresent)
+
+        val missingArray: Optional<ArrayNode> = Json.tryGetArrayAtIndex(node, 2)
+        assertTrue(!missingArray.isPresent)
+    }
+
+    @Test
     fun `tryGetArray works as expected`() {
         val json = """{ "foo": [1, 2, 3], "bar": 123 }"""
         val node = Json.parseObject(json)
+
+        val presentArray: Optional<ArrayNode> = Json.tryGetArray(node, "foo")
+        assertTrue(presentArray.isPresent)
+        assertEquals(3, presentArray.get().size())
+
+        val notAnArray: Optional<ArrayNode> = Json.tryGetArray(node, "bar")
+        assertTrue(!notAnArray.isPresent)
+
+        val missingArray: Optional<ArrayNode> = Json.tryGetArray(node, "baz")
+        assertTrue(!missingArray.isPresent)
+    }
+
+    @Test
+    fun `tryGetArray works with arrays as POJO Nodes`() {
+        val node = Json.createObject().putPOJO("foo", listOf(1, 2, 3)).put("bar", 123)
 
         val presentArray: Optional<ArrayNode> = Json.tryGetArray(node, "foo")
         assertTrue(presentArray.isPresent)
@@ -244,6 +274,22 @@ class JsonTest {
         assertTrue(!notAnArray.isPresent)
 
         val missingArray: Optional<ArrayNode> = Json.tryGetArrayAt(node, Json.createPointer("baz"))
+        assertTrue(!missingArray.isPresent)
+    }
+
+    @Test
+    fun `tryGetArrayAt works with arrays as POJO Nodes`() {
+        val node = Json.createObject()
+                .set<ObjectNode>("nested", Json.createObject().putPOJO("foo", listOf(1, 2, 3)).put("bar", 123))
+
+        val presentArray: Optional<ArrayNode> = Json.tryGetArrayAt(node, Json.createPointer("nested/foo"))
+        assertTrue(presentArray.isPresent)
+        assertEquals(3, presentArray.get().size())
+
+        val notAnArray: Optional<ArrayNode> = Json.tryGetArrayAt(node, Json.createPointer("nested/bar"))
+        assertTrue(!notAnArray.isPresent)
+
+        val missingArray: Optional<ArrayNode> = Json.tryGetArrayAt(node, Json.createPointer("nested/baz"))
         assertTrue(!missingArray.isPresent)
     }
 


### PR DESCRIPTION
Previously problems arose within the array helper methods when calling them on JSON nodes that contained pojo list nodes instead of jackson ArrayNodes. As we do construct JSON objects quite often we expanded the logic of these methods to also correctly convert such nodes to ArrayNodes so they are properly returned instead of an empty optional.

Fixes: [SIRI-841](https://scireum.myjetbrains.com/youtrack/issue/SIRI-841)