### PR TITLE
Quoting in CSV writing allignment to rfc 4180

### DIFF
--- a/src/main/java/sirius/kernel/commons/CSVWriter.java
+++ b/src/main/java/sirius/kernel/commons/CSVWriter.java
@@ -32,8 +32,9 @@ public class CSVWriter implements Closeable {
     private final Writer writer;
     private boolean firstLine = true;
     private char separator = ';';
-    private String separatorString = String.valueOf(';');
+    private String separatorString = String.valueOf(separator);
     private char quotation = '"';
+    private String quotationString = String.valueOf(quotation);
     private boolean isQuotationEmpty = false;
     private boolean forceQuotation = false;
     private char escape = '\\';
@@ -90,6 +91,7 @@ public class CSVWriter implements Closeable {
      */
     public CSVWriter withQuotation(char quotation) {
         this.quotation = quotation;
+        this.quotationString = String.valueOf(quotation);
         this.isQuotationEmpty = quotation == '\0';
         return this;
     }
@@ -137,10 +139,10 @@ public class CSVWriter implements Closeable {
     }
 
     /**
-     * Specifies wether or not all fields in the generated CSV should be enclosed with the specified quotation character.
+     * Specifies whether all fields in the generated CSV should be enclosed with the specified quotation character.
      * <p>
-     * By default this is <tt>false</tt>, which means only fields that require quotation because they contain
-     * the separator character or a line break are enclosed with quotations.
+     * By default, this is <tt>false</tt>, which means only fields that require quotation because they contain
+     * the separator character, the quotation character or a line break are enclosed with quotations.
      *
      * @param force if all fields should be quoted regardless of content or not
      * @return the writer itself for fluent method calls
@@ -230,7 +232,8 @@ public class CSVWriter implements Closeable {
         if (forceQuotation) {
             return true;
         }
-        return stringValue.contains(separatorString) || stringValue.contains("\n") || stringValue.contains("\r");
+        return stringValue.contains(separatorString) || stringValue.contains(quotationString) || stringValue.contains(
+                "\n") || stringValue.contains("\r");
     }
 
     /**

--- a/src/test/kotlin/sirius/kernel/commons/CSVReaderTest.kt
+++ b/src/test/kotlin/sirius/kernel/commons/CSVReaderTest.kt
@@ -69,16 +69,19 @@ class CSVReaderTest {
     @Test
     fun `escaping works`() {
         val data = """
-            \"a;\;;\\;x
+            \"a;\;;\\;x;a quotationMark: " ;"a aQuotationMarkWithinQuotationMarks: "" ";theEnd
         """.trimIndent()
         val output = mutableListOf<Values>()
         CSVReader(StringReader(data)).execute { output.add(it) }
 
         assertEquals(1, output.size)
-        assertEquals("\"a", output[0].at("A").rawString)
+        assertEquals(""""a""", output[0].at("A").rawString)
         assertEquals(";", output[0].at("B").rawString)
-        assertEquals("\\", output[0].at("C").rawString)
+        assertEquals("""\""", output[0].at("C").rawString)
         assertEquals("x", output[0].at("D").rawString)
+        assertEquals("""a quotationMark: " """, output[0].at("E").rawString)
+        assertEquals("""a aQuotationMarkWithinQuotationMarks: " """, output[0].at("F").rawString)
+        assertEquals("theEnd", output[0].at("G").rawString)
     }
 
     @Test

--- a/src/test/kotlin/sirius/kernel/commons/CSVReaderTest.kt
+++ b/src/test/kotlin/sirius/kernel/commons/CSVReaderTest.kt
@@ -85,6 +85,63 @@ class CSVReaderTest {
     }
 
     @Test
+    fun `rfc4180 example 2-5`() {
+        val data = """
+            "aaa","bbb","ccc"
+            zzz,yyy,xxx
+           """.trimIndent()
+        val output = mutableListOf<Values>()
+        val csvReader = CSVReader(StringReader(data))
+        csvReader.withSeparator(',').withQuotation('"')
+        csvReader.execute { output.add(it) }
+
+        assertEquals(2, output.size)
+        assertEquals("aaa", output[0].at(0).rawString)
+        assertEquals("bbb", output[0].at(1).rawString)
+        assertEquals("ccc", output[0].at(2).rawString)
+        assertEquals("zzz", output[1].at(0).rawString)
+        assertEquals("yyy", output[1].at(1).rawString)
+        assertEquals("xxx", output[1].at(2).rawString)
+    }
+
+    @Test
+    fun `rfc4180 example 2-6`() {
+        val data = """
+            "aaa","b
+            bb","ccc"
+            zzz,yyy,xxx
+           """.trimIndent()
+        val output = mutableListOf<Values>()
+        val csvReader = CSVReader(StringReader(data))
+        csvReader.withSeparator(',').withQuotation('"')
+        csvReader.execute { output.add(it) }
+
+        assertEquals(2, output.size)
+        assertEquals("aaa", output[0].at(0).rawString)
+        assertEquals("b\nbb", output[0].at(1).rawString)
+        assertEquals("ccc", output[0].at(2).rawString)
+        assertEquals("zzz", output[1].at(0).rawString)
+        assertEquals("yyy", output[1].at(1).rawString)
+        assertEquals("xxx", output[1].at(2).rawString)
+    }
+
+    @Test
+    fun `rfc4180 example 2-7`() {
+        val data = """
+            "aaa","b""bb","ccc"
+           """.trimIndent()
+        val output = mutableListOf<Values>()
+        val csvReader = CSVReader(StringReader(data))
+        csvReader.withSeparator(',').withQuotation('"')
+        csvReader.execute { output.add(it) }
+
+        assertEquals(1, output.size)
+        assertEquals("aaa", output[0].at(0).rawString)
+        assertEquals("b\"bb", output[0].at(1).rawString)
+        assertEquals("ccc", output[0].at(2).rawString)
+    }
+
+    @Test
     fun `empty cells work with and without quotation`() {
         val data = """
             a;;"";d
@@ -133,7 +190,7 @@ class CSVReaderTest {
         val output = mutableListOf<Values>()
 
         CSVReader(StringReader(data)).withSeparator(':').withQuotation('!').withEscape('&').notIgnoringWhitespaces()
-                .execute { output.add(it) }
+            .execute { output.add(it) }
 
         assertEquals(1, output.size)
         assertEquals("a", output[0].at("A").rawString)
@@ -170,7 +227,7 @@ class CSVReaderTest {
 
         val output = mutableListOf<Values>()
         CSVReader(StringReader(completeData)).withLimit(Limit(250, 100))
-                .execute { output.add(it) }
+            .execute { output.add(it) }
 
         assertEquals(50, output.size)
     }

--- a/src/test/kotlin/sirius/kernel/commons/CSVReaderTest.kt
+++ b/src/test/kotlin/sirius/kernel/commons/CSVReaderTest.kt
@@ -69,7 +69,7 @@ class CSVReaderTest {
     @Test
     fun `escaping works`() {
         val data = """
-            \"a;\;;\\;x;a quotationMark: " ;"a aQuotationMarkWithinQuotationMarks: "" ";theEnd
+            \"a;\;;\\;x;"a aQuotationMarkWithinQuotationMarks: "" "
         """.trimIndent()
         val output = mutableListOf<Values>()
         CSVReader(StringReader(data)).execute { output.add(it) }
@@ -79,9 +79,7 @@ class CSVReaderTest {
         assertEquals(";", output[0].at("B").rawString)
         assertEquals("""\""", output[0].at("C").rawString)
         assertEquals("x", output[0].at("D").rawString)
-        assertEquals("""a quotationMark: " """, output[0].at("E").rawString)
-        assertEquals("""a aQuotationMarkWithinQuotationMarks: " """, output[0].at("F").rawString)
-        assertEquals("theEnd", output[0].at("G").rawString)
+        assertEquals("""a aQuotationMarkWithinQuotationMarks: " """, output[0].at("E").rawString)
     }
 
     @Test

--- a/src/test/kotlin/sirius/kernel/commons/CSVWriterTest.kt
+++ b/src/test/kotlin/sirius/kernel/commons/CSVWriterTest.kt
@@ -132,8 +132,61 @@ class CSVWriterTest {
             )
         }
     }
+
+    @Test
+    fun `rfc4180 example 2-5`() {
+        StringWriter().use { output ->
+            val writer = CSVWriter(output)
+            writer.withEscape('"').withSeparator(',').withForceQuotation(true)
+            writer.writeArray("aaa", "bbb", "ccc")
+            writer.withForceQuotation(false)
+            writer.writeArray("zzz", "yyy", "xxx")
+
+            assertEquals(
+                """
+            "aaa","bbb","ccc"
+            zzz,yyy,xxx""".trimIndent(), output.toString()
+            )
         }
     }
+
+    @Test
+    fun `rfc4180 example 2-6`() {
+        StringWriter().use { output ->
+            val writer = CSVWriter(output)
+            writer.withEscape('"').withSeparator(',').withForceQuotation(true)
+            writer.writeArray("aaa", "b\nbb", "ccc")
+            writer.withForceQuotation(false)
+            writer.writeArray("zzz", "yyy", "xxx")
+
+            assertEquals(
+                """
+            "aaa","b
+            bb","ccc"
+            zzz,yyy,xxx
+           """.trimIndent(), output.toString()
+            )
+        }
+    }
+
+    @Test
+    fun `rfc4180 example 2-7 + extra line`() {
+        StringWriter().use { output ->
+            val writer = CSVWriter(output)
+            writer.withEscape('"').withSeparator(',').withForceQuotation(true)
+            writer.writeArray("aaa", "b\"bb", "ccc")
+            writer.withForceQuotation(false)
+            writer.writeArray("z\"zz", "yyy", "xxx")
+
+            assertEquals(
+                """
+            "aaa","b""bb","ccc"
+            "z""zz",yyy,xxx
+           """.trimIndent(), output.toString()
+            )
+        }
+    }
+
 
     @Test
     fun `throw an exception if we have to escape quotes, but there is no escape-char`() {
@@ -144,8 +197,8 @@ class CSVWriterTest {
                 writer.writeArray("\"a\";b")
             }
             assertEquals(
-                    "Cannot output a quotation character within a quoted string without an escape character.",
-                    exception.message
+                "Cannot output a quotation character within a quoted string without an escape character.",
+                exception.message
             )
         }
     }
@@ -159,8 +212,8 @@ class CSVWriterTest {
                 writer.writeArray("'a;b")
             }
             assertEquals(
-                    "Cannot output a column which contains the separator character ';' without an escape or quotation character.",
-                    exception.message
+                "Cannot output a column which contains the separator character ';' without an escape or quotation character.",
+                exception.message
             )
         }
     }
@@ -174,8 +227,8 @@ class CSVWriterTest {
                 writer.writeArray("a\nb")
             }
             assertEquals(
-                    "Cannot output a column which contains a line break without an quotation character.",
-                    exception.message
+                "Cannot output a column which contains a line break without an quotation character.",
+                exception.message
             )
         }
     }

--- a/src/test/kotlin/sirius/kernel/commons/CSVWriterTest.kt
+++ b/src/test/kotlin/sirius/kernel/commons/CSVWriterTest.kt
@@ -118,6 +118,20 @@ class CSVWriterTest {
     }
 
     @Test
+    fun `escaping works for escape character and quotation with rfc escape character`() {
+        StringWriter().use { output ->
+            val writer = CSVWriter(output)
+            writer.withEscape('"')
+
+            writer.writeArray("quote and separator: a;b\"", "quote only: c\"")
+
+            assertEquals(""" 
+                "quote and separator: a;b""${'"'};quote only: c" 
+                """.trimIndent().trim(), output.toString())
+        }
+    }
+
+    @Test
     fun `throw an exception if we have to escape quotes, but there is no escape-char`() {
         StringWriter().use { output ->
             val writer = CSVWriter(output).withEscape(0.toChar())

--- a/src/test/kotlin/sirius/kernel/commons/CSVWriterTest.kt
+++ b/src/test/kotlin/sirius/kernel/commons/CSVWriterTest.kt
@@ -125,9 +125,13 @@ class CSVWriterTest {
 
             writer.writeArray("quote and separator: a;b\"", "quote only: c\"")
 
-            assertEquals(""" 
-                "quote and separator: a;b""${'"'};quote only: c" 
-                """.trimIndent().trim(), output.toString())
+            assertEquals(
+                """ 
+                "quote and separator: a;b""${'"'};"quote only: c""${'"'} 
+                """.trimIndent().trim(), output.toString()
+            )
+        }
+    }
         }
     }
 

--- a/src/test/kotlin/sirius/kernel/commons/CSVWriterTest.kt
+++ b/src/test/kotlin/sirius/kernel/commons/CSVWriterTest.kt
@@ -102,7 +102,7 @@ class CSVWriterTest {
 
             writer.writeArray("a;b\"", "\\", "c")
 
-            assertEquals("\"a;b\\\"\";\\\\;c", output.toString())
+            assertEquals(""""a;b\"";\\;c""", output.toString())
         }
     }
 


### PR DESCRIPTION
### Description
CSV format is described in [RFC 4180](https://datatracker.ietf.org/doc/html/rfc4180). We now do enforce quoting of csv field values, if the value contains the quote character. 

### Additional Notes

- This PR fixes or works on following ticket(s): [SIRI-1110](https://scireum.myjetbrains.com/youtrack/issue/SIRI-1110)


### Checklist

- [x] Code change has been tested and works locally
- [x] Code was formatted via IntelliJ and follows SonarLint & [best practices](https://scireum.myjetbrains.com/youtrack/articles/MISC-A-16/CodeStyle-JavaDoc)
- [ ] Patch Tasks: Is local execution of Patch Tasks necessary? If so, please also mark the PR with the tag.
