### PR TITLE
XXE soften for XMLStructuredInput

### DIFF
--- a/src/main/java/sirius/kernel/xml/XMLGenerator.java
+++ b/src/main/java/sirius/kernel/xml/XMLGenerator.java
@@ -146,8 +146,7 @@ public class XMLGenerator extends XMLStructuredOutput {
     public static Document createDocument(@Nullable String namespaceURI,
                                           String qualifiedName,
                                           @Nullable DocumentType docType) throws ParserConfigurationException {
-        DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
-        factory.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, true);
+        DocumentBuilderFactory factory = XmlUtil.createSecurityAwareDocumentBuilderFactory();
         DocumentBuilder builder = factory.newDocumentBuilder();
         DOMImplementation impl = builder.getDOMImplementation();
         return impl.createDocument(namespaceURI, qualifiedName, docType);

--- a/src/main/java/sirius/kernel/xml/XMLReader.java
+++ b/src/main/java/sirius/kernel/xml/XMLReader.java
@@ -64,8 +64,7 @@ public class XMLReader extends DefaultHandler {
      */
     public XMLReader() {
         try {
-            DocumentBuilderFactory documentBuilderFactory = DocumentBuilderFactory.newInstance();
-            documentBuilderFactory.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, true);
+            DocumentBuilderFactory documentBuilderFactory = XmlUtil.createSecurityAwareDocumentBuilderFactory();;
             documentBuilder = documentBuilderFactory.newDocumentBuilder();
             taskContext = TaskContext.get();
         } catch (ParserConfigurationException exception) {

--- a/src/main/java/sirius/kernel/xml/XMLStructuredInput.java
+++ b/src/main/java/sirius/kernel/xml/XMLStructuredInput.java
@@ -38,8 +38,8 @@ public class XMLStructuredInput implements StructuredInput {
      */
     public XMLStructuredInput(InputStream inputStream, @Nullable NamespaceContext namespaceContext) throws IOException {
         try {
-            DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
-            factory.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, true);
+            DocumentBuilderFactory factory = XmlUtil.createSecurityAwareDocumentBuilderFactory();
+
             if (namespaceContext != null) {
                 factory.setNamespaceAware(true);
             }

--- a/src/main/java/sirius/kernel/xml/XmlUtil.java
+++ b/src/main/java/sirius/kernel/xml/XmlUtil.java
@@ -24,6 +24,9 @@ public class XmlUtil {
         DocumentBuilderFactory result = DocumentBuilderFactory.newInstance();
         result.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, true);
         result.setFeature("http://apache.org/xml/features/nonvalidating/load-external-dtd", false);
+        result.setFeature("http://xml.org/sax/features/external-general-entities", false);
+        result.setFeature("http://xml.org/sax/features/external-parameter-entities", false);
+        result.setExpandEntityReferences(false);
         result.setXIncludeAware(false);
         return result;
     }

--- a/src/main/java/sirius/kernel/xml/XmlUtil.java
+++ b/src/main/java/sirius/kernel/xml/XmlUtil.java
@@ -1,0 +1,30 @@
+package sirius.kernel.xml;
+
+import javax.xml.XMLConstants;
+import javax.xml.parsers.DocumentBuilderFactory;
+import javax.xml.parsers.ParserConfigurationException;
+
+/**
+ * Provides utility methods for working with XML.
+ */
+public class XmlUtil {
+
+    private XmlUtil() {
+        // Prevent instantiation
+    }
+
+    /**
+     * Creates a new {@link DocumentBuilderFactory} which is secure by default.
+     *
+     * @return a new {@link DocumentBuilderFactory}
+     * @throws ParserConfigurationException if a configuration error occurs
+     */
+    public static DocumentBuilderFactory createSecurityAwareDocumentBuilderFactory()
+            throws ParserConfigurationException {
+        DocumentBuilderFactory result = DocumentBuilderFactory.newInstance();
+        result.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, true);
+        result.setFeature("http://apache.org/xml/features/nonvalidating/load-external-dtd", false);
+        result.setXIncludeAware(false);
+        return result;
+    }
+}

--- a/src/test/kotlin/sirius/kernel/xml/XMLStructuredInputTest.kt
+++ b/src/test/kotlin/sirius/kernel/xml/XMLStructuredInputTest.kt
@@ -1,0 +1,45 @@
+/*
+ * Made with all the love in the world
+ * by scireum in Remshalden, Germany
+ *
+ * Copyright by scireum GmbH
+ * http://www.scireum.de - info@scireum.de
+ */
+
+package sirius.kernel.xml
+
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import org.junit.jupiter.api.extension.ExtendWith
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.CsvSource
+import org.xml.sax.SAXParseException
+import sirius.kernel.SiriusExtension
+import sirius.kernel.commons.ValueHolder
+import sirius.kernel.health.Counter
+import java.io.ByteArrayInputStream
+import java.io.IOException
+import java.text.ParseException
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+/**
+ * Tests the [XMLStructuredInput] class.
+ */
+internal class XMLStructuredInputTest {
+
+    @Test
+    fun `Read xml content with external DTD works`() {
+        val input = XMLStructuredInput(
+            ByteArrayInputStream(//language=xml
+                """<?xml version="1.0" encoding="UTF-8"?>
+                <!DOCTYPE something_details SYSTEM "https://something.com/schemas/something/1.0.0/something.dtd">
+                <something_details><something_number>123456</something_number></something_details>
+                """.toByteArray()
+            ), null
+        )
+        assertEquals("123456", input.root().queryString("."))
+    }
+
+}

--- a/src/test/kotlin/sirius/kernel/xml/XMLStructuredInputTest.kt
+++ b/src/test/kotlin/sirius/kernel/xml/XMLStructuredInputTest.kt
@@ -44,16 +44,15 @@ internal class XMLStructuredInputTest {
 
     @Test
     fun `Preventing access to local resources works`() {
-        assertThrows<IOException> {
-            XMLStructuredInput(
-                ByteArrayInputStream(//language=xml
-                    """<?xml version="1.0" encoding="UTF-8"?>
+        val input = XMLStructuredInput(
+            ByteArrayInputStream(//language=xml
+                """<?xml version="1.0" encoding="UTF-8"?>
                     <!DOCTYPE root [<!ENTITY xxe SYSTEM "file:///etc/hosts">]>
                     <root>&xxe;</root>
                 """.toByteArray()
-                ), null
-            )
-        }
+            ), null
+        )
+        assertEquals(null, input.root().queryString("."))
     }
 
 }

--- a/src/test/kotlin/sirius/kernel/xml/XMLStructuredInputTest.kt
+++ b/src/test/kotlin/sirius/kernel/xml/XMLStructuredInputTest.kt
@@ -42,4 +42,18 @@ internal class XMLStructuredInputTest {
         assertEquals("123456", input.root().queryString("."))
     }
 
+    @Test
+    fun `Preventing access to local resources works`() {
+        assertThrows<IOException> {
+            XMLStructuredInput(
+                ByteArrayInputStream(//language=xml
+                    """<?xml version="1.0" encoding="UTF-8"?>
+                    <!DOCTYPE root [<!ENTITY xxe SYSTEM "file:///etc/hosts">]>
+                    <root>&xxe;</root>
+                """.toByteArray()
+                ), null
+            )
+        }
+    }
+
 }


### PR DESCRIPTION
### Description
Adapts securits setting for XML parsing. See commit messages for details. 
Adds new unit tests as well. 

### Additional Notes

- This PR fixes or works on following ticket(s): [SIRI-1037](https://scireum.myjetbrains.com/youtrack/issue/SIRI-1037)


### Checklist

- [x] Code change has been tested and works locally
- [x] Code was formatted via IntelliJ and follows SonarLint & [best practices](https://scireum.myjetbrains.com/youtrack/articles/MISC-A-16/CodeStyle-JavaDoc)
- [ ] Patch Tasks: Is local execution of Patch Tasks necessary? If so, please also mark the PR with the tag.
