### PR TITLE
Detects entities in texts to decide if its xml

### DIFF
--- a/src/main/java/sirius/kernel/commons/StringCleanup.java
+++ b/src/main/java/sirius/kernel/commons/StringCleanup.java
@@ -181,7 +181,7 @@ public class StringCleanup {
                                                                       TAG_UL,
                                                                       TAG_LI);
 
-    private static final Pattern PATTERN_STRIP_XML = Pattern.compile("\\s*" + Strings.REGEX_DETECT_XML + "\\s*");
+    private static final Pattern PATTERN_STRIP_XML = Pattern.compile("\\s*" + Strings.REGEX_DETECT_XML_TAGS + "\\s*");
     private static final Map<Integer, String> unicodeMapping = new TreeMap<>();
 
     static {

--- a/src/main/java/sirius/kernel/commons/Strings.java
+++ b/src/main/java/sirius/kernel/commons/Strings.java
@@ -576,7 +576,7 @@ public class Strings {
     }
 
     protected static final String REGEX_DETECT_XML_TAGS = "</?[a-zA-Z][^>]*>";
-    protected static final String REGEX_DETECT_ENTITIES = "&[a-zA-Z]+[0-9]{0,2};";
+    protected static final String REGEX_DETECT_ENTITIES = "&#?[a-zA-Z0-9]*;";
     /**
      * Defines a pattern (regular expression) to detect XML tags and entities.
      */

--- a/src/main/java/sirius/kernel/commons/Strings.java
+++ b/src/main/java/sirius/kernel/commons/Strings.java
@@ -575,17 +575,19 @@ public class Strings {
         return value;
     }
 
-    protected static final String REGEX_DETECT_XML = "</?[a-zA-Z][^>]*>";
+    protected static final String REGEX_DETECT_XML_TAGS = "</?[a-zA-Z][^>]*>";
+    protected static final String REGEX_DETECT_ENTITIES = "&[a-zA-Z]+[0-9]{0,2};";
     /**
-     * Defines a pattern (regular expression) to detect XML tags.
+     * Defines a pattern (regular expression) to detect XML tags and entities.
      */
-    public static final Pattern PATTERN_DETECT_XML = Pattern.compile(REGEX_DETECT_XML);
+    public static final Pattern PATTERN_DETECT_XML =
+            Pattern.compile(Strings.join("|", REGEX_DETECT_XML_TAGS, REGEX_DETECT_ENTITIES));
 
     /**
-     * Determines if the given content contains XML tags.
+     * Determines if the given content contains XML tags or entities.
      *
      * @param content the content to check
-     * @return <tt>true</tt> if XML tags were found, <tt>false</tt> otherwise
+     * @return <tt>true</tt> if XML tags or entities were found, <tt>false</tt> otherwise
      */
     public static boolean probablyContainsXml(@Nullable String content) {
         if (Strings.isEmpty(content)) {

--- a/src/main/java/sirius/kernel/commons/Strings.java
+++ b/src/main/java/sirius/kernel/commons/Strings.java
@@ -576,7 +576,7 @@ public class Strings {
     }
 
     protected static final String REGEX_DETECT_XML_TAGS = "</?[a-zA-Z][^>]*>";
-    protected static final String REGEX_DETECT_ENTITIES = "&#?[a-zA-Z0-9]*;";
+    protected static final String REGEX_DETECT_ENTITIES = "&#?[a-zA-Z0-9]+;";
     /**
      * Defines a pattern (regular expression) to detect XML tags and entities.
      */

--- a/src/test/kotlin/sirius/kernel/commons/StringsTest.kt
+++ b/src/test/kotlin/sirius/kernel/commons/StringsTest.kt
@@ -264,8 +264,11 @@ class StringsTest {
         assertTrue(Strings.probablyContainsXml("<br test=\"foo\">"))
         assertTrue(Strings.probablyContainsXml("</div>"))
         assertTrue(Strings.probablyContainsXml("<namespace:element>"))
+        assertTrue(Strings.probablyContainsXml("test&amp;test"))
+        assertTrue(Strings.probablyContainsXml("test&frac12;test"))
         assertFalse(Strings.probablyContainsXml("foo having < 3 m, with >= 3 m"))
         assertFalse(Strings.probablyContainsXml("foo having <3 m, with > 3 m"))
+        assertFalse(Strings.probablyContainsXml("test & amp ; test"))
     }
 
     @Test

--- a/src/test/kotlin/sirius/kernel/commons/StringsTest.kt
+++ b/src/test/kotlin/sirius/kernel/commons/StringsTest.kt
@@ -270,6 +270,7 @@ class StringsTest {
         assertFalse(Strings.probablyContainsXml("foo having < 3 m, with >= 3 m"))
         assertFalse(Strings.probablyContainsXml("foo having <3 m, with > 3 m"))
         assertFalse(Strings.probablyContainsXml("test & amp ; test"))
+        assertFalse(Strings.probablyContainsXml("test &; test"))
     }
 
     @Test

--- a/src/test/kotlin/sirius/kernel/commons/StringsTest.kt
+++ b/src/test/kotlin/sirius/kernel/commons/StringsTest.kt
@@ -266,6 +266,7 @@ class StringsTest {
         assertTrue(Strings.probablyContainsXml("<namespace:element>"))
         assertTrue(Strings.probablyContainsXml("test&amp;test"))
         assertTrue(Strings.probablyContainsXml("test&frac12;test"))
+        assertTrue(Strings.probablyContainsXml("test&#x00F7;test"))
         assertFalse(Strings.probablyContainsXml("foo having < 3 m, with >= 3 m"))
         assertFalse(Strings.probablyContainsXml("foo having <3 m, with > 3 m"))
         assertFalse(Strings.probablyContainsXml("test & amp ; test"))


### PR DESCRIPTION
Texts that do not contain xml tags, but entities, should also be recognized as xml.

This facilitates the correct display of texts.