### PR TITLE
Adds date comparison methods

### DIFF
--- a/src/main/java/sirius/kernel/commons/Dates.java
+++ b/src/main/java/sirius/kernel/commons/Dates.java
@@ -8,6 +8,9 @@
 
 package sirius.kernel.commons;
 
+import com.google.common.collect.Range;
+
+import javax.annotation.Nonnull;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.Arrays;
@@ -42,10 +45,7 @@ public class Dates {
      * @return the latest date-time object or <tt>null</tt> if no date is given
      */
     public static LocalDateTime computeLatestDateTime(List<LocalDateTime> dateTimes) {
-        return dateTimes.stream()
-                        .filter(Objects::nonNull)
-                        .max(LocalDateTime::compareTo)
-                        .orElse(null);
+        return dateTimes.stream().filter(Objects::nonNull).max(LocalDateTime::compareTo).orElse(null);
     }
 
     /**
@@ -60,14 +60,12 @@ public class Dates {
 
     /**
      * Computes the latest date of the given date objects.
+     *
      * @param dates a list of date objects to compare
      * @return the latest date object or <tt>null</tt> if no date is given
      */
     public static LocalDate computeLatestDate(List<LocalDate> dates) {
-        return dates.stream()
-                    .filter(Objects::nonNull)
-                    .max(LocalDate::compareTo)
-                    .orElse(null);
+        return dates.stream().filter(Objects::nonNull).max(LocalDate::compareTo).orElse(null);
     }
 
     /**
@@ -87,10 +85,7 @@ public class Dates {
      * @return the earliest date-time object or <tt>null</tt> if no date is given
      */
     public static LocalDateTime computeEarliestDateTime(List<LocalDateTime> dateTimes) {
-        return dateTimes.stream()
-                        .filter(Objects::nonNull)
-                        .min(LocalDateTime::compareTo)
-                        .orElse(null);
+        return dateTimes.stream().filter(Objects::nonNull).min(LocalDateTime::compareTo).orElse(null);
     }
 
     /**
@@ -110,9 +105,42 @@ public class Dates {
      * @return the earliest date object or <tt>null</tt> if no date is given
      */
     public static LocalDate computeEarliestDate(List<LocalDate> dates) {
-        return dates.stream()
-                    .filter(Objects::nonNull)
-                    .min(LocalDate::compareTo)
-                    .orElse(null);
+        return dates.stream().filter(Objects::nonNull).min(LocalDate::compareTo).orElse(null);
+    }
+
+    /**
+     * Determines if the given date is before or after the given reference date.
+     *
+     * @param dateToCheck   the date to check
+     * @param referenceDate the reference date
+     * @return <tt>true</tt> if the date is before or after the reference date, <tt>false</tt> otherwise
+     */
+    public static boolean isBeforeOrEqual(@Nonnull LocalDate dateToCheck, @Nonnull LocalDate referenceDate) {
+        return Range.atMost(referenceDate).contains(dateToCheck);
+    }
+
+    /**
+     * Determines if the given date is after or equal to the given reference date.
+     *
+     * @param dateToCheck   the date to check
+     * @param referenceDate the reference date
+     * @return <tt>true</tt> if the date is after or equal to the reference date, <tt>false</tt> otherwise
+     */
+    public static boolean isAfterOrEqual(@Nonnull LocalDate dateToCheck, @Nonnull LocalDate referenceDate) {
+        return Range.atLeast(referenceDate).contains(dateToCheck);
+    }
+
+    /**
+     * Determines if the given date is within the given range.
+     *
+     * @param startDate   the range's start date
+     * @param endDate     the range's end date
+     * @param dateToCheck the date to check
+     * @return <tt>true</tt> if the date is within the range, <tt>false</tt> otherwise
+     */
+    public static boolean isWithinRange(@Nonnull LocalDate startDate,
+                                        @Nonnull LocalDate endDate,
+                                        @Nonnull LocalDate dateToCheck) {
+        return Range.closed(startDate, endDate).contains(dateToCheck);
     }
 }

--- a/src/main/java/sirius/kernel/commons/Dates.java
+++ b/src/main/java/sirius/kernel/commons/Dates.java
@@ -8,8 +8,6 @@
 
 package sirius.kernel.commons;
 
-import com.google.common.collect.Range;
-
 import javax.annotation.Nonnull;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
@@ -116,7 +114,7 @@ public class Dates {
      * @return <tt>true</tt> if the date is before or after the reference date, <tt>false</tt> otherwise
      */
     public static boolean isBeforeOrEqual(@Nonnull LocalDate dateToCheck, @Nonnull LocalDate referenceDate) {
-        return Range.atMost(referenceDate).contains(dateToCheck);
+        return dateToCheck.isBefore(referenceDate) || dateToCheck.equals(referenceDate);
     }
 
     /**
@@ -127,11 +125,11 @@ public class Dates {
      * @return <tt>true</tt> if the date is after or equal to the reference date, <tt>false</tt> otherwise
      */
     public static boolean isAfterOrEqual(@Nonnull LocalDate dateToCheck, @Nonnull LocalDate referenceDate) {
-        return Range.atLeast(referenceDate).contains(dateToCheck);
+        return dateToCheck.isAfter(referenceDate) || dateToCheck.equals(referenceDate);
     }
 
     /**
-     * Determines if the given date is within the given range.
+     * Determines if the given date is within the given range, inclusive the range dates.
      *
      * @param startDate   the range's start date
      * @param endDate     the range's end date
@@ -141,6 +139,6 @@ public class Dates {
     public static boolean isWithinRange(@Nonnull LocalDate startDate,
                                         @Nonnull LocalDate endDate,
                                         @Nonnull LocalDate dateToCheck) {
-        return Range.closed(startDate, endDate).contains(dateToCheck);
+        return isAfterOrEqual(dateToCheck, startDate) && isBeforeOrEqual(dateToCheck, endDate);
     }
 }

--- a/src/test/kotlin/sirius/kernel/commons/DatesTest.kt
+++ b/src/test/kotlin/sirius/kernel/commons/DatesTest.kt
@@ -10,7 +10,10 @@ package sirius.kernel.commons
 
 import java.time.LocalDate
 import java.time.LocalDateTime
-import kotlin.test.*
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
 
 /**
  * Tests the [Dates] class.
@@ -50,5 +53,36 @@ class DatesTest {
         val now = LocalDate.now()
         assertEquals(theDayBeforeYesterday, Dates.computeEarliestDate(null, theDayBeforeYesterday, now, yesterday))
         assertEquals(null, Dates.computeEarliestDate(null, null, null))
+    }
+
+    @Test
+    fun isBeforeOrEqual() {
+        val theDayBeforeYesterday = LocalDate.now().minusDays(2)
+        val yesterday = LocalDate.now().minusDays(1)
+        val now = LocalDate.now()
+        assertTrue(Dates.isBeforeOrEqual(theDayBeforeYesterday, yesterday))
+        assertTrue(Dates.isBeforeOrEqual(yesterday, yesterday))
+        assertFalse(Dates.isBeforeOrEqual(now, yesterday))
+    }
+
+    @Test
+    fun isAfterOrEqual() {
+        val theDayBeforeYesterday = LocalDate.now().minusDays(2)
+        val yesterday = LocalDate.now().minusDays(1)
+        val now = LocalDate.now()
+        assertTrue(Dates.isAfterOrEqual(now, yesterday))
+        assertTrue(Dates.isAfterOrEqual(yesterday, yesterday))
+        assertFalse(Dates.isAfterOrEqual(theDayBeforeYesterday, yesterday))
+    }
+
+    @Test
+    fun isWithinRange() {
+        val theDayBeforeYesterday = LocalDate.now().minusDays(2)
+        val yesterday = LocalDate.now().minusDays(1)
+        val now = LocalDate.now()
+        assertTrue(Dates.isWithinRange(theDayBeforeYesterday, now, yesterday))
+        assertTrue(Dates.isWithinRange(theDayBeforeYesterday, now, theDayBeforeYesterday))
+        assertTrue(Dates.isWithinRange(theDayBeforeYesterday, now, now))
+        assertFalse(Dates.isWithinRange(theDayBeforeYesterday, yesterday, now))
     }
 }


### PR DESCRIPTION
### Description

Unfortunately Java's standard methods do not provide `afterOrEqual` or `beforeOrEqual`, nor a range check.

Note that we are leaving null-handling for the caller to decide, as it strongly depends on usage: am empty date might represent an infinite date in the past or in the future, or represent an exception.

### Checklist

- [x] Code change has been tested and works locally
- [x] Code was formatted via IntelliJ and follows SonarLint & [best practices](https://scireum.myjetbrains.com/youtrack/articles/MISC-A-16/CodeStyle-JavaDoc)
