### PR TITLE
Configurable Outcall blacklisting

### DIFF
--- a/src/main/java/sirius/kernel/xml/Outcall.java
+++ b/src/main/java/sirius/kernel/xml/Outcall.java
@@ -437,10 +437,11 @@ public class Outcall {
     }
 
     private void connect() throws IOException {
-        checkTimeoutBlacklist();
         if (response != null) {
             return;
         }
+
+        checkTimeoutBlacklist();
 
         if (oAuthAccessToken != null) {
             setRequestProperty(HEADER_AUTHORIZATION, oAuthAccessToken.get());

--- a/src/main/java/sirius/kernel/xml/XMLCall.java
+++ b/src/main/java/sirius/kernel/xml/XMLCall.java
@@ -46,6 +46,19 @@ public class XMLCall {
     }
 
     /**
+     * Creates a new XMLCall for the given URI and Content-Type.
+     *
+     * @param uri         the target URI to call
+     * @param blacklistId the id for the blacklist to use.
+     * @param contentType the value of the Content-Type property for requests
+     * @throws IOException in case the URI is blacklisted
+     */
+    protected XMLCall(URI uri, String blacklistId, String contentType) throws IOException {
+        this.outcall = new Outcall(uri, blacklistId);
+        this.outcall.setRequestProperty("Content-Type", contentType);
+    }
+
+    /**
      * Creates a new XMLCall for the given url with Content-Type 'text/xml'.
      *
      * @param url the target URL to call

--- a/src/main/java/sirius/kernel/xml/XMLCall.java
+++ b/src/main/java/sirius/kernel/xml/XMLCall.java
@@ -38,23 +38,9 @@ public class XMLCall {
      *
      * @param uri         the target URI to call
      * @param contentType the value of the Content-Type property for requests
-     * @throws IOException in case the URI is blacklisted
      */
-    protected XMLCall(URI uri, String contentType) throws IOException {
+    protected XMLCall(URI uri, String contentType) {
         this.outcall = new Outcall(uri);
-        this.outcall.setRequestProperty("Content-Type", contentType);
-    }
-
-    /**
-     * Creates a new XMLCall for the given URI and Content-Type.
-     *
-     * @param uri         the target URI to call
-     * @param blacklistId the id for the blacklist to use.
-     * @param contentType the value of the Content-Type property for requests
-     * @throws IOException in case the URI is blacklisted
-     */
-    protected XMLCall(URI uri, String blacklistId, String contentType) throws IOException {
-        this.outcall = new Outcall(uri, blacklistId);
         this.outcall.setRequestProperty("Content-Type", contentType);
     }
 


### PR DESCRIPTION
Add a blacklistid to finely adjust the Outcalls blacklisting.
This is needed for proxying servers that redirects connections to different sub servers based on configurated ids.
If one of those servers has a timeout the whole host is blocked even when other sub servers doesn't have problems.

Fixes: [SIRI-893](https://scireum.myjetbrains.com/youtrack/issue/SIRI-893)