### PR TITLE
Improves XML Query Performance when Handling Node List Items

### DIFF
--- a/src/main/java/sirius/kernel/xml/StructuredNode.java
+++ b/src/main/java/sirius/kernel/xml/StructuredNode.java
@@ -217,7 +217,7 @@ public class StructuredNode {
             NodeList result = (NodeList) compile(xpath).evaluate(node, XPathConstants.NODESET);
             List<StructuredNode> resultList = new ArrayList<>(result.getLength());
             for (int i = 0; i < result.getLength(); i++) {
-                resultList.add(new StructuredNode(result.item(i), namespaceContext));
+                resultList.add(new StructuredNode(result.item(i).cloneNode(true), namespaceContext));
             }
             return resultList;
         } catch (XPathExpressionException exception) {


### PR DESCRIPTION
### Description

Nodes are by default "live" meaning they could be edited (which we however don't encourage when using StructuredNode). Also, when querying fields, the node "checks" its predecessors and parent each time using a double linked list. This results in a massive performance hit for later nodes as all previous nodes are iterated each time.

Cloning a node creates a node without a parent and sibling context making queries much faster. In a test case with an XML that contained 570 node list items where multiple fields are queried for each, it took **36 seconds** in total to query all fields, afterwards it only took **411 milliseconds**.

Caveat: The parent and siblings of nodes resolved via StructuredNode#queryNodeList can no longer be queried. There seems to be no use case for that as the parent must already be known to the caller and siblings can be resolved via the returned List.

Note, that cloning is done always instead of defining a threshold to keep things clear and to avoid situations where whacky code works with smaller XML files (probably during testing) but will break for larger files (possible on production systems).

See https://stackoverflow.com/questions/3782618/xpath-evaluate-performance-slows-down-absurdly-over-multiple-calls for others running into the same issues and alternative solutions (e.g. removing the child from the parent, but this has no performance improvement and may introduce additional issues as we can't query the lists then more than once).

### Additional Notes

- This PR fixes or works on following ticket(s): [SE-14446](https://scireum.myjetbrains.com/youtrack/issue/SE-14446)

### Checklist

- [x] Code change has been tested and works locally
- [x] Code was formatted via IntelliJ and follows SonarLint & [best practices](https://scireum.myjetbrains.com/youtrack/articles/MISC-A-16/CodeStyle-JavaDoc)
- [ ] Patch Tasks: Is local execution of Patch Tasks necessary? If so, please also mark the PR with the tag.
