### PR TITLE
SIRI-1085: Fine Log XML Responses pretty printed

### DIFF
--- a/src/main/java/sirius/kernel/xml/XMLCall.java
+++ b/src/main/java/sirius/kernel/xml/XMLCall.java
@@ -195,7 +195,7 @@ public class XMLCall {
             // log the request, even when parsing fails
             try (InputStream body = getResponseBody()) {
                 byte[] bytes = body.readAllBytes();
-                logRequest(new String(bytes, outcall.getContentEncoding()));
+                logRequest(bytes);
                 return new ByteArrayInputStream(bytes);
             }
         }
@@ -214,7 +214,7 @@ public class XMLCall {
         return outcall.getResponse().body();
     }
 
-    private void logRequest(String response) throws IOException {
+    private void logRequest(byte[] response) throws IOException {
         debugLogger.FINE(Formatter.create("""
                                                   ---------- call ----------
                                                   ${httpMethod} ${url} [
@@ -231,7 +231,16 @@ public class XMLCall {
                                   .set("callBody",
                                        outcall.getRequest().bodyPublisher().isPresent() ? getOutput() : null)
                                   .set("responseCode", getOutcall().getResponseCode())
-                                  .set("response", response)
+                                  .set("response", formatResponseForLogging(response))
                                   .smartFormat());
+    }
+
+    private String formatResponseForLogging(byte[] response) {
+        try {
+            return new XMLStructuredInput(new ByteArrayInputStream(response), namespaceContext).toString();
+        } catch (Exception e) {
+            Exceptions.ignore(e);
+            return new String(response, outcall.getContentEncoding());
+        }
     }
 }

--- a/src/main/java/sirius/kernel/xml/XMLCall.java
+++ b/src/main/java/sirius/kernel/xml/XMLCall.java
@@ -218,11 +218,11 @@ public class XMLCall {
         debugLogger.FINE(Formatter.create("""
                                                   ---------- call ----------
                                                   ${httpMethod} ${url} [
-                                                                               
+                                                  
                                                   ${callBody}]
                                                   ---------- response ----------
                                                   HTTP-Response-Code: ${responseCode}
-                                                                               
+                                                  
                                                   ${response}
                                                   ---------- end ----------
                                                   """)


### PR DESCRIPTION
### Description

Logging an XML response pretty printed makes debugging it easier as determining proper capsulation or finding specific fields in a wall of texts is tedious.

But if the response can't be formatted properly (e. g. a non XML compatible HTML body), we still want to log it.

### Additional Notes

- This PR fixes or works on following ticket(s): [SIRI-1085](https://scireum.myjetbrains.com/youtrack/issue/SIRI-1085)

### Checklist

- [x] Code change has been tested and works locally
- [x] Code was formatted via IntelliJ and follows SonarLint & [best practices](https://scireum.myjetbrains.com/youtrack/articles/MISC-A-16/CodeStyle-JavaDoc)
- [ ] Patch Tasks: Is local execution of Patch Tasks necessary? If so, please also mark the PR with the tag.
