### PR TITLE
Fixes a race condition in auto tranformer

### DIFF
--- a/src/main/java/sirius/kernel/di/transformers/AutoTransformLoadAction.java
+++ b/src/main/java/sirius/kernel/di/transformers/AutoTransformLoadAction.java
@@ -83,6 +83,7 @@ public class AutoTransformLoadAction implements ClassLoadAction {
         public T make(@Nonnull Object source) {
             try {
                 T result = createInstance(source);
+                globalContext.wire(result);
 
                 if (source instanceof Composable composable && additionalTargetTypes != null) {
                     for (Class<?> additionalTarget : additionalTargetTypes) {
@@ -90,7 +91,6 @@ public class AutoTransformLoadAction implements ClassLoadAction {
                     }
                 }
 
-                globalContext.wire(result);
                 return result;
             } catch (InvocationTargetException exception) {
                 if (exception.getCause() instanceof IllegalArgumentException) {


### PR DESCRIPTION
### Description
We must properly wire the object before attaching it or else race conditions might occur where the wiring has not happened yet

### Additional Notes

- This PR fixes or works on following ticket(s): [SE-13624](https://scireum.myjetbrains.com/youtrack/issue/SE-13624)
- This PR is related to PR: <!-- URL of PR if applicable, remove otherwise -->

### Checklist

- [x] Code change has been tested and works locally
- [x] Code was formatted via IntelliJ and follows SonarLint & [best practices](https://scireum.myjetbrains.com/youtrack/articles/MISC-A-16/CodeStyle-JavaDoc)
- [ ] Patch Tasks: Is local execution of Patch Tasks necessary? If so, please also mark the PR with the tag.
