### PR TITLE
 Extends the limit method in order to support preserving chars at the end of the input

### DIFF
--- a/src/main/java/sirius/kernel/commons/Strings.java
+++ b/src/main/java/sirius/kernel/commons/Strings.java
@@ -395,6 +395,42 @@ public class Strings {
     }
 
     /**
+     * Truncates the given string while preserving characters at the end. Also adds a truncated signal in the middle to
+     * indicate that the string was truncated.
+     * <p>
+     * Note:
+     * The truncated string consists of three parts:
+     * <ul>
+     *     <li>
+     *         start - this is the first part of the string for which the algorithm tries to calculate an effective
+     *         length. This is done by subtracting the length of the truncated signal (13) and the characters to
+     *         preserve at the end from the given <tt>length</tt>. If for some reason the calculated effective length is
+     *         negative, the original provided length is taken. This means that the total length of the returned string
+     *         could be length + 13 + charactersToPreserveAtTheEnd. This is only the case if either the length is very
+     *         small or the charactersToPreserveAtTheEnd is ridiculously high.
+     *     </li>
+     *     <li>
+     *         middle - this is the truncated signal which is added in the middle of the truncated string. It consists
+     *         of 13 characters in total (<tt>…[truncated]…</tt>).
+     *     </li>
+     *     <li>
+     *         end - this is the last part of the original string and contains the characters which should be
+     *         preserved at the end of the input.
+     *     </li>
+     * </ul>
+     *
+     * @param input                        the object which string representation should be limited to the given length
+     * @param length                       the max. number of characters to return
+     * @param charactersToPreserveAtTheEnd the number of characters to preserve at the end of the string
+     * @return the truncated string with a signal in the middle and characters preserved at the end, or the full string
+     * if the <tt>input</tt> is shorter than the given length + charactersToPreserveAtTheEnd. However,
+     * if input is <tt>null</tt>, "" is returned.
+     */
+    public static String truncateMiddle(@Nullable Object input, int length, int charactersToPreserveAtTheEnd) {
+        return limit(input, length, true, true, charactersToPreserveAtTheEnd);
+    }
+
+    /**
      * Limits the length of the given string to the given length.
      *
      * @param input                        the object which string representation should be limited to the given length
@@ -406,11 +442,11 @@ public class Strings {
      * than <tt>length</tt>, the full value is returned. If input is <tt>null</tt>, "" is returned.
      * If <tt>charactersToPreserveAtTheEnd</tt> is negativ it is omitted.
      */
-    public static String limit(@Nullable Object input,
-                               int length,
-                               boolean showEllipsis,
-                               boolean showTruncated,
-                               int charactersToPreserveAtTheEnd) {
+    private static String limit(@Nullable Object input,
+                                int length,
+                                boolean showEllipsis,
+                                boolean showTruncated,
+                                int charactersToPreserveAtTheEnd) {
         if (isEmpty(input)) {
             return "";
         }
@@ -424,15 +460,15 @@ public class Strings {
             charactersToPreserveAtTheEnd = 0;
         }
 
-        String signal = generateTruncatedSignal(showEllipsis, showTruncated, charactersToPreserveAtTheEnd > 0);
-        int effectiveLength = length - signal.length() - charactersToPreserveAtTheEnd;
+        String middle = generateTruncatedSignal(showEllipsis, showTruncated, charactersToPreserveAtTheEnd > 0);
+        int effectiveLength = length - middle.length() - charactersToPreserveAtTheEnd;
         if (effectiveLength < 0) {
             effectiveLength = length;
         }
 
-        String truncatedStr = str.substring(0, effectiveLength).trim();
+        String start = str.substring(0, effectiveLength).trim();
         String end = str.substring(str.length() - charactersToPreserveAtTheEnd).trim();
-        return truncatedStr + signal + end;
+        return start + middle + end;
     }
 
     private static String generateTruncatedSignal(boolean showEllipsis,

--- a/src/main/java/sirius/kernel/commons/Strings.java
+++ b/src/main/java/sirius/kernel/commons/Strings.java
@@ -452,8 +452,12 @@ public class Strings {
         }
 
         String str = String.valueOf(input).trim();
-        if (str.length() <= length + charactersToPreserveAtTheEnd || length < 0) {
+        if (str.length() <= length + charactersToPreserveAtTheEnd) {
             return str;
+        }
+
+        if (length < 0) {
+            length = 0;
         }
 
         if (charactersToPreserveAtTheEnd < 0) {

--- a/src/main/java/sirius/kernel/commons/Strings.java
+++ b/src/main/java/sirius/kernel/commons/Strings.java
@@ -39,6 +39,16 @@ import java.util.stream.Collectors;
 public class Strings {
 
     /**
+     * Contains the characters which should be used in order to depict an ellipsis.
+     */
+    private static final String ELLIPSIS = "…";
+
+    /**
+     * Contains the marker which should be used to depict that the string has been truncated.
+     */
+    private static final String TRUNCATED_MARKER = "[truncated]";
+
+    /**
      * Contains all characters which can safely be used for codes without too much confusion (e.g. 0 vs O are
      * excluded).
      */
@@ -410,22 +420,19 @@ public class Strings {
             return str;
         }
 
-        final String ellipsis = "…";
-        final String truncated = "[truncated]";
-
         if (charactersToPreserveAtTheEnd < 0) {
             charactersToPreserveAtTheEnd = 0;
         }
 
         StringBuilder signal = new StringBuilder();
         if (showEllipsis) {
-            signal.append(ellipsis);
+            signal.append(ELLIPSIS);
         }
         if (showTruncated) {
-            signal.append(truncated);
+            signal.append(TRUNCATED_MARKER);
         }
         if (charactersToPreserveAtTheEnd > 0 && showTruncated && showEllipsis) {
-            signal.append(ellipsis);
+            signal.append(ELLIPSIS);
         }
 
         int effectiveLength = length - signal.length() - charactersToPreserveAtTheEnd;

--- a/src/main/java/sirius/kernel/commons/Strings.java
+++ b/src/main/java/sirius/kernel/commons/Strings.java
@@ -451,17 +451,17 @@ public class Strings {
             return "";
         }
 
-        String str = String.valueOf(input).trim();
-        if (str.length() <= length + charactersToPreserveAtTheEnd) {
-            return str;
-        }
-
         if (length < 0) {
             length = 0;
         }
 
         if (charactersToPreserveAtTheEnd < 0) {
             charactersToPreserveAtTheEnd = 0;
+        }
+
+        String str = String.valueOf(input).trim();
+        if (str.length() <= length + charactersToPreserveAtTheEnd) {
+            return str;
         }
 
         String middle = generateTruncatedSignal(showEllipsis, showTruncated, charactersToPreserveAtTheEnd > 0);

--- a/src/main/java/sirius/kernel/commons/Strings.java
+++ b/src/main/java/sirius/kernel/commons/Strings.java
@@ -381,15 +381,61 @@ public class Strings {
      * than <tt>length</tt>, the full value is returned. If input is <tt>null</tt>, "" is returned.
      */
     public static String limit(@Nullable Object input, int length, boolean showEllipsis) {
+        return limit(input, length, showEllipsis, false, 0);
+    }
+
+    /**
+     * Limits the length of the given string to the given length.
+     *
+     * @param input the object which string representation should be limited to the given length
+     * @param length the max. number of characters to return
+     * @param showEllipsis whether to append three dots if <tt>input</tt> is longer than <tt>length</tt>
+     * @param showTruncated whether to append a marker/signal if <tt>input</tt> is longer than <tt>length</tt>
+     * @param charactersToPreserveAtTheEnd the number of characters to preserve at the end of the string
+     * @return a part of the string representation of the given <tt>input</tt>. If input is shorter
+     * than <tt>length</tt>, the full value is returned. If input is <tt>null</tt>, "" is returned.
+     * If <tt>charactersToPreserveAtTheEnd</tt> is negativ it is omitted.
+     */
+    public static String limit(@Nullable Object input,
+                               int length,
+                               boolean showEllipsis,
+                               boolean showTruncated,
+                               int charactersToPreserveAtTheEnd) {
         if (isEmpty(input)) {
             return "";
         }
+
         String str = String.valueOf(input).trim();
-        if (str.length() > length) {
-            return str.substring(0, (showEllipsis ? length - 1 : length)) + (showEllipsis ? "…" : "");
-        } else {
+        if (str.length() <= length) {
             return str;
         }
+
+        final String ellipsis = "…";
+        final String truncated = "[truncated]";
+
+        if (charactersToPreserveAtTheEnd < 0) {
+            charactersToPreserveAtTheEnd = 0;
+        }
+
+        StringBuilder signal = new StringBuilder();
+        if (showEllipsis) {
+            signal.append(ellipsis);
+        }
+        if (showTruncated) {
+            signal.append(truncated);
+        }
+        if (charactersToPreserveAtTheEnd > 0 && showTruncated && showEllipsis) {
+            signal.append(ellipsis);
+        }
+
+        int effectiveLength = length - signal.length() - charactersToPreserveAtTheEnd;
+        if (effectiveLength < 0) {
+            effectiveLength = length;
+        }
+
+        String truncatedStr = str.substring(0, effectiveLength).trim();
+        String end = str.substring(str.length() - charactersToPreserveAtTheEnd).trim();
+        return truncatedStr + signal + end;
     }
 
     /**

--- a/src/main/java/sirius/kernel/commons/Strings.java
+++ b/src/main/java/sirius/kernel/commons/Strings.java
@@ -465,7 +465,7 @@ public class Strings {
         }
 
         String middle = generateTruncatedSignal(showEllipsis, showTruncated, charactersToPreserveAtTheEnd > 0);
-        int effectiveLength = length - middle.length() - charactersToPreserveAtTheEnd;
+        int effectiveLength = length - middle.length();
         if (effectiveLength < 0) {
             effectiveLength = length;
         }

--- a/src/main/java/sirius/kernel/commons/Strings.java
+++ b/src/main/java/sirius/kernel/commons/Strings.java
@@ -403,15 +403,19 @@ public class Strings {
      * <ul>
      *     <li>
      *         start - this is the first part of the string for which the algorithm tries to calculate an effective
-     *         length. This is done by subtracting the length of the truncated signal (13) and the characters to
-     *         preserve at the end from the given <tt>length</tt>. If for some reason the calculated effective length is
-     *         negative, the original provided length is taken. This means that the total length of the returned string
-     *         could be length + 13 + charactersToPreserveAtTheEnd. This is only the case if either the length is very
-     *         small or the charactersToPreserveAtTheEnd is ridiculously high.
+     *         length. This is done by subtracting the length of the truncated signal (12 or 13) from the given length.
+     *         If the provided length is smaller then 13 or 14 the truncated signal length is omitted from the
+     *         calculation. In this case the input will be truncated to the given length, and the truncated signal will
+     *         be added at the end. This means that in this particular case the <tt>start</tt> string will have a length
+     *         of the provided length + 13 or length + 12. The truncated signal has either 12 or 13 characters,
+     *         depending on charactersToPreserveAtTheEnd. If charactersToPreserveAtTheEnd is greater than 0, the
+     *         truncated signal will have an additional ellipsis at the end, and therefore 13 characters in total.
      *     </li>
      *     <li>
      *         middle - this is the truncated signal which is added in the middle of the truncated string. It consists
-     *         of 13 characters in total (<tt>…[truncated]…</tt>).
+     *         of 12 or 13 characters in total (<tt>…[truncated]</tt> or <tt>…[truncated]…</tt>). depending on
+     *         charactersToPreserveAtTheEnd. If charactersToPreserveAtTheEnd is greater than 0, the truncated signal
+     *         will have an additional ellipsis at the end, and therefore 13 characters in total.
      *     </li>
      *     <li>
      *         end - this is the last part of the original string and contains the characters which should be

--- a/src/main/java/sirius/kernel/commons/Strings.java
+++ b/src/main/java/sirius/kernel/commons/Strings.java
@@ -424,17 +424,7 @@ public class Strings {
             charactersToPreserveAtTheEnd = 0;
         }
 
-        StringBuilder signal = new StringBuilder();
-        if (showEllipsis) {
-            signal.append(ELLIPSIS);
-        }
-        if (showTruncated) {
-            signal.append(TRUNCATED_MARKER);
-        }
-        if (charactersToPreserveAtTheEnd > 0 && showTruncated && showEllipsis) {
-            signal.append(ELLIPSIS);
-        }
-
+        String signal = generateTruncatedSignal(showEllipsis, showTruncated, charactersToPreserveAtTheEnd > 0);
         int effectiveLength = length - signal.length() - charactersToPreserveAtTheEnd;
         if (effectiveLength < 0) {
             effectiveLength = length;
@@ -443,6 +433,22 @@ public class Strings {
         String truncatedStr = str.substring(0, effectiveLength).trim();
         String end = str.substring(str.length() - charactersToPreserveAtTheEnd).trim();
         return truncatedStr + signal + end;
+    }
+
+    private static String generateTruncatedSignal(boolean showEllipsis,
+                                                  boolean showTruncated,
+                                                  boolean preserveCharactersAtEnd) {
+        StringBuilder signal = new StringBuilder();
+        if (showEllipsis) {
+            signal.append(ELLIPSIS);
+        }
+        if (showTruncated) {
+            signal.append(TRUNCATED_MARKER);
+        }
+        if (preserveCharactersAtEnd && showTruncated && showEllipsis) {
+            signal.append(ELLIPSIS);
+        }
+        return signal.toString();
     }
 
     /**

--- a/src/main/java/sirius/kernel/commons/Strings.java
+++ b/src/main/java/sirius/kernel/commons/Strings.java
@@ -387,10 +387,10 @@ public class Strings {
     /**
      * Limits the length of the given string to the given length.
      *
-     * @param input the object which string representation should be limited to the given length
-     * @param length the max. number of characters to return
-     * @param showEllipsis whether to append three dots if <tt>input</tt> is longer than <tt>length</tt>
-     * @param showTruncated whether to append a marker/signal if <tt>input</tt> is longer than <tt>length</tt>
+     * @param input                        the object which string representation should be limited to the given length
+     * @param length                       the max. number of characters to return
+     * @param showEllipsis                 whether to append three dots if <tt>input</tt> is longer than <tt>length</tt>
+     * @param showTruncated                whether to append a marker/signal if <tt>input</tt> is longer than <tt>length</tt>
      * @param charactersToPreserveAtTheEnd the number of characters to preserve at the end of the string
      * @return a part of the string representation of the given <tt>input</tt>. If input is shorter
      * than <tt>length</tt>, the full value is returned. If input is <tt>null</tt>, "" is returned.

--- a/src/main/java/sirius/kernel/commons/Strings.java
+++ b/src/main/java/sirius/kernel/commons/Strings.java
@@ -406,7 +406,7 @@ public class Strings {
         }
 
         String str = String.valueOf(input).trim();
-        if (str.length() <= length) {
+        if (str.length() <= length + charactersToPreserveAtTheEnd || length < 0) {
             return str;
         }
 

--- a/src/main/java/sirius/kernel/commons/Strings.java
+++ b/src/main/java/sirius/kernel/commons/Strings.java
@@ -463,9 +463,9 @@ public class Strings {
             charactersToPreserveAtTheEnd = 0;
         }
 
-        String str = String.valueOf(input).trim();
-        if (str.length() <= length + charactersToPreserveAtTheEnd) {
-            return str;
+        String trimmedInputString = String.valueOf(input).trim();
+        if (trimmedInputString.length() <= length + charactersToPreserveAtTheEnd) {
+            return trimmedInputString;
         }
 
         String middle = generateTruncatedSignal(showEllipsis, showTruncated, charactersToPreserveAtTheEnd > 0);
@@ -474,8 +474,8 @@ public class Strings {
             effectiveLength = length;
         }
 
-        String start = str.substring(0, effectiveLength).trim();
-        String end = str.substring(str.length() - charactersToPreserveAtTheEnd).trim();
+        String start = trimmedInputString.substring(0, effectiveLength).trim();
+        String end = trimmedInputString.substring(trimmedInputString.length() - charactersToPreserveAtTheEnd).trim();
         return start + middle + end;
     }
 

--- a/src/test/kotlin/sirius/kernel/commons/StringsTest.kt
+++ b/src/test/kotlin/sirius/kernel/commons/StringsTest.kt
@@ -332,4 +332,90 @@ class StringsTest {
         assertEquals("", Strings.limit("ABCDEFGHIJKLMNOP", -1000, false))
     }
 
+    @Test
+    fun truncatedMiddle() {
+        // Szenario 1: no input present
+        assertEquals("", Strings.truncateMiddle(null, 10, 10))
+        assertEquals("", Strings.truncateMiddle(null, 1, 10))
+        assertEquals("", Strings.truncateMiddle(null, 10, 1))
+        assertEquals("", Strings.truncateMiddle(null, 0, 1))
+        assertEquals("", Strings.truncateMiddle(null, 1, 0))
+        assertEquals("", Strings.truncateMiddle(null, 1, -1))
+        assertEquals("", Strings.truncateMiddle(null, -1, 0))
+        assertEquals("", Strings.truncateMiddle(null, -1, -1))
+        assertEquals("", Strings.truncateMiddle(null, 0, 0))
+        // Szenario 2: input present but empty
+        assertEquals("", Strings.truncateMiddle("", 10, 10))
+        assertEquals("", Strings.truncateMiddle("", 1, 10))
+        assertEquals("", Strings.truncateMiddle("", 10, 1))
+        assertEquals("", Strings.truncateMiddle("", 0, 1))
+        assertEquals("", Strings.truncateMiddle("", 1, 0))
+        assertEquals("", Strings.truncateMiddle("", 1, -1))
+        assertEquals("", Strings.truncateMiddle("", -1, 0))
+        assertEquals("", Strings.truncateMiddle("", -1, -1))
+        assertEquals("", Strings.truncateMiddle("", 0, 0))
+        // Szenario 3: input present and length is greater than input.length() and charactersToPreserveAtTheEnd is 0 or negative
+        assertEquals("ABCDEFG", Strings.truncateMiddle("ABCDEFG", 10, 0))
+        assertEquals("ABCDEFG", Strings.truncateMiddle("ABCDEFG", 10, -10))
+        // Szenario 4: input present and length is smaller than input.length() and charactersToPreserveAtTheEnd is 0 or negative
+        assertEquals("ABCDEFG-AB…[truncated]", Strings.truncateMiddle("ABCDEFG-ABCDEFG", 10, 0))
+        assertEquals("ABCDEFG-AB…[truncated]", Strings.truncateMiddle("ABCDEFG-ABCDEFG", 10, -10))
+        assertEquals("ABCDEFG-AB…[truncated]", Strings.truncateMiddle("ABCDEFG-ABCDEFG-ABCDEFG-ABCDEFG-ABCDEFG-ABCDEFG", 10, -10))
+        // Szenario 5: input present and length is equal to input.length() and charactersToPreserveAtTheEnd is 0 or negative
+        assertEquals("ABCDEFG", Strings.truncateMiddle("ABCDEFG", 7, 0))
+        assertEquals("ABCDEFG", Strings.truncateMiddle("ABCDEFG", 7, -10))
+        // Szenario 6: input present and length is 0 and charactersToPreserveAtTheEnd is 0 or negative
+        assertEquals("…[truncated]", Strings.truncateMiddle("ABCDEFG", 0, 0))
+        assertEquals("…[truncated]", Strings.truncateMiddle("ABCDEFG", 0, -10))
+        // Szenario 7: input present and length is negative and charactersToPreserveAtTheEnd is 0 or negative
+        assertEquals("…[truncated]", Strings.truncateMiddle("ABCDEFG", -10, 0))
+        assertEquals("…[truncated]", Strings.truncateMiddle("ABCDEFG", -10, -10))
+        // Szenario 8: input present and length is greater than input.length() and charactersToPreserveAtTheEnd is greater than length
+        assertEquals("ABCDEFG", Strings.truncateMiddle("ABCDEFG", 10, 10000))
+        assertEquals("ABCDEFG", Strings.truncateMiddle("ABCDEFG", 10, 11))
+        // Szenario 9: input present and length is greater than input.length() and charactersToPreserveAtTheEnd is greater than input.length()
+        assertEquals("ABCDEFG", Strings.truncateMiddle("ABCDEFG", 10, 8))
+        // Szenario 10: input present and length is greater than input.length() and charactersToPreserveAtTheEnd is equal to input.length()
+        assertEquals("ABCDEFG", Strings.truncateMiddle("ABCDEFG", 10, 7))
+        // Szenario 11: input present and length is smaller than input.length() and charactersToPreserveAtTheEnd is greater than length and length + charactersToPreserveAtTheEnd is smaller than input.length()
+        // Note: the ellipsis after the truncated signal is only added if there are characters to preserve at the end
+        // Note: the length of the truncated signal is only taken into account when limiting the input to length if length is greater than 13, otherwise the input will be truncated to the provided length and the truncated signal is added afterward
+        assertEquals("ABCDEFG-…[truncated]…This is the important part", Strings.truncateMiddle("ABCDEFG-ABCDEFG-This is the important part", 8, 26))
+        assertEquals("ABCDEFG-".length, 8)
+        assertEquals("This is the important part".length, 26)
+        // Szenario 12: input present and length is smaller than input.length() and charactersToPreserveAtTheEnd is greater than length and length + charactersToPreserveAtTheEnd is greater than input.length()
+        // Note: in the following case it is assumed that the whole string should be preserved because charactersToPreserveAtTheEnd is greater than input.length()
+        assertEquals("ABCDEFG-ABCDEFG-This is the important part", Strings.truncateMiddle("ABCDEFG-ABCDEFG-This is the important part", 0, 260))
+        assertEquals("ABCDEFG-ABCDEFG-This is the important part", Strings.truncateMiddle("ABCDEFG-ABCDEFG-This is the important part", -10, 260))
+        // Szenario 13: input present and length is smaller than input.length() and charactersToPreserveAtTheEnd is equal to length and length + charactersToPreserveAtTheEnd is equal to input.length()
+        // Note: in the following case it is assumed that the whole string should be preserved because length + charactersToPreserveAtTheEnd is equal to input.length()
+        assertEquals("ABCDEFG-ABCDEFG-This is the important part", Strings.truncateMiddle("ABCDEFG-ABCDEFG-This is the important part", 21, 21))
+        assertEquals("ABCDEFG-ABCDEFG-This is the important part".length, 42)
+        // Szenario 14: input present and length is equal to input.length() and charactersToPreserveAtTheEnd is greater than length
+        assertEquals("ABCDEFG", Strings.truncateMiddle("ABCDEFG", 7, 8))
+        // Szenario 15: input present and length is equal to input.length() and charactersToPreserveAtTheEnd is greater than input.length()
+        assertEquals("ABCDEFG", Strings.truncateMiddle("ABCDEFG", 7, 8000))
+        // Szenario 16: input present and length is equal to input.length() and charactersToPreserveAtTheEnd is equal to input.length()
+        assertEquals("ABCDEFG", Strings.truncateMiddle("ABCDEFG", 7, 7))
+        // Szenario 17: input present and length is 0 and charactersToPreserveAtTheEnd is greater than length
+        assertEquals("…[truncated]…FG", Strings.truncateMiddle("ABCDEFG", 0, 2))
+        // Szenario 18: input present and length is 0 and charactersToPreserveAtTheEnd is greater than input.length()
+        assertEquals("ABCDEFG", Strings.truncateMiddle("ABCDEFG", 0, 10))
+        // Szenario 19: input present and length is 0 and charactersToPreserveAtTheEnd is equal to input.length()
+        assertEquals("ABCDEFG", Strings.truncateMiddle("ABCDEFG", 0, 7))
+        // Szenario 20: input present and length is negative and charactersToPreserveAtTheEnd is greater than length
+        assertEquals("…[truncated]…DEFG", Strings.truncateMiddle("ABCDEFG", -10, 4))
+        // Szenario 21: input present and length is negative and charactersToPreserveAtTheEnd is greater than input.length()
+        assertEquals("ABCDEFG", Strings.truncateMiddle("ABCDEFG", -10, 40))
+        // Szenario 22: input present and length is negative and charactersToPreserveAtTheEnd is equal to input.length()
+        assertEquals("ABCDEFG", Strings.truncateMiddle("ABCDEFG", 0, 7))
+        // Szenario 23: input present and length is smaller then input.length() and charactersToPreserveAtTheEnd is smaller then input.length()
+        val boringPart = "0123456789-0123456789-0123456789-"
+        val importantPart = "This is the important part"
+        val input = boringPart + importantPart
+        assertEquals("0123456789…[truncated]…This is the important part", Strings.truncateMiddle(input, 23, 26))
+        assertEquals("0123456789…[truncated]…".length, 23)
+        assertEquals("This is the important part".length, 26)
+    }
+
 }

--- a/src/test/kotlin/sirius/kernel/commons/StringsTest.kt
+++ b/src/test/kotlin/sirius/kernel/commons/StringsTest.kt
@@ -301,14 +301,35 @@ class StringsTest {
 
     @Test
     fun limit() {
+        // Szenario 1: no input present
         assertEquals("", Strings.limit(null, 10, false))
         assertEquals("", Strings.limit(null, 10, true))
+        assertEquals("", Strings.limit(null, -10, true))
+        assertEquals("", Strings.limit(null, -10, false))
+        assertEquals("", Strings.limit(null, 0, true))
+        assertEquals("", Strings.limit(null, 0, false))
+        // Szenario 2: input present but empty
         assertEquals("", Strings.limit("", 10, false))
         assertEquals("", Strings.limit("", 10, true))
+        assertEquals("", Strings.limit("", -10, true))
+        assertEquals("", Strings.limit("", -10, false))
+        // Szenario 3: input present and length is greater than input.length()
         assertEquals("ABCDE", Strings.limit("ABCDE", 10, false))
         assertEquals("ABCDE", Strings.limit("ABCDE", 10, true))
+        // Szenario 4: input present and length is smaller than input.length()
         assertEquals("ABCDEFGHIJ", Strings.limit("ABCDEFGHIJKLMNOP", 10, false))
         assertEquals("ABCDEFGHI…", Strings.limit("ABCDEFGHIJKLMNOP", 10, true))
+        // Szenario 5: input present and length is equal to input.length()
+        assertEquals("ABCDEFGHIJKLMNOP", Strings.limit("ABCDEFGHIJKLMNOP", 16, false))
+        assertEquals("ABCDEFGHIJKLMNOP", Strings.limit("ABCDEFGHIJKLMNOP", 16, true))
+        // Szenario 6: input present and length is 0
+        assertEquals("", Strings.limit("ABCDE", 0, false))
+        assertEquals("…", Strings.limit("ABCDE", 0, true))
+        // Szenario 7: input present and length is negative
+        assertEquals("…", Strings.limit("ABCDE", -1, true))
+        assertEquals("", Strings.limit("ABCDE", -7, false))
+        assertEquals("…", Strings.limit("ABCDEFGHIJKLMNOP", -9, true))
+        assertEquals("", Strings.limit("ABCDEFGHIJKLMNOP", -1000, false))
     }
 
 }


### PR DESCRIPTION
- This is helpful when truncating error messages as often the helpful information is at the end of the String.
- Also adds an option to add a marker/signal which states that the input has been truncated to increase the visibility for a user reading the truncated String.
- Also handles negativ `length`

![Bildschirmfoto 2024-05-16 um 14 56 04](https://github.com/scireum/sirius-kernel/assets/106659278/37cf474c-27c8-49c3-99bb-e46f75ab7676)


### Additional Notes

- This PR fixes or works on following ticket(s): [SIRI-960](https://scireum.myjetbrains.com/youtrack/issue/SIRI-960)

### Checklist

- [x] Code change has been tested and works locally
- [x] Code was formatted via IntelliJ and follows SonarLint & [best practices](https://scireum.myjetbrains.com/youtrack/articles/MISC-A-16/CodeStyle-JavaDoc)

