### PR TITLE
Allows defining a custom Content-Type header for SOAP requests.

### DIFF
--- a/src/main/java/sirius/kernel/xml/SOAPClient.java
+++ b/src/main/java/sirius/kernel/xml/SOAPClient.java
@@ -98,11 +98,13 @@ public class SOAPClient {
      */
     public static final String SOAP_TIMEOUT_CONFIG_KEY = "soap";
 
+    private static final String DEFAULT_CONTENT_TYPE_HEADER = "text/xml";
+
     private final URL endpoint;
     private final BasicNamespaceContext namespaceContext = new BasicNamespaceContext();
     private List<Attribute> namespaceDefinitions;
     private String actionPrefix = "";
-    private String contentTypeHeader = "text/xml";
+    private String contentTypeHeader = DEFAULT_CONTENT_TYPE_HEADER;
     private Consumer<XMLCall> callEnhancer;
     private final Map<String, URL> customEndpoints = new HashMap<>();
     private Consumer<BiConsumer<String, Object>> defaultParameterProvider;
@@ -172,7 +174,7 @@ public class SOAPClient {
 
     /**
      * Defines a custom value for the "Content-Type" HTTP header to use for requests. By default, the header is set
-     * to "text/xml".
+     * to {@link #DEFAULT_CONTENT_TYPE_HEADER}.
      *
      * @param contentTypeHeader the content type to use for requests
      * @return the client itself for fluent method calls

--- a/src/main/java/sirius/kernel/xml/SOAPClient.java
+++ b/src/main/java/sirius/kernel/xml/SOAPClient.java
@@ -102,6 +102,7 @@ public class SOAPClient {
     private final BasicNamespaceContext namespaceContext = new BasicNamespaceContext();
     private List<Attribute> namespaceDefinitions;
     private String actionPrefix = "";
+    private String contentTypeHeader = "text/xml";
     private Consumer<XMLCall> callEnhancer;
     private final Map<String, URL> customEndpoints = new HashMap<>();
     private Consumer<BiConsumer<String, Object>> defaultParameterProvider;
@@ -166,6 +167,18 @@ public class SOAPClient {
      */
     public SOAPClient withActionPrefix(@Nonnull String prefix) {
         this.actionPrefix = prefix;
+        return this;
+    }
+
+    /**
+     * Defines a custom value for the "Content-Type" HTTP header to use for requests. By default, the header is set
+     * to "text/xml".
+     *
+     * @param contentTypeHeader the content type to use for requests
+     * @return the client itself for fluent method calls
+     */
+    public SOAPClient withCustomContentTypeHeader(@Nonnull String contentTypeHeader) {
+        this.contentTypeHeader = contentTypeHeader;
         return this;
     }
 
@@ -311,7 +324,8 @@ public class SOAPClient {
 
         try (Operation op = new Operation(() -> Strings.apply("SOAP %s -> %s", action, effectiveEndpoint),
                                           Duration.ofSeconds(15))) {
-            XMLCall call = XMLCall.to(effectiveEndpoint.toURI()).withFineLogger(LOG, isDebugLogActive);
+            XMLCall call =
+                    XMLCall.to(effectiveEndpoint.toURI(), contentTypeHeader).withFineLogger(LOG, isDebugLogActive);
             call.getOutcall().withConfiguredTimeout(SOAP_TIMEOUT_CONFIG_KEY);
             call.withNamespaceContext(namespaceContext);
             if (callEnhancer != null) {


### PR DESCRIPTION
By default, the underlying XMLCall sets the header to "text/xml" if left underfined, but some servers may require a different header (e.g. "text/xml; charset=utf-8").

Fixes: SE-13428