### PR TITLE
Default User-Agent for Outcall

### DIFF
--- a/src/main/java/sirius/kernel/xml/Outcall.java
+++ b/src/main/java/sirius/kernel/xml/Outcall.java
@@ -167,12 +167,6 @@ public class Outcall {
                 userAgentString.append("/");
                 userAgentString.append(version);
             }
-            String baseUrl = Sirius.getSettings().getString("product.baseUrl");
-            if (Strings.isFilled(baseUrl)) {
-                userAgentString.append(" (+");
-                userAgentString.append(baseUrl);
-                userAgentString.append(")");
-            }
             defaultUserAgent = userAgentString.toString();
         }
         return defaultUserAgent;


### PR DESCRIPTION
### Description

Removes the URL from the default user agent as our calls have been dropped by some external servers due to its presence in the UA. Apparently, the URL is considered a distinguishing feature of web-crawlers, and some providers seem to base firewall rules on a URL being present in the UA.

### Additional Notes

- This PR fixes or works on following ticket(s): [OX-11816](https://scireum.myjetbrains.com/youtrack/issue/OX-11816)

### Checklist

- [x] Code change has been tested and works locally
- [x] Code was formatted via IntelliJ and follows SonarLint & [best practices](https://scireum.myjetbrains.com/youtrack/articles/MISC-A-16/CodeStyle-JavaDoc)
