### PR TITLE
Adds a simple parallel task executor

### DIFF
--- a/src/main/java/sirius/kernel/async/ParallelTaskExecutor.java
+++ b/src/main/java/sirius/kernel/async/ParallelTaskExecutor.java
@@ -1,0 +1,98 @@
+/*
+ * Made with all the love in the world
+ * by scireum in Remshalden, Germany
+ *
+ * Copyright by scireum GmbH
+ * http://www.scireum.de - info@scireum.de
+ */
+
+package sirius.kernel.async;
+
+import sirius.kernel.commons.Wait;
+
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.Semaphore;
+import java.util.concurrent.atomic.AtomicInteger;
+
+/**
+ * Executes tasks in parallel in the current node using virtual threads with a limit on concurrency.
+ * <p>
+ * After the executor has been initialized, submit tasks using {@link #submitTask(Runnable)}. They will start as
+ * soon as the first task is submitted.
+ * Once all tasks have been submitted, call {@link #shutdownWhenDone()} to wait for all pending tasks to complete.
+ * <p>
+ * Note that the current {@linkplain CallContext#getCurrent() current context} will be passed to the tasks when they
+ * are executed.
+ */
+public class ParallelTaskExecutor {
+
+    private final ExecutorService executor;
+    private final BlockingQueue<Runnable> taskQueue;
+    private final Semaphore semaphore;
+    private final AtomicInteger taskCount;
+    private final CallContext currentContext;
+
+    /**
+     * Creates a new parallel task executor.
+     *
+     * @param maxConcurrentTasks the maximum number of tasks to run concurrently
+     */
+    public ParallelTaskExecutor(int maxConcurrentTasks) {
+        this.currentContext = CallContext.getCurrent();
+        this.executor = Executors.newVirtualThreadPerTaskExecutor();
+        this.taskQueue = new LinkedBlockingQueue<>();
+        this.semaphore = new Semaphore(maxConcurrentTasks);
+        this.taskCount = new AtomicInteger(0);
+        startProcessing();
+    }
+
+    /**
+     * Submits a task to be executed in parallel.
+     *
+     * @param task the task to execute
+     * @return {@code true} if the task was successfully submitted, {@code false} otherwise
+     */
+    public boolean submitTask(Runnable task) {
+        return taskQueue.offer(() -> {
+            try {
+                CallContext.setCurrent(currentContext);
+                taskCount.incrementAndGet();
+                task.run();
+            } finally {
+                taskCount.decrementAndGet();
+                semaphore.release();
+            }
+        });
+    }
+
+    /**
+     * Waits for all tasks to complete and shuts down the executor.
+     */
+    public void shutdownWhenDone() {
+        while (TaskContext.get().isActive()) {
+            if (taskQueue.isEmpty() && taskCount.get() == 0) {
+                executor.close();
+                break;
+            }
+            Wait.millis(500);
+        }
+    }
+
+    private void startProcessing() {
+        Thread.startVirtualThread(() -> {
+            while (TaskContext.get().isActive()) {
+                try {
+                    Runnable task = taskQueue.take();
+                    semaphore.acquire();
+                    executor.submit(task);
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                    break;
+                }
+            }
+        });
+    }
+}

--- a/src/main/java/sirius/kernel/async/ParallelTaskExecutor.java
+++ b/src/main/java/sirius/kernel/async/ParallelTaskExecutor.java
@@ -24,8 +24,8 @@ import java.util.concurrent.atomic.AtomicInteger;
  * soon as the first task is submitted. The underlying queue is unbounded and only limited by the memory available.
  * Once all tasks have been submitted, call {@link #shutdownWhenDone()} to wait for all pending tasks to complete.
  * <p>
- * Note that the current {@linkplain CallContext#getCurrent() current context} will be passed to the tasks when they
- * are executed.
+ * Note that the {@linkplain CallContext#getCurrent() current context} will be passed to the tasks when they are
+ * executed.
  */
 public class ParallelTaskExecutor {
 

--- a/src/main/java/sirius/kernel/async/ParallelTaskExecutor.java
+++ b/src/main/java/sirius/kernel/async/ParallelTaskExecutor.java
@@ -21,7 +21,7 @@ import java.util.concurrent.atomic.AtomicInteger;
  * Executes tasks in parallel in the current node using virtual threads with a limit on concurrency.
  * <p>
  * After the executor has been initialized, submit tasks using {@link #submitTask(Runnable)}. They will start as
- * soon as the first task is submitted.
+ * soon as the first task is submitted. The underlying queue is unbounded and only limited by the memory available.
  * Once all tasks have been submitted, call {@link #shutdownWhenDone()} to wait for all pending tasks to complete.
  * <p>
  * Note that the current {@linkplain CallContext#getCurrent() current context} will be passed to the tasks when they
@@ -88,7 +88,7 @@ public class ParallelTaskExecutor {
                     Runnable task = taskQueue.take();
                     semaphore.acquire();
                     executor.submit(task);
-                } catch (InterruptedException e) {
+                } catch (InterruptedException exception) {
                     Thread.currentThread().interrupt();
                     break;
                 }


### PR DESCRIPTION
### Description

This is an easy to initialize and use executor which permits to run a number of limited tasks in parallel using virtual threads.
Useful for parallel tasks not demanding a complex clustered setup. For that, our framework already offers many options.

Call sample:
```java
ParallelTaskExecutor executor = new ParallelTaskExecutor(4);

for (int i = 0; i < 1000; i++) {
    final int taskId = i;
    executor.submitTask(() -> {
        System.out.println("Executing Task " + taskId + " on thread " + Thread.currentThread().getName());
        // Enough theory, do some real stuff in here...
    });
}

executor.shutdownWhenDone();
```

- tasks start running as soon as they are submitted
- shutdown will wait until the last task finishes
- current context is passed to each task

### Additional Notes

- This PR fixes or works on following ticket(s): [OX-11751](https://scireum.myjetbrains.com/youtrack/issue/OX-11751)

### Checklist

- [x] Code change has been tested and works locally
- [x] Code was formatted via IntelliJ and follows SonarLint & [best practices](https://scireum.myjetbrains.com/youtrack/articles/MISC-A-16/CodeStyle-JavaDoc)
- [ ] Patch Tasks: Is local execution of Patch Tasks necessary? If so, please also mark the PR with the tag.
