### PR TITLE
URL Checker Fix

### DIFF
--- a/src/main/java/sirius/kernel/commons/Strings.java
+++ b/src/main/java/sirius/kernel/commons/Strings.java
@@ -277,6 +277,16 @@ public class Strings {
                      url -> "http".equalsIgnoreCase(url.getProtocol()) || "https".equalsIgnoreCase(url.getProtocol()));
     }
 
+    /**
+     * Returns if the given string is an HTTPS URL, explicitly excluding unencrypted HTTP URLs.
+     *
+     * @param value the string to check
+     * @return <tt>true</tt> if the given string is an HTTPS URL, <tt>false</tt> otherwise
+     */
+    public static boolean isHttpsUrl(@Nullable String value) {
+        return isUrl(value, url -> "https".equalsIgnoreCase(url.getProtocol()));
+    }
+
     protected static boolean isUrl(@Nullable String value, Predicate<URL> checker) {
         if (isEmpty(value)) {
             return false;

--- a/src/main/java/sirius/kernel/commons/Strings.java
+++ b/src/main/java/sirius/kernel/commons/Strings.java
@@ -12,6 +12,8 @@ import sirius.kernel.nls.NLS;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
+import java.net.URI;
+import java.net.URL;
 import java.net.URLDecoder;
 import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
@@ -21,6 +23,7 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.function.Predicate;
 import java.util.function.UnaryOperator;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -48,11 +51,6 @@ public class Strings {
      * Contains the marker/signal which should be used to depict that the string has been truncated.
      */
     private static final String TRUNCATED_SIGNAL = ELLIPSIS + "[" + ELLIPSIS + "]" + ELLIPSIS;
-
-    /**
-     * Contains the pattern to detect if a string is an HTTP(S) URL.
-     */
-    private static final Pattern HTTP_URL_PATTERN = Pattern.compile("^https?://", Pattern.CASE_INSENSITIVE);
 
     /**
      * Contains all characters which can safely be used for codes without too much confusion (e.g. 0 vs O are
@@ -275,10 +273,20 @@ public class Strings {
      * @return <tt>true</tt> if the given string is an HTTP(S) URL, <tt>false</tt> otherwise
      */
     public static boolean isHttpUrl(@Nullable String value) {
+        return isUrl(value,
+                     url -> "http".equalsIgnoreCase(url.getProtocol()) || "https".equalsIgnoreCase(url.getProtocol()));
+    }
+
+    protected static boolean isUrl(@Nullable String value, Predicate<URL> checker) {
         if (isEmpty(value)) {
             return false;
         }
-        return HTTP_URL_PATTERN.matcher(value).find();
+
+        try {
+            return checker.test(URI.create(value).toURL());
+        } catch (Exception exception) {
+            return false;
+        }
     }
 
     /**

--- a/src/test/kotlin/sirius/kernel/commons/StringsTest.kt
+++ b/src/test/kotlin/sirius/kernel/commons/StringsTest.kt
@@ -118,6 +118,7 @@ class StringsTest {
         "true, http://user@server.com/path",
         "true, https://example.com/my/sample/page",
         "true, http://example.com:8080/my/sample/page?user=foo&password=bar",
+        "false, https:// ;%@@ lol whatever i don't care",
         "false, HttpS",
         "false, ",
         "false, ''",

--- a/src/test/kotlin/sirius/kernel/commons/StringsTest.kt
+++ b/src/test/kotlin/sirius/kernel/commons/StringsTest.kt
@@ -128,6 +128,26 @@ class StringsTest {
         assertEquals(isUrl, Strings.isHttpUrl(url))
     }
 
+    @ParameterizedTest
+    @CsvSource(
+        "true, https://example.com",
+        "true, HTTPS://example.com",
+        "false, http://example.com",
+        "false, Http://example.com?foo=bar",
+        "false, http://user:password@server.com/path",
+        "false, http://user@server.com/path",
+        "true, https://example.com/my/sample/page",
+        "false, http://example.com:8080/my/sample/page?user=foo&password=bar",
+        "false, https:// ;%@@ lol whatever i don't care",
+        "false, HttpS",
+        "false, ",
+        "false, ''",
+        "false, For testing look at https://example.com"
+    )
+    fun isHttpsUrl(isUrl: Boolean, url: String?) {
+        assertEquals(isUrl, Strings.isHttpsUrl(url))
+    }
+
     @Test
     fun urlEncode() {
         assertEquals("A%3FTEST%26B%C3%84%C3%96%C3%9C", Strings.urlEncode("A?TEST&BÄÖÜ"))


### PR DESCRIPTION
### Description

Repairs `Strings.isHttpUrl(…)` by using proper URL parsing methods.

### Checklist

- [x] Code change has been tested and works locally (via test case)
- [x] Code was formatted via IntelliJ and follows SonarLint & [best practices](https://scireum.myjetbrains.com/youtrack/articles/MISC-A-16/CodeStyle-JavaDoc)
