### PR TITLE
Softens xml security settings

### DIFF
--- a/src/main/java/sirius/kernel/xml/XMLReader.java
+++ b/src/main/java/sirius/kernel/xml/XMLReader.java
@@ -182,7 +182,9 @@ public class XMLReader extends DefaultHandler {
         try (stream) {
             SAXParserFactory factory = SAXParserFactory.newInstance();
             factory.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, true);
-            factory.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true);
+            factory.setFeature("http://xml.org/sax/features/external-general-entities", false);
+            factory.setFeature("http://xml.org/sax/features/external-parameter-entities", false);
+            factory.setFeature("http://apache.org/xml/features/nonvalidating/load-external-dtd", false);
             factory.setXIncludeAware(false);
             SAXParser saxParser = factory.newSAXParser();
             org.xml.sax.XMLReader reader = saxParser.getXMLReader();

--- a/src/test/kotlin/sirius/kernel/xml/XmlReaderTest.kt
+++ b/src/test/kotlin/sirius/kernel/xml/XmlReaderTest.kt
@@ -148,16 +148,16 @@ internal class XmlReaderTest {
         reader.addHandler("root") { node: StructuredNode ->
             readString.set(node.queryString("."))
         }
-        assertThrows<IOException> {
-            reader.parse(
-                ByteArrayInputStream(//language=xml
-                    """
-                            <?xml version="1.0" encoding="UTF-8"?> 
-                            <!DOCTYPE root [<!ENTITY xxe SYSTEM "file:///etc/hosts">]> 
-                            <root>&xxe;</root>
-                        """.trimIndent().toByteArray()
-                )
+
+        reader.parse(
+            ByteArrayInputStream(//language=xml
+                """
+                    <?xml version="1.0" encoding="UTF-8"?>
+                    <!DOCTYPE root [<!ENTITY xxe SYSTEM "file:///etc/hosts">]>
+                    <root>&xxe;</root>
+                """.trimIndent().toByteArray()
             )
-        }
+        )
+        assertEquals(null, readString.get())
     }
 }

--- a/src/test/kotlin/sirius/kernel/xml/XmlReaderTest.kt
+++ b/src/test/kotlin/sirius/kernel/xml/XmlReaderTest.kt
@@ -160,4 +160,24 @@ internal class XmlReaderTest {
         )
         assertEquals(null, readString.get())
     }
+
+    @Test
+    fun `Reading xml with doctype is allowed`() {
+        val readString = ValueHolder.of<String?>(null)
+        val reader = XMLReader()
+        reader.addHandler("root") { node: StructuredNode ->
+            readString.set(node.queryString("."))
+        }
+
+        reader.parse(
+            ByteArrayInputStream(//language=xml
+                """
+                    <?xml version="1.0" encoding="UTF-8"?>
+                    <!DOCTYPE SOMETHING SYSTEM "something.dtd">
+                    <root>content</root>
+                """.trimIndent().toByteArray()
+            )
+        )
+        assertEquals("content", readString.get())
+    }
 }


### PR DESCRIPTION
### Description
Softens/relaxes xml security settings:
- some of our customers deliver xml files with a doctype set
- we do not want to forbid this, and so set the permission more fine granular
- target state is that xxe attacks are still impossible, see the adapted test case that still does not contain the /etc/hosts content

### Additional Notes

- This PR fixes or works on following ticket(s): [SIRI-1037](https://scireum.myjetbrains.com/youtrack/issue/SIRI-1037)

### Checklist

- [x] Code change has been tested and works locally
- [x] Code was formatted via IntelliJ and follows SonarLint & [best practices](https://scireum.myjetbrains.com/youtrack/articles/MISC-A-16/CodeStyle-JavaDoc)
- [ ] Patch Tasks: Is local execution of Patch Tasks necessary? If so, please also mark the PR with the tag.
