### PR TITLE
Allow 1 and 0 for boolean values in Value#asBoolean

### DIFF
--- a/src/main/java/sirius/kernel/commons/AdvancedDateParser.java
+++ b/src/main/java/sirius/kernel/commons/AdvancedDateParser.java
@@ -27,7 +27,7 @@ import java.util.TreeSet;
  * A flexible parser for dates in various formats.
  * <p>
  * It can parse formats like DD.MM.YYYY, DD-MM-YYYY, MM/DD/YYYY or ISO dates like YYYY-MM-DDTHH:MM:SS along with some
- * modifiers as decribed below.
+ * modifiers as described below.
  * <p>
  * A valid expression is defined by the following grammar:
  * <ul>

--- a/src/main/java/sirius/kernel/commons/Value.java
+++ b/src/main/java/sirius/kernel/commons/Value.java
@@ -534,7 +534,7 @@ public class Value {
                 return (T) data;
             }
             String stringValue = String.valueOf(data).trim();
-            return (T) fastPathBoolean(stringValue).orElseGet(() -> NLS.parseMachineString(Boolean.class, stringValue));
+            return (T) parseWithoutNLS(stringValue).orElseGet(() -> NLS.parseMachineString(Boolean.class, stringValue));
         }
         if (data == null) {
             return defaultValue;
@@ -815,13 +815,18 @@ public class Value {
         }
 
         String stringValue = String.valueOf(data).trim();
-        return fastPathBoolean(stringValue).orElseGet(() -> {
+        return parseWithoutNLS(stringValue).orElseGet(() -> {
             return Objects.requireNonNullElse(NLS.parseUserString(Boolean.class, stringValue), defaultValue);
         });
     }
 
-    // fast-track for common boolean cases without the need to involve NLS framework
-    private Optional<Boolean> fastPathBoolean(String value) {
+    /**
+     * Fast-track for common boolean cases without the need to involve NLS framework
+     *
+     * @param value the value to parse
+     * @return an optional boolean value
+     */
+    private Optional<Boolean> parseWithoutNLS(String value) {
         if ("true".equalsIgnoreCase(value) || "1".equals(value)) {
             return Optional.of(true);
         }

--- a/src/main/java/sirius/kernel/commons/Value.java
+++ b/src/main/java/sirius/kernel/commons/Value.java
@@ -802,7 +802,7 @@ public class Value {
      *
      * @param defaultValue the value to be used if the wrapped value cannot be converted to a boolean.
      * @return <tt>true</tt> if the wrapped value is <tt>true</tt>
-     * or if the string representation of it is {@code "true"}. Returns <tt>false</tt> otherwise,
+     * or if the string representation of it is {@code "true"} or {@code "1!"}. Returns <tt>false</tt> otherwise,
      * especially if the wrapped value is <tt>null</tt>
      */
     public boolean asBoolean(boolean defaultValue) {
@@ -813,16 +813,21 @@ public class Value {
             return booleanValue;
         }
 
-        // fast-track for common cases without the need to involve NLS framework
-        if ("true".equalsIgnoreCase(String.valueOf(data))) {
-            return true;
-        }
-        if ("false".equalsIgnoreCase(String.valueOf(data))) {
-            return false;
-        }
+        String stringValue = String.valueOf(data);
+        return fastPathBoolean(stringValue).orElseGet(() -> {
+            return Objects.requireNonNullElse(NLS.parseUserString(Boolean.class, stringValue.trim()), defaultValue);
+        });
+    }
 
-        return Objects.requireNonNullElse(NLS.parseUserString(Boolean.class, String.valueOf(data).trim()),
-                                          defaultValue);
+    // fast-track for common boolean cases without the need to involve NLS framework
+    private Optional<Boolean> fastPathBoolean(String value) {
+        if ("true".equalsIgnoreCase(value) || "1".equals(value)) {
+            return Optional.of(true);
+        }
+        if ("false".equalsIgnoreCase(value) || "0".equals(value)) {
+            return Optional.of(false);
+        }
+        return Optional.empty();
     }
 
     /**

--- a/src/main/java/sirius/kernel/commons/Value.java
+++ b/src/main/java/sirius/kernel/commons/Value.java
@@ -803,7 +803,7 @@ public class Value {
      *
      * @param defaultValue the value to be used if the wrapped value cannot be converted to a boolean.
      * @return <tt>true</tt> if the wrapped value is <tt>true</tt>
-     * or if the string representation of it is {@code "true"} or {@code "1!"}. Returns <tt>false</tt> otherwise,
+     * or if the string representation of it is {@code "true"} or {@code "1"}. Returns <tt>false</tt> otherwise,
      * especially if the wrapped value is <tt>null</tt>
      */
     public boolean asBoolean(boolean defaultValue) {

--- a/src/main/java/sirius/kernel/commons/Value.java
+++ b/src/main/java/sirius/kernel/commons/Value.java
@@ -528,12 +528,13 @@ public class Value {
     public <T> T coerce(Class<T> targetClazz, T defaultValue) {
         if (Boolean.class.equals(targetClazz) || boolean.class.equals(targetClazz)) {
             if (isEmptyString()) {
-                return (T) Boolean.FALSE;
+                return defaultValue != null ? defaultValue : (T) Boolean.FALSE;
             }
             if (data instanceof Boolean) {
                 return (T) data;
             }
-            return (T) NLS.parseMachineString(Boolean.class, String.valueOf(data));
+            String stringValue = String.valueOf(data).trim();
+            return (T) fastPathBoolean(stringValue).orElseGet(() -> NLS.parseMachineString(Boolean.class, stringValue));
         }
         if (data == null) {
             return defaultValue;
@@ -813,9 +814,9 @@ public class Value {
             return booleanValue;
         }
 
-        String stringValue = String.valueOf(data);
+        String stringValue = String.valueOf(data).trim();
         return fastPathBoolean(stringValue).orElseGet(() -> {
-            return Objects.requireNonNullElse(NLS.parseUserString(Boolean.class, stringValue.trim()), defaultValue);
+            return Objects.requireNonNullElse(NLS.parseUserString(Boolean.class, stringValue), defaultValue);
         });
     }
 

--- a/src/test/kotlin/sirius/kernel/commons/ValueTest.kt
+++ b/src/test/kotlin/sirius/kernel/commons/ValueTest.kt
@@ -114,12 +114,16 @@ class ValueTest {
     @Test
     fun `Test asBoolean with default`() {
         assertEquals(false, Value.of("").asBoolean(false))
-        assertEquals(false, Value.of("false").asBoolean(false))
-        assertEquals(true, Value.of("true").asBoolean(false))
         assertEquals(false, Value.of(false).asBoolean(false))
-        assertEquals(true, Value.of(true).asBoolean(false))
-        assertEquals(true, Value.of(NLS.get("NLS.yes")).asBoolean(false))
+        assertEquals(false, Value.of("false").asBoolean(false))
+        assertEquals(false, Value.of(0).asBoolean(false))
+        assertEquals(false, Value.of("0").asBoolean(false))
         assertEquals(false, Value.of(NLS.get("NLS.no")).asBoolean(false))
+        assertEquals(true, Value.of(true).asBoolean(false))
+        assertEquals(true, Value.of("true").asBoolean(false))
+        assertEquals(true, Value.of(1).asBoolean(false))
+        assertEquals(true, Value.of("1").asBoolean(false))
+        assertEquals(true, Value.of(NLS.get("NLS.yes")).asBoolean(false))
     }
 
     @Test

--- a/src/test/kotlin/sirius/kernel/commons/ValueTest.kt
+++ b/src/test/kotlin/sirius/kernel/commons/ValueTest.kt
@@ -135,12 +135,36 @@ class ValueTest {
     }
 
     @Test
-    fun `Test coerce boolean and without default`() {
+    fun `Test coerce boolean without default`() {
         assertEquals(false, Value.of("").coerce(Boolean::class.java, null))
         assertEquals(false, Value.of("false").coerce(Boolean::class.java, null))
         assertEquals(true, Value.of("true").coerce(Boolean::class.java, null))
+        assertEquals(false, Value.of("0").coerce(Boolean::class.java, null))
+        assertEquals(true, Value.of("1").coerce(Boolean::class.java, null))
         assertEquals(false, Value.of(false).coerce(Boolean::class.java, null))
         assertEquals(true, Value.of(true).coerce(Boolean::class.java, null))
+    }
+
+    @Test
+    fun `Test coerce boolean with default true`() {
+        assertEquals(true, Value.of("").coerce(Boolean::class.java, true))
+        assertEquals(false, Value.of("false").coerce(Boolean::class.java, true))
+        assertEquals(true, Value.of("true").coerce(Boolean::class.java, true))
+        assertEquals(false, Value.of("0").coerce(Boolean::class.java, true))
+        assertEquals(true, Value.of("1").coerce(Boolean::class.java, true))
+        assertEquals(false, Value.of(false).coerce(Boolean::class.java, true))
+        assertEquals(true, Value.of(true).coerce(Boolean::class.java, true))
+    }
+
+    @Test
+    fun `Test coerce boolean with default false`() {
+        assertEquals(false, Value.of("").coerce(Boolean::class.java, false))
+        assertEquals(false, Value.of("false").coerce(Boolean::class.java, false))
+        assertEquals(true, Value.of("true").coerce(Boolean::class.java, false))
+        assertEquals(false, Value.of("0").coerce(Boolean::class.java, false))
+        assertEquals(true, Value.of("1").coerce(Boolean::class.java, false))
+        assertEquals(false, Value.of(false).coerce(Boolean::class.java, false))
+        assertEquals(true, Value.of(true).coerce(Boolean::class.java, false))
     }
 
     @Test


### PR DESCRIPTION
in https://www.w3.org/TR/2004/REC-xmlschema-2-20041028/#boolean 1 and 0 are also allowed as valid boolean values. In Some places we read from XML and have StructuredNode.queryValue("VALUE_WITH_0_OR_1").asBoolean(false) which should also return true if the value is 1

BREAKING: Value#coerce(Boolean.class, true) now return true as expected and no longer false if the value is empty

- fixes: SE-13483