### PR TITLE
Increases the maximum of parsed JSON strings

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.scireum</groupId>
         <artifactId>sirius-parent</artifactId>
-        <version>10.2.0</version>
+        <version>10.2.1</version>
     </parent>
     <artifactId>sirius-kernel</artifactId>
     <name>SIRIUS kernel</name>

--- a/src/main/java/sirius/kernel/commons/Json.java
+++ b/src/main/java/sirius/kernel/commons/Json.java
@@ -11,6 +11,7 @@ package sirius.kernel.commons;
 import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.core.JsonPointer;
 import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.StreamReadConstraints;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -61,6 +62,10 @@ public class Json {
                               .configure(JsonParser.Feature.ALLOW_SINGLE_QUOTES, true)
                               .disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS)
                               .registerModule(new JavaTimeModule());
+
+    static {
+        MAPPER.getFactory().setStreamReadConstraints(StreamReadConstraints.builder().maxStringLength(25_000_000).build());
+    }
 
     private Json() {
     }


### PR DESCRIPTION
The previous limit (5 mil) was a bit low for our use cases. The new limit shouldn't be a problem as newer versions of Jackson already use a default of 20 mil.

Fixes: [SIRI-883](https://scireum.myjetbrains.com/youtrack/issue/SIRI-883)