### PR TITLE
adjust Value.ignore() to make ignoring of other types than String available

### DIFF
--- a/src/main/java/sirius/kernel/commons/Value.java
+++ b/src/main/java/sirius/kernel/commons/Value.java
@@ -234,11 +234,11 @@ public class Value {
      * Otherwise, the current value is returned.
      */
     @Nonnull
-    public Value ignore(@Nonnull String... ignoredValues) {
+    public Value ignore(@Nonnull Object... ignoredValues) {
         if (isEmptyString()) {
             return this;
         }
-        for (String val : ignoredValues) {
+        for (Object val : ignoredValues) {
             if (data.equals(val)) {
                 return Value.EMPTY;
             }

--- a/src/test/kotlin/sirius/kernel/commons/ValueTest.kt
+++ b/src/test/kotlin/sirius/kernel/commons/ValueTest.kt
@@ -274,8 +274,11 @@ class ValueTest {
         assertTrue(Value.of("A").ignore("B", "C").isFilled)
         assertTrue(Value.of("0").ignore("0").isEmptyString)
         assertTrue(Value.of("0").ignore(BigDecimal.ZERO).isFilled)
-        assertTrue(Value.of("0").ignore("0").isEmptyString)
+        assertTrue(Value.of("1").ignore("0").isFilled)
+        assertTrue(Value.of(BigDecimal.ONE).ignore("1").isFilled)
         assertTrue(Value.of(BigDecimal.ZERO).ignore(BigDecimal.ZERO).isEmptyString)
+        assertTrue(Value.of(BigDecimal.ZERO).ignore("0").isFilled)
         assertTrue(Value.of(BigDecimal.valueOf(0)).ignore(BigDecimal.ZERO).isEmptyString)
+        assertTrue(Value.of(BigDecimal.valueOf(1)).ignore(BigDecimal.ZERO).isFilled)
     }
 }

--- a/src/test/kotlin/sirius/kernel/commons/ValueTest.kt
+++ b/src/test/kotlin/sirius/kernel/commons/ValueTest.kt
@@ -267,4 +267,15 @@ class ValueTest {
         assertEquals("x", Value.of("x").tryAppend(" ", null).asString())
         assertEquals("x y", Value.of("x").tryAppend(" ", "y").asString())
     }
+
+    @Test
+    fun `Test ignore of objects`() {
+        assertTrue(Value.of("A").ignore("A", "B").isEmptyString)
+        assertTrue(Value.of("A").ignore("B", "C").isFilled)
+        assertTrue(Value.of("0").ignore("0").isEmptyString)
+        assertTrue(Value.of("0").ignore(BigDecimal.ZERO).isFilled)
+        assertTrue(Value.of("0").ignore("0").isEmptyString)
+        assertTrue(Value.of(BigDecimal.ZERO).ignore(BigDecimal.ZERO).isEmptyString)
+        assertTrue(Value.of(BigDecimal.valueOf(0)).ignore(BigDecimal.ZERO).isEmptyString)
+    }
 }


### PR DESCRIPTION
### Description
Sometimes we have a JDBC Row where 0 value means "null" but ignoring does only work with strings until now. `object.as(Row.class).getValue("value").ignore(BigDecimal.ZERO)` should ignore a found 0 without calling casted `Value.of(object.as(Row.class).getValue().asString()).ignore("0")`

<!--  Describe your changes in detail. Also mention how to handle breaking changes if there are any -->

### Additional Notes

- This PR fixes or works on following ticket(s): [SE-13904](https://scireum.myjetbrains.com/youtrack/issue/SE-13904)
- This PR is related to PR: <!-- URL of PR if applicable, remove otherwise -->

### Checklist

- [x] Code change has been tested and works locally
- [x] Code was formatted via IntelliJ and follows SonarLint & [best practices](https://scireum.myjetbrains.com/youtrack/articles/MISC-A-16/CodeStyle-JavaDoc)
- [ ] Patch Tasks: Is local execution of Patch Tasks necessary? If so, please also mark the PR with the tag.
