### PR TITLE
Adds the Strings.areAllFilled

### DIFF
--- a/src/main/java/sirius/kernel/commons/Strings.java
+++ b/src/main/java/sirius/kernel/commons/Strings.java
@@ -140,6 +140,25 @@ public class Strings {
     }
 
     /**
+     * Checks if the string representations of the given objects are not "" or <tt>null</tt>.
+     *
+     * @param first   the first object which is to be checked
+     * @param second  the second object which is to be checked
+     * @param further additional objects to be checked
+     * @return <tt>true</tt> if all strings are not <tt>null</tt> or "", <tt>false</tt> if one of them is empty
+     * @see #isFilled(Object)
+     */
+    public static boolean areAllFilled(Object first, Object second, Object... further) {
+        if (Strings.isEmpty(first) || Strings.isEmpty(second)) {
+            return false;
+        }
+        if (further != null) {
+            return Stream.of(further).allMatch(Strings::isFilled);
+        }
+        return true;
+    }
+
+    /**
      * Compares the given <tt>Strings</tt> while treating upper- and lowercase characters as equal.
      * <p>
      * This is essentially the same as {@code left.equalsIgnoreCase(right)}

--- a/src/main/java/sirius/kernel/commons/Strings.java
+++ b/src/main/java/sirius/kernel/commons/Strings.java
@@ -736,19 +736,6 @@ public class Strings {
     }
 
     /**
-     * Removes all umlauts and other decorated latin characters.
-     *
-     * @param input the term to reduce characters in
-     * @return the term with all decorated latin characters replaced
-     * @deprecated Use {@link StringCleanup#reduceCharacters(String)} or
-     * * {@code Strings.cleanup(input, Cleanup::reduceCharacters)} instead
-     */
-    @Deprecated
-    public static String reduceCharacters(String input) {
-        return StringCleanup.reduceCharacters(input);
-    }
-
-    /**
      * Shortens a string to the given number of chars,
      * cutting of at most half of the string and adding ... if something has been cut of.
      *

--- a/src/test/kotlin/sirius/kernel/commons/StringsTest.kt
+++ b/src/test/kotlin/sirius/kernel/commons/StringsTest.kt
@@ -51,6 +51,21 @@ class StringsTest {
     }
 
     @Test
+    fun areAllFilled() {
+        assertFalse { Strings.areAllFilled(null, null) }
+        assertFalse { Strings.areAllFilled("", "") }
+        assertFalse { Strings.areAllFilled("", null) }
+        assertFalse { Strings.areAllFilled(null, "") }
+        assertFalse { Strings.areAllFilled(null, "", null, "") }
+        assertFalse { Strings.areAllFilled("Test", null) }
+        assertFalse { Strings.areAllFilled(null, "Test") }
+        assertTrue { Strings.areAllFilled("Test", "Test") }
+        assertFalse { Strings.areAllFilled(null, "", null, "", "Test") }
+        assertFalse { Strings.areAllFilled(null, "", "Test") }
+        assertTrue { Strings.areAllFilled("Test", "Test", "Test") }
+    }
+
+    @Test
     fun equalIgnoreCase() {
         assertTrue { Strings.equalIgnoreCase("A", "a") }
         assertFalse { Strings.equalIgnoreCase("A", "b") }


### PR DESCRIPTION
### Description

We have a `Strings.areAllEmpty()`, but that is not the same as `!areAllEmpty()`

**Drive By**: kills a deprecated method. Use `StringCleanup.reduceCharacters(input)` as a direct replacement.

### Additional Notes

- This PR fixes or works on following ticket(s): [OX-11912](https://scireum.myjetbrains.com/youtrack/issue/OX-11912)

### Checklist

- [x] Code change has been tested and works locally
- [x] Code was formatted via IntelliJ and follows SonarLint & [best practices](https://scireum.myjetbrains.com/youtrack/articles/MISC-A-16/CodeStyle-JavaDoc)
