### PR TITLE
Amount without Trailing Zeros

### DIFF
--- a/src/main/java/sirius/kernel/commons/Amount.java
+++ b/src/main/java/sirius/kernel/commons/Amount.java
@@ -30,7 +30,7 @@ import java.util.function.Supplier;
  * <p>
  * Adds some extended computations as well as locale aware formatting options to perform "exact" computations on
  * numeric value. The internal representation is <tt>BigDecimal</tt> and uses MathContext.DECIMAL128 for
- * numerical operations. Also the scale of each value is fixed to 5 decimal places after the comma, since this is
+ * numerical operations. Also, the scale of each value is fixed to 5 decimal places after the comma, since this is
  * enough for most business applications and rounds away any rounding errors introduced by doubles.
  * <p>
  * A textual representation can be created by calling one of the <tt>toString</tt> methods or by supplying
@@ -39,7 +39,7 @@ import java.util.function.Supplier;
  * Note that {@link #toMachineString()} to be used to obtain a technical representation suitable for file formats
  * like XML etc. This is also used by {@link NLS#toMachineString(Object)}. The default representation uses two
  * decimal digits. However, if the amount has bed {@link #round(int, RoundingMode) rounded}, the given amount
- * of decimals will be used in all subesquent call to {@link #toMachineString()}. Therefore, this can be used to
+ * of decimals will be used in all subsequent call to {@link #toMachineString()}. Therefore, this can be used to
  * control the exact formatting (e.g. when writing XML or JSON).
  * <p>
  * Being able to be <i>empty</i>, this class handles <tt>null</tt> values gracefully, which simplifies many operations.

--- a/src/main/java/sirius/kernel/commons/Amount.java
+++ b/src/main/java/sirius/kernel/commons/Amount.java
@@ -22,6 +22,7 @@ import java.math.BigDecimal;
 import java.math.MathContext;
 import java.math.RoundingMode;
 import java.text.DecimalFormat;
+import java.util.Optional;
 import java.util.function.Consumer;
 import java.util.function.Supplier;
 
@@ -245,6 +246,22 @@ public class Amount extends Number implements Comparable<Amount>, Serializable {
     @Nullable
     public BigDecimal getAmount() {
         return value;
+    }
+
+    /**
+     * Unwraps the internally used <tt>BigDecimal</tt> like {@link #getAmount()}, but also strips trailing zeros from
+     * the decimal part.
+     *
+     * @return the amount with trailing zeros stripped of the decimal part
+     */
+    @Nullable
+    public BigDecimal fetchAmountWithoutTrailingZeros() {
+        return Optional.ofNullable(value)
+                       .map(BigDecimal::stripTrailingZeros)
+                       .map(bigDecimal -> bigDecimal.scale() < 0 ?
+                                          bigDecimal.setScale(0, RoundingMode.UNNECESSARY) :
+                                          bigDecimal)
+                       .orElse(null);
     }
 
     /**

--- a/src/test/kotlin/sirius/kernel/commons/AmountTest.kt
+++ b/src/test/kotlin/sirius/kernel/commons/AmountTest.kt
@@ -374,4 +374,20 @@ class AmountTest {
 
         assertEquals(result, a.remainder(b))
     }
+
+    @ParameterizedTest
+    @CsvSource(
+        delimiter = '|', textBlock = """
+        0.420          | 0.42
+        1.0            | 1
+        200            | 200
+        200.0000       | 200
+        600.010        | 600.01"""
+    )
+    fun `getAmountWithoutTrailingZeros() works as expected`(
+        @ConvertWith(AmountConverter::class) a: Amount,
+        result: String,
+    ) {
+        assertEquals(result, a.fetchAmountWithoutTrailingZeros()?.toPlainString())
+    }
 }

--- a/src/test/kotlin/sirius/kernel/commons/AmountTest.kt
+++ b/src/test/kotlin/sirius/kernel/commons/AmountTest.kt
@@ -160,7 +160,7 @@ class AmountTest {
 
     @ParameterizedTest
     @CsvSource(
-            delimiter = '|', textBlock = """
+        delimiter = '|', textBlock = """
         4.2            | 42             | 46.2
         42             | 4.2            | 46.2
         0              | 42             | 42 
@@ -169,9 +169,9 @@ class AmountTest {
         42             |                | 42 """
     )
     fun `add() works as expected`(
-            @ConvertWith(AmountConverter::class) a: Amount,
-            @ConvertWith(AmountConverter::class) b: Amount,
-            @ConvertWith(AmountConverter::class) result: Amount,
+        @ConvertWith(AmountConverter::class) a: Amount,
+        @ConvertWith(AmountConverter::class) b: Amount,
+        @ConvertWith(AmountConverter::class) result: Amount,
     ) {
 
         assertEquals(result, a.add(b))
@@ -179,7 +179,7 @@ class AmountTest {
 
     @ParameterizedTest
     @CsvSource(
-            delimiter = '|', textBlock = """
+        delimiter = '|', textBlock = """
         4.2            | 42             | -37.8
         42             | 4.2            | 37.8
          0             | 42             | -42
@@ -188,9 +188,9 @@ class AmountTest {
         42             |                | 42 """
     )
     fun `subtract() works as expected`(
-            @ConvertWith(AmountConverter::class) a: Amount,
-            @ConvertWith(AmountConverter::class) b: Amount,
-            @ConvertWith(AmountConverter::class) result: Amount,
+        @ConvertWith(AmountConverter::class) a: Amount,
+        @ConvertWith(AmountConverter::class) b: Amount,
+        @ConvertWith(AmountConverter::class) result: Amount,
     ) {
 
         assertEquals(result, a.subtract(b))
@@ -198,7 +198,7 @@ class AmountTest {
 
     @ParameterizedTest
     @CsvSource(
-            delimiter = '|', textBlock = """
+        delimiter = '|', textBlock = """
         4.2            | 42             | 176.4
         42             | 4.2            | 176.4
         0              | 42             | 0
@@ -207,16 +207,16 @@ class AmountTest {
         42             |                |   """
     )
     fun `times() works as expected`(
-            @ConvertWith(AmountConverter::class) a: Amount,
-            @ConvertWith(AmountConverter::class) b: Amount,
-            @ConvertWith(AmountConverter::class) result: Amount,
+        @ConvertWith(AmountConverter::class) a: Amount,
+        @ConvertWith(AmountConverter::class) b: Amount,
+        @ConvertWith(AmountConverter::class) result: Amount,
     ) {
         assertEquals(result, a.times(b))
     }
 
     @ParameterizedTest
     @CsvSource(
-            delimiter = '|', textBlock = """
+        delimiter = '|', textBlock = """
         4.2            | 42             | 0.1
         42             | 4.2            | 10
         0              | 42             | 0
@@ -225,16 +225,16 @@ class AmountTest {
         42             |                |    """
     )
     fun `divideBy() works as expected`(
-            @ConvertWith(AmountConverter::class) a: Amount,
-            @ConvertWith(AmountConverter::class) b: Amount,
-            @ConvertWith(AmountConverter::class) result: Amount,
+        @ConvertWith(AmountConverter::class) a: Amount,
+        @ConvertWith(AmountConverter::class) b: Amount,
+        @ConvertWith(AmountConverter::class) result: Amount,
     ) {
         assertEquals(result, a.divideBy(b))
     }
 
     @ParameterizedTest
     @CsvSource(
-            delimiter = '|', textBlock = """
+        delimiter = '|', textBlock = """
         4.2            | -4.2
         -4.2           | 4.2
         42             | -42
@@ -243,15 +243,15 @@ class AmountTest {
                        |    """
     )
     fun `negate() works as expected`(
-            @ConvertWith(AmountConverter::class) a: Amount,
-            @ConvertWith(AmountConverter::class) result: Amount,
+        @ConvertWith(AmountConverter::class) a: Amount,
+        @ConvertWith(AmountConverter::class) result: Amount,
     ) {
         assertEquals(result, a.negate())
     }
 
     @ParameterizedTest
     @CsvSource(
-            delimiter = '|', textBlock = """
+        delimiter = '|', textBlock = """
         4.2            | 10             | 4.62
         0              | 42             | 0
         42             | 0              | 42
@@ -259,9 +259,9 @@ class AmountTest {
         42             |                | 42 """
     )
     fun `increasePercent() works as expected`(
-            @ConvertWith(AmountConverter::class) a: Amount,
-            @ConvertWith(AmountConverter::class) b: Amount,
-            @ConvertWith(AmountConverter::class) result: Amount,
+        @ConvertWith(AmountConverter::class) a: Amount,
+        @ConvertWith(AmountConverter::class) b: Amount,
+        @ConvertWith(AmountConverter::class) result: Amount,
     ) {
 
         assertEquals(result, a.increasePercent(b))
@@ -269,7 +269,7 @@ class AmountTest {
 
     @ParameterizedTest
     @CsvSource(
-            delimiter = '|', textBlock = """
+        delimiter = '|', textBlock = """
         4.2            | 10             | 3.78
         0              | 42             | 0
         42             | 0              | 42
@@ -277,9 +277,9 @@ class AmountTest {
         42             |                | 42"""
     )
     fun `decreasePercent() works as expected`(
-            @ConvertWith(AmountConverter::class) a: Amount,
-            @ConvertWith(AmountConverter::class) b: Amount,
-            @ConvertWith(AmountConverter::class) result: Amount,
+        @ConvertWith(AmountConverter::class) a: Amount,
+        @ConvertWith(AmountConverter::class) b: Amount,
+        @ConvertWith(AmountConverter::class) result: Amount,
     ) {
 
         assertEquals(result, a.decreasePercent(b))
@@ -287,7 +287,7 @@ class AmountTest {
 
     @ParameterizedTest
     @CsvSource(
-            delimiter = '|', textBlock = """
+        delimiter = '|', textBlock = """
         4.2            | 42             | 10
         0              | 42             | 0
         42             | 0              | 
@@ -295,9 +295,9 @@ class AmountTest {
         42             |                | """
     )
     fun `percentageOf() works as expected`(
-            @ConvertWith(AmountConverter::class) a: Amount,
-            @ConvertWith(AmountConverter::class) b: Amount,
-            @ConvertWith(AmountConverter::class) result: Amount,
+        @ConvertWith(AmountConverter::class) a: Amount,
+        @ConvertWith(AmountConverter::class) b: Amount,
+        @ConvertWith(AmountConverter::class) result: Amount,
     ) {
 
         assertEquals(result, a.percentageOf(b))
@@ -305,7 +305,7 @@ class AmountTest {
 
     @ParameterizedTest
     @CsvSource(
-            delimiter = '|', textBlock = """
+        delimiter = '|', textBlock = """
         4.62           | 4.2            | 10
         0              | 42             | -100
         42             | 0              | 
@@ -313,9 +313,9 @@ class AmountTest {
         42             |                |  """
     )
     fun `percentageDifferenceOf() works as expected`(
-            @ConvertWith(AmountConverter::class) a: Amount,
-            @ConvertWith(AmountConverter::class) b: Amount,
-            @ConvertWith(AmountConverter::class) result: Amount,
+        @ConvertWith(AmountConverter::class) a: Amount,
+        @ConvertWith(AmountConverter::class) b: Amount,
+        @ConvertWith(AmountConverter::class) result: Amount,
     ) {
 
         assertEquals(result, a.percentageDifferenceOf(b))
@@ -323,7 +323,7 @@ class AmountTest {
 
     @ParameterizedTest
     @CsvSource(
-            delimiter = '|', textBlock = """
+        delimiter = '|', textBlock = """
         0.42           | 42
         1              | 100
         2              | 200
@@ -331,8 +331,8 @@ class AmountTest {
                        |  """
     )
     fun `toPercent() works as expected`(
-            @ConvertWith(AmountConverter::class) a: Amount,
-            @ConvertWith(AmountConverter::class) result: Amount,
+        @ConvertWith(AmountConverter::class) a: Amount,
+        @ConvertWith(AmountConverter::class) result: Amount,
     ) {
 
         assertEquals(result, a.toPercent())
@@ -341,7 +341,7 @@ class AmountTest {
 
     @ParameterizedTest
     @CsvSource(
-            delimiter = '|', textBlock = """
+        delimiter = '|', textBlock = """
         42                 | 0.42
         100                | 1
         200                | 2
@@ -349,8 +349,8 @@ class AmountTest {
                            |  """
     )
     fun `asDecimal() works as expected`(
-            @ConvertWith(AmountConverter::class) a: Amount,
-            @ConvertWith(AmountConverter::class) result: Amount,
+        @ConvertWith(AmountConverter::class) a: Amount,
+        @ConvertWith(AmountConverter::class) result: Amount,
     ) {
 
         assertEquals(result, a.asDecimal())
@@ -358,7 +358,7 @@ class AmountTest {
 
     @ParameterizedTest
     @CsvSource(
-            delimiter = '|', textBlock = """
+        delimiter = '|', textBlock = """
         10             | 2              | 0
         10             | 3              | 1
         10             | 0              | 
@@ -367,9 +367,9 @@ class AmountTest {
         10             |                |  """
     )
     fun `remainder() works as expected`(
-            @ConvertWith(AmountConverter::class) a: Amount,
-            @ConvertWith(AmountConverter::class) b: Amount,
-            @ConvertWith(AmountConverter::class) result: Amount,
+        @ConvertWith(AmountConverter::class) a: Amount,
+        @ConvertWith(AmountConverter::class) b: Amount,
+        @ConvertWith(AmountConverter::class) result: Amount,
     ) {
 
         assertEquals(result, a.remainder(b))


### PR DESCRIPTION
Adds method allowing to obtain the value of an `Amount` as `BigDecimal` without unnecessary trailing zeros.