### PR TITLE
Introduces `truncateMiddle` which is capable of truncating a string in the middle

### DIFF
--- a/src/main/java/sirius/kernel/commons/Strings.java
+++ b/src/main/java/sirius/kernel/commons/Strings.java
@@ -39,6 +39,16 @@ import java.util.stream.Collectors;
 public class Strings {
 
     /**
+     * Contains the characters which should be used in order to depict an ellipsis.
+     */
+    private static final String ELLIPSIS = "…";
+
+    /**
+     * Contains the marker/signal which should be used to depict that the string has been truncated.
+     */
+    private static final String TRUNCATED_SIGNAL = ELLIPSIS + "[truncated]" + ELLIPSIS;
+
+    /**
      * Contains all characters which can safely be used for codes without too much confusion (e.g. 0 vs O are
      * excluded).
      */
@@ -386,7 +396,7 @@ public class Strings {
         }
         String str = String.valueOf(input).trim();
         if (str.length() > length) {
-            return str.substring(0, (showEllipsis ? length - 1 : length)) + (showEllipsis ? "…" : "");
+            return str.substring(0, (showEllipsis ? length - ELLIPSIS.length() : length)) + (showEllipsis ? ELLIPSIS : "");
         } else {
             return str;
         }
@@ -412,15 +422,14 @@ public class Strings {
             return "";
         }
 
-        String middle = "…[truncated]…";
         String trimmedInputString = String.valueOf(input).trim();
-        if (trimmedInputString.length() <= charsToPreserve + middle.length()) {
+        if (trimmedInputString.length() <= charsToPreserve + TRUNCATED_SIGNAL.length()) {
             return trimmedInputString;
         }
 
         String start = trimmedInputString.substring(0, charsToPreserveFromStart).trim();
         String end = trimmedInputString.substring(trimmedInputString.length() - charsToPreserveFromEnd).trim();
-        return start + middle + end;
+        return start + TRUNCATED_SIGNAL + end;
     }
 
     /**

--- a/src/main/java/sirius/kernel/commons/Strings.java
+++ b/src/main/java/sirius/kernel/commons/Strings.java
@@ -412,14 +412,15 @@ public class Strings {
             return "";
         }
 
+        String middle = "…[truncated]…";
         String trimmedInputString = String.valueOf(input).trim();
-        if (trimmedInputString.length() <= charsToPreserve) {
+        if (trimmedInputString.length() <= charsToPreserve + middle.length()) {
             return trimmedInputString;
         }
 
         String start = trimmedInputString.substring(0, charsToPreserveFromStart).trim();
         String end = trimmedInputString.substring(trimmedInputString.length() - charsToPreserveFromEnd).trim();
-        return start + "…[truncated]…" + end;
+        return start + middle + end;
     }
 
     /**

--- a/src/main/java/sirius/kernel/commons/Strings.java
+++ b/src/main/java/sirius/kernel/commons/Strings.java
@@ -388,7 +388,7 @@ public class Strings {
      * @param length       the max. number of characters to return. Note: If the parameter is less than 1 an empty string is returned.
      * @param showEllipsis whether to append three dots if <tt>input</tt> is longer than <tt>length</tt>
      * @return a part of the string representation of the given <tt>input</tt>. If input is shorter
-     * than <tt>length</tt>, the full value is returned. If input is <tt>null</tt> or empty, "" is returned. This also applies if <tt>length</tt> is less than 1.
+     * than <tt>length</tt>, the trimmed input value is returned. If input is <tt>null</tt> or empty, "" is returned. This also applies if <tt>length</tt> is less than 1.
      */
     public static String limit(@Nullable Object input, int length, boolean showEllipsis) {
         if (isEmpty(input) || length <= 0) {
@@ -406,13 +406,16 @@ public class Strings {
     /**
      * Truncates the given input in the middle by preserving characters from the start and end.
      * <p>
-     * Note: Adds a truncated signal in the form of "…[truncated]…" in the middle of the string.
+     * Note:
+     * Adds a truncated signal in the form of "…[truncated]…" in the middle of the string. This signal consist of 13 chars.
+     * The chars of the signal are considered when determining if a truncation is necessary. Therefore, a truncation only
+     * takes place if the input string is longer than <tt>charsToPreserveFromStart</tt> + <tt>charsToPreserveFromEnd</tt> + length of the truncated signal.
      *
      * @param input                    the input to truncate
      * @param charsToPreserveFromStart the number of characters to preserve from the start. Note that this value must be greater than or equal to 0.
      * @param charsToPreserveFromEnd   the number of characters to preserve from the end. Note that this value must be greater than or equal to 0.
      * @return a part of the string representation of the given <tt>input</tt> with a truncated signal added in the middle.
-     * If input is shorter than (<tt>charsToPreserveFromStart</tt> + <tt>charsToPreserveFromEnd</tt>), the full value is returned.
+     * If input is shorter than or equal to (<tt>charsToPreserveFromStart</tt> + <tt>charsToPreserveFromEnd</tt> + length of the truncated signal), the trimmed input value is returned.
      * If input is <tt>null</tt> or empty, "" is returned. This also applies if (<tt>charsToPreserveFromStart</tt> + <tt>charsToPreserveFromEnd</tt>) is 0.
      */
     public static String truncateMiddle(@Nullable Object input,

--- a/src/main/java/sirius/kernel/commons/Strings.java
+++ b/src/main/java/sirius/kernel/commons/Strings.java
@@ -393,6 +393,36 @@ public class Strings {
     }
 
     /**
+     * Truncates the given input in the middle by preserving characters from the start and end.
+     * <p>
+     * Note: Adds a truncated signal in the form of "…[truncated]…" in the middle of the string.
+     *
+     * @param input                    the input to truncate
+     * @param charsToPreserveFromStart the number of characters to preserve from the start. Note that this value must be greater than or equal to 0.
+     * @param charsToPreserveFromEnd   the number of characters to preserve from the end. Note that this value must be greater than or equal to 0.
+     * @return a part of the string representation of the given <tt>input</tt> with a truncated signal added in the middle.
+     * If input is shorter than (<tt>charsToPreserveFromStart</tt> + <tt>charsToPreserveFromEnd</tt>), the full value is returned.
+     * If input is <tt>null</tt> or empty, "" is returned. This also applies if (<tt>charsToPreserveFromStart</tt> + <tt>charsToPreserveFromEnd</tt>) is 0.
+     */
+    public static String truncateMiddle(@Nullable Object input,
+                                        int charsToPreserveFromStart,
+                                        int charsToPreserveFromEnd) {
+        int charsToPreserve = charsToPreserveFromStart + charsToPreserveFromEnd;
+        if (isEmpty(input) || charsToPreserveFromStart < 0 || charsToPreserveFromEnd < 0 || charsToPreserve == 0) {
+            return "";
+        }
+
+        String trimmedInputString = String.valueOf(input).trim();
+        if (trimmedInputString.length() <= charsToPreserve) {
+            return trimmedInputString;
+        }
+
+        String start = trimmedInputString.substring(0, charsToPreserveFromStart).trim();
+        String end = trimmedInputString.substring(trimmedInputString.length() - charsToPreserveFromEnd).trim();
+        return start + "…[truncated]…" + end;
+    }
+
+    /**
      * Returns a string representation of the given map.
      * <p>
      * Keys and values are separated by a colon (:) and entries by a new line.

--- a/src/main/java/sirius/kernel/commons/Strings.java
+++ b/src/main/java/sirius/kernel/commons/Strings.java
@@ -394,11 +394,12 @@ public class Strings {
         if (isEmpty(input) || length <= 0) {
             return "";
         }
-        String str = String.valueOf(input).trim();
-        if (str.length() > length) {
-            return str.substring(0, (showEllipsis ? length - ELLIPSIS.length() : length)) + (showEllipsis ? ELLIPSIS : "");
+        String trimmedInputString = String.valueOf(input).trim();
+        if (trimmedInputString.length() > length) {
+            return trimmedInputString.substring(0, (showEllipsis ? length - ELLIPSIS.length() : length))
+                   + (showEllipsis ? ELLIPSIS : "");
         } else {
-            return str;
+            return trimmedInputString;
         }
     }
 

--- a/src/main/java/sirius/kernel/commons/Strings.java
+++ b/src/main/java/sirius/kernel/commons/Strings.java
@@ -46,7 +46,7 @@ public class Strings {
     /**
      * Contains the marker/signal which should be used to depict that the string has been truncated.
      */
-    private static final String TRUNCATED_SIGNAL = ELLIPSIS + "[truncated]" + ELLIPSIS;
+    private static final String TRUNCATED_SIGNAL = ELLIPSIS + "[" + ELLIPSIS + "]" + ELLIPSIS;
 
     /**
      * Contains all characters which can safely be used for codes without too much confusion (e.g. 0 vs O are
@@ -407,7 +407,7 @@ public class Strings {
      * Truncates the given input in the middle by preserving characters from the start and end.
      * <p>
      * Note:
-     * Adds a truncated signal in the form of "…[truncated]…" in the middle of the string. This signal consist of 13 chars.
+     * Adds a truncated signal in the form of "…[…]…" in the middle of the string. This signal consist of 5 chars.
      * The chars of the signal are considered when determining if a truncation is necessary. Therefore, a truncation only
      * takes place if the input string is longer than <tt>charsToPreserveFromStart</tt> + <tt>charsToPreserveFromEnd</tt> + length of the truncated signal.
      *

--- a/src/test/kotlin/sirius/kernel/commons/StringsTest.kt
+++ b/src/test/kotlin/sirius/kernel/commons/StringsTest.kt
@@ -319,4 +319,25 @@ class StringsTest {
         assertEquals("A", Strings.limit("A", 1, false))
     }
 
+    @Test
+    fun truncateMiddle() {
+        assertEquals("", Strings.truncateMiddle(null, 4, 4))
+        assertEquals("", Strings.truncateMiddle(null, -4, 4))
+        assertEquals("", Strings.truncateMiddle(null, 4, -4))
+        assertEquals("", Strings.truncateMiddle("", 4, 4))
+        assertEquals("", Strings.truncateMiddle("", -4, 4))
+        assertEquals("", Strings.truncateMiddle("", 4, -4))
+        assertEquals("", Strings.truncateMiddle("1234-6789", -4, 4))
+        assertEquals("", Strings.truncateMiddle("1234-6789", 4, -4))
+        assertEquals("", Strings.truncateMiddle("1234-6789", -4, -4))
+        assertEquals("", Strings.truncateMiddle("1234-6789", 0, 0))
+        assertEquals("1234-6789", Strings.truncateMiddle("1234-6789", 40, 0))
+        assertEquals("1234-6789", Strings.truncateMiddle("1234-6789", 0, 40))
+        assertEquals("1234-6789", Strings.truncateMiddle("1234-6789", 5, 4))
+        assertEquals("1234-6789", Strings.truncateMiddle("1234-6789", 4, 5))
+        assertEquals("1234…[truncated]…6789", Strings.truncateMiddle("1234-6789", 4, 4))
+        assertEquals("…[truncated]…6789", Strings.truncateMiddle("1234-6789", 0, 4))
+        assertEquals("1234…[truncated]…", Strings.truncateMiddle("1234-6789", 4, 0))
+        assertEquals("1…[truncated]…9", Strings.truncateMiddle("1234-6789", 1, 1))
+    }
 }

--- a/src/test/kotlin/sirius/kernel/commons/StringsTest.kt
+++ b/src/test/kotlin/sirius/kernel/commons/StringsTest.kt
@@ -335,9 +335,14 @@ class StringsTest {
         assertEquals("1234-6789", Strings.truncateMiddle("1234-6789", 0, 40))
         assertEquals("1234-6789", Strings.truncateMiddle("1234-6789", 5, 4))
         assertEquals("1234-6789", Strings.truncateMiddle("1234-6789", 4, 5))
-        assertEquals("1234…[truncated]…6789", Strings.truncateMiddle("1234-6789", 4, 4))
-        assertEquals("…[truncated]…6789", Strings.truncateMiddle("1234-6789", 0, 4))
-        assertEquals("1234…[truncated]…", Strings.truncateMiddle("1234-6789", 4, 0))
-        assertEquals("1…[truncated]…9", Strings.truncateMiddle("1234-6789", 1, 1))
+        assertEquals("1234-6789", Strings.truncateMiddle("1234-6789", 4, 4))
+        assertEquals("1234-6789", Strings.truncateMiddle("1234-6789", 0, 4))
+        assertEquals("1234-6789", Strings.truncateMiddle("1234-6789", 4, 0))
+        assertEquals("1234-6789", Strings.truncateMiddle("1234-6789", 1, 1))
+        assertEquals("1234…[truncated]…6789", Strings.truncateMiddle("123456789-123456789-123456789", 4, 4))
+        assertEquals("…[truncated]…6789", Strings.truncateMiddle("123456789-123456789-123456789", 0, 4))
+        assertEquals("1234…[truncated]…", Strings.truncateMiddle("123456789-123456789-123456789", 4, 0))
+        assertEquals("1…[truncated]…9", Strings.truncateMiddle("123456789-123456789-123456789", 1, 1))
+        assertEquals("12345678901234", Strings.truncateMiddle("12345678901234", 6, 6))
     }
 }

--- a/src/test/kotlin/sirius/kernel/commons/StringsTest.kt
+++ b/src/test/kotlin/sirius/kernel/commons/StringsTest.kt
@@ -338,11 +338,11 @@ class StringsTest {
         assertEquals("1234-6789", Strings.truncateMiddle("1234-6789", 4, 4))
         assertEquals("1234-6789", Strings.truncateMiddle("1234-6789", 0, 4))
         assertEquals("1234-6789", Strings.truncateMiddle("1234-6789", 4, 0))
-        assertEquals("1234-6789", Strings.truncateMiddle("1234-6789", 1, 1))
-        assertEquals("1234…[truncated]…6789", Strings.truncateMiddle("123456789-123456789-123456789", 4, 4))
-        assertEquals("…[truncated]…6789", Strings.truncateMiddle("123456789-123456789-123456789", 0, 4))
-        assertEquals("1234…[truncated]…", Strings.truncateMiddle("123456789-123456789-123456789", 4, 0))
-        assertEquals("1…[truncated]…9", Strings.truncateMiddle("123456789-123456789-123456789", 1, 1))
+        assertEquals("123-456", Strings.truncateMiddle("123-456", 1, 1))
+        assertEquals("1234…[…]…6789", Strings.truncateMiddle("123456789-123456789-123456789", 4, 4))
+        assertEquals("…[…]…6789", Strings.truncateMiddle("123456789-123456789-123456789", 0, 4))
+        assertEquals("1234…[…]…", Strings.truncateMiddle("123456789-123456789-123456789", 4, 0))
+        assertEquals("1…[…]…9", Strings.truncateMiddle("123456789-123456789-123456789", 1, 1))
         assertEquals("12345678901234", Strings.truncateMiddle("12345678901234", 6, 6))
     }
 }


### PR DESCRIPTION
### Additional Notes

- This PR fixes or works on following ticket(s): [SIRI-960](https://scireum.myjetbrains.com/youtrack/issue/SIRI-960)


### Checklist

- [x] Code change has been tested and works locally
- [x] Code was formatted via IntelliJ and follows SonarLint & [best practices](https://scireum.myjetbrains.com/youtrack/articles/MISC-A-16/CodeStyle-JavaDoc)

