### PR TITLE
Reduces logging for blacklisted hosts

### DIFF
--- a/src/main/java/sirius/kernel/xml/Outcall.java
+++ b/src/main/java/sirius/kernel/xml/Outcall.java
@@ -15,6 +15,7 @@ import sirius.kernel.commons.Explain;
 import sirius.kernel.commons.Monoflop;
 import sirius.kernel.commons.Streams;
 import sirius.kernel.commons.Strings;
+import sirius.kernel.commons.Tuple;
 import sirius.kernel.commons.Watch;
 import sirius.kernel.di.std.ConfigValue;
 import sirius.kernel.health.Average;
@@ -110,8 +111,11 @@ public class Outcall {
      * <p>
      * These hosts are blacklisted for a short amount of time ({@link #connectTimeoutBlacklistDuration}) to prevent
      * cascading failures.
+     * <p>
+     * We log a warning for each host which is blacklisted and is called again. To make sure this doesn't spam the logs,
+     * we only log once and then set the second value of the tuple to <tt>true</tt> to prevent further log messages.
      */
-    private static final Map<String, Long> timeoutBlacklist = new ConcurrentHashMap<>();
+    private static final Map<String, Tuple<Long, Boolean>> timeoutBlacklist = new ConcurrentHashMap<>();
 
     /**
      * If the {@link #timeoutBlacklist} contains more than the given number of entries, we remove all expired ones
@@ -500,15 +504,25 @@ public class Outcall {
             return;
         }
 
-        Long timeout = timeoutBlacklist.get(blacklistId);
-        if (timeout != null) {
-            if (timeout > System.currentTimeMillis()) {
+        Tuple<Long, Boolean> blacklistedHostInformation = timeoutBlacklist.get(blacklistId);
+        if(blacklistedHostInformation == null) {
+            return;
+        }
+
+        Long timeout = blacklistedHostInformation.getFirst();
+        if (timeout == null) {
+            return;
+        }
+
+        if (timeout > System.currentTimeMillis()) {
+            if (Boolean.FALSE.equals(blacklistedHostInformation.getSecond())) {
+                blacklistedHostInformation.setSecond(true);
                 throw new IOException(Strings.apply(
                         "Connections with blacklist identifier %s are currently rejected due to connectivity issues.",
                         blacklistId));
-            } else {
-                timeoutBlacklist.remove(blacklistId);
             }
+        } else {
+            timeoutBlacklist.remove(blacklistId);
         }
     }
 
@@ -518,11 +532,11 @@ public class Outcall {
         }
 
         long now = System.currentTimeMillis();
-        timeoutBlacklist.put(blacklistId, now + connectTimeoutBlacklistDuration.toMillis());
+        timeoutBlacklist.put(blacklistId, new Tuple<>(now + connectTimeoutBlacklistDuration.toMillis(), false));
         if (timeoutBlacklist.size() > TIMEOUT_BLACKLIST_HIGH_WATERMARK) {
             // We collected a bunch of hosts - try to some cleanup (remove all hosts for which the timeout expired)...
             timeoutBlacklist.forEach((id, timeout) -> {
-                if (timeout < now) {
+                if (timeout.getFirst() < now) {
                     timeoutBlacklist.remove(id);
                 }
             });

--- a/src/main/java/sirius/kernel/xml/Outcall.java
+++ b/src/main/java/sirius/kernel/xml/Outcall.java
@@ -505,7 +505,7 @@ public class Outcall {
         }
 
         Tuple<Long, Boolean> blacklistedHostInformation = timeoutBlacklist.get(blacklistId);
-        if(blacklistedHostInformation == null) {
+        if (blacklistedHostInformation == null) {
             return;
         }
 
@@ -532,7 +532,7 @@ public class Outcall {
         }
 
         long now = System.currentTimeMillis();
-        timeoutBlacklist.put(blacklistId, new Tuple<>(now + connectTimeoutBlacklistDuration.toMillis(), false));
+        timeoutBlacklist.put(blacklistId, Tuple.create(now + connectTimeoutBlacklistDuration.toMillis(), false));
         if (timeoutBlacklist.size() > TIMEOUT_BLACKLIST_HIGH_WATERMARK) {
             // We collected a bunch of hosts - try to some cleanup (remove all hosts for which the timeout expired)...
             timeoutBlacklist.forEach((id, timeout) -> {


### PR DESCRIPTION
We log every attempt to call a blacklisted host again. This PR limits this logging to one message per host so that the logs are not flooded with frequent calls.