### PR TITLE
Strings.limit - Fixes IndexOutOfBoundsException for length values lesser than 1

### DIFF
--- a/src/main/java/sirius/kernel/commons/Strings.java
+++ b/src/main/java/sirius/kernel/commons/Strings.java
@@ -375,13 +375,13 @@ public class Strings {
      * Limits the length of the given string to the given length.
      *
      * @param input        the object which string representation should be limited to the given length
-     * @param length       the max. number of characters to return
+     * @param length       the max. number of characters to return. Note: If the parameter is less than 1 an empty string is returned.
      * @param showEllipsis whether to append three dots if <tt>input</tt> is longer than <tt>length</tt>
      * @return a part of the string representation of the given <tt>input</tt>. If input is shorter
-     * than <tt>length</tt>, the full value is returned. If input is <tt>null</tt>, "" is returned.
+     * than <tt>length</tt>, the full value is returned. If input is <tt>null</tt> or empty "" is returned. This also applies if <tt>length</tt> is less than 1.
      */
     public static String limit(@Nullable Object input, int length, boolean showEllipsis) {
-        if (isEmpty(input) || length < 0) {
+        if (isEmpty(input) || length <= 0) {
             return "";
         }
         String str = String.valueOf(input).trim();

--- a/src/main/java/sirius/kernel/commons/Strings.java
+++ b/src/main/java/sirius/kernel/commons/Strings.java
@@ -378,7 +378,7 @@ public class Strings {
      * @param length       the max. number of characters to return. Note: If the parameter is less than 1 an empty string is returned.
      * @param showEllipsis whether to append three dots if <tt>input</tt> is longer than <tt>length</tt>
      * @return a part of the string representation of the given <tt>input</tt>. If input is shorter
-     * than <tt>length</tt>, the full value is returned. If input is <tt>null</tt> or empty "" is returned. This also applies if <tt>length</tt> is less than 1.
+     * than <tt>length</tt>, the full value is returned. If input is <tt>null</tt> or empty, "" is returned. This also applies if <tt>length</tt> is less than 1.
      */
     public static String limit(@Nullable Object input, int length, boolean showEllipsis) {
         if (isEmpty(input) || length <= 0) {

--- a/src/main/java/sirius/kernel/commons/Strings.java
+++ b/src/main/java/sirius/kernel/commons/Strings.java
@@ -381,7 +381,7 @@ public class Strings {
      * than <tt>length</tt>, the full value is returned. If input is <tt>null</tt>, "" is returned.
      */
     public static String limit(@Nullable Object input, int length, boolean showEllipsis) {
-        if (isEmpty(input)) {
+        if (isEmpty(input) || length < 0) {
             return "";
         }
         String str = String.valueOf(input).trim();

--- a/src/test/kotlin/sirius/kernel/commons/StringsTest.kt
+++ b/src/test/kotlin/sirius/kernel/commons/StringsTest.kt
@@ -303,12 +303,16 @@ class StringsTest {
     fun limit() {
         assertEquals("", Strings.limit(null, 10, false))
         assertEquals("", Strings.limit(null, 10, true))
+        assertEquals("", Strings.limit(null, -10, true))
         assertEquals("", Strings.limit("", 10, false))
         assertEquals("", Strings.limit("", 10, true))
+        assertEquals("", Strings.limit("", -10, true))
         assertEquals("ABCDE", Strings.limit("ABCDE", 10, false))
         assertEquals("ABCDE", Strings.limit("ABCDE", 10, true))
+        assertEquals("", Strings.limit("ABCDE", -10, true))
         assertEquals("ABCDEFGHIJ", Strings.limit("ABCDEFGHIJKLMNOP", 10, false))
         assertEquals("ABCDEFGHI…", Strings.limit("ABCDEFGHIJKLMNOP", 10, true))
+        assertEquals("", Strings.limit("ABCDEFGHIJKLMNOP", -10, true))
     }
 
 }

--- a/src/test/kotlin/sirius/kernel/commons/StringsTest.kt
+++ b/src/test/kotlin/sirius/kernel/commons/StringsTest.kt
@@ -314,6 +314,9 @@ class StringsTest {
         assertEquals("ABCDEFGHI…", Strings.limit("ABCDEFGHIJKLMNOP", 10, true))
         assertEquals("", Strings.limit("ABCDEFGHIJKLMNOP", -10, true))
         assertEquals("", Strings.limit("A", 0, true))
+        assertEquals("", Strings.limit("A", 0, false))
+        assertEquals("A", Strings.limit("A", 1, true))
+        assertEquals("A", Strings.limit("A", 1, false))
     }
 
 }

--- a/src/test/kotlin/sirius/kernel/commons/StringsTest.kt
+++ b/src/test/kotlin/sirius/kernel/commons/StringsTest.kt
@@ -313,6 +313,7 @@ class StringsTest {
         assertEquals("ABCDEFGHIJ", Strings.limit("ABCDEFGHIJKLMNOP", 10, false))
         assertEquals("ABCDEFGHI…", Strings.limit("ABCDEFGHIJKLMNOP", 10, true))
         assertEquals("", Strings.limit("ABCDEFGHIJKLMNOP", -10, true))
+        assertEquals("", Strings.limit("A", 0, true))
     }
 
 }


### PR DESCRIPTION
### Additional Notes

- This PR fixes or works on following ticket(s): [SIRI-960](https://scireum.myjetbrains.com/youtrack/issue/SIRI-960)


### Checklist

- [x] Code change has been tested and works locally
- [x] Code was formatted via IntelliJ and follows SonarLint & [best practices](https://scireum.myjetbrains.com/youtrack/articles/MISC-A-16/CodeStyle-JavaDoc)

