### PR TITLE
Provide helper for quoting spaces in URLs

### DIFF
--- a/src/main/java/sirius/kernel/commons/Strings.java
+++ b/src/main/java/sirius/kernel/commons/Strings.java
@@ -12,18 +12,12 @@ import sirius.kernel.nls.NLS;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
-import java.net.URI;
-import java.net.URL;
-import java.net.URLDecoder;
-import java.net.URLEncoder;
-import java.nio.charset.StandardCharsets;
 import java.security.SecureRandom;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
-import java.util.function.Predicate;
 import java.util.function.UnaryOperator;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -290,10 +284,11 @@ public class Strings {
      *
      * @param value the string to check
      * @return <tt>true</tt> if the given string is an HTTP(S) URL, <tt>false</tt> otherwise
+     * @deprecated use {@link Urls#isHttpUrl(String)} instead.
      */
+    @Deprecated(since = "2025-06-11", forRemoval = true)
     public static boolean isHttpUrl(@Nullable String value) {
-        return isUrl(value,
-                     url -> "http".equalsIgnoreCase(url.getProtocol()) || "https".equalsIgnoreCase(url.getProtocol()));
+        return Urls.isHttpUrl(value);
     }
 
     /**
@@ -301,21 +296,11 @@ public class Strings {
      *
      * @param value the string to check
      * @return <tt>true</tt> if the given string is an HTTPS URL, <tt>false</tt> otherwise
+     * @deprecated use {@link Urls#isHttpsUrl(String)} instead.
      */
+    @Deprecated(since = "2025-06-11", forRemoval = true)
     public static boolean isHttpsUrl(@Nullable String value) {
-        return isUrl(value, url -> "https".equalsIgnoreCase(url.getProtocol()));
-    }
-
-    protected static boolean isUrl(@Nullable String value, Predicate<URL> checker) {
-        if (isEmpty(value)) {
-            return false;
-        }
-
-        try {
-            return checker.test(URI.create(value).toURL());
-        } catch (Exception exception) {
-            return false;
-        }
+        return Urls.isHttpsUrl(value);
     }
 
     /**
@@ -323,13 +308,12 @@ public class Strings {
      *
      * @param value the value to be encoded.
      * @return an url encoded representation of value, using UTF-8 as character encoding.
+     * @deprecated use {@link Urls#encode(String)} instead.
      */
     @Nullable
+    @Deprecated(since = "2025-06-11", forRemoval = true)
     public static String urlEncode(@Nullable String value) {
-        if (isFilled(value)) {
-            return URLEncoder.encode(value, StandardCharsets.UTF_8);
-        }
-        return value;
+        return Urls.encode(value);
     }
 
     /**
@@ -337,13 +321,12 @@ public class Strings {
      *
      * @param value the value to be decoded.
      * @return an url decoded representation of value, using UTF-8 as character encoding.
+     * @deprecated use {@link Urls#decode(String)} instead.
      */
     @Nullable
+    @Deprecated(since = "2025-06-11", forRemoval = true)
     public static String urlDecode(@Nullable String value) {
-        if (isFilled(value)) {
-            return URLDecoder.decode(value, StandardCharsets.UTF_8);
-        }
-        return value;
+        return Urls.decode(value);
     }
 
     /**

--- a/src/main/java/sirius/kernel/commons/URLBuilder.java
+++ b/src/main/java/sirius/kernel/commons/URLBuilder.java
@@ -187,7 +187,7 @@ public class URLBuilder {
         url.append("=");
         String stringValue = value == null ? "" : value.toString();
         if (urlEncode) {
-            stringValue = Strings.urlEncode(stringValue);
+            stringValue = Urls.encode(stringValue);
         }
         url.append(stringValue);
 

--- a/src/main/java/sirius/kernel/commons/Urls.java
+++ b/src/main/java/sirius/kernel/commons/Urls.java
@@ -1,0 +1,34 @@
+/*
+ * Made with all the love in the world
+ * by scireum in Remshalden, Germany
+ *
+ * Copyright by scireum GmbH
+ * http://www.scireum.de - info@scireum.de
+ */
+
+package sirius.kernel.commons;
+
+/**
+ * Provides various helper methods for working with {@linkplain java.net.URI URIs} and {@linkplain java.net.URL URLs}.
+ * <p>
+ * This class can and should not be instantiated, as all methods are static.
+ */
+public class Urls {
+
+    private Urls() {
+        // prevent instantiation
+    }
+
+    /**
+     * Tries to fix the given URL by replacing spaces with "%20".
+     *
+     * @param url the URL to fix
+     * @return the fixed URL with spaces replaced by "%20", or the original URL if it was null or empty
+     */
+    public static String quoteSpaces(String url) {
+        if (Strings.isEmpty(url)) {
+            return url;
+        }
+        return url.replace(" ", "%20");
+    }
+}

--- a/src/main/java/sirius/kernel/commons/Urls.java
+++ b/src/main/java/sirius/kernel/commons/Urls.java
@@ -8,6 +8,14 @@
 
 package sirius.kernel.commons;
 
+import javax.annotation.Nullable;
+import java.net.URI;
+import java.net.URL;
+import java.net.URLDecoder;
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
+import java.util.function.Predicate;
+
 /**
  * Provides various helper methods for working with {@linkplain java.net.URI URIs} and {@linkplain java.net.URL URLs}.
  * <p>
@@ -17,6 +25,67 @@ public class Urls {
 
     private Urls() {
         // prevent instantiation
+    }
+
+    /**
+     * Returns if the given string is an HTTP(S) URL.
+     *
+     * @param value the string to check
+     * @return <tt>true</tt> if the given string is an HTTP(S) URL, <tt>false</tt> otherwise
+     */
+    public static boolean isHttpUrl(@Nullable String value) {
+        return isUrl(value,
+                     url -> "http".equalsIgnoreCase(url.getProtocol()) || "https".equalsIgnoreCase(url.getProtocol()));
+    }
+
+    /**
+     * Returns if the given string is an HTTPS URL, explicitly excluding unencrypted HTTP URLs.
+     *
+     * @param value the string to check
+     * @return <tt>true</tt> if the given string is an HTTPS URL, <tt>false</tt> otherwise
+     */
+    public static boolean isHttpsUrl(@Nullable String value) {
+        return isUrl(value, url -> "https".equalsIgnoreCase(url.getProtocol()));
+    }
+
+    private static boolean isUrl(@Nullable String value, Predicate<URL> checker) {
+        if (Strings.isEmpty(value)) {
+            return false;
+        }
+
+        try {
+            return checker.test(URI.create(value).toURL());
+        } catch (Exception exception) {
+            return false;
+        }
+    }
+
+    /**
+     * Returns a URL-encoded representation of the given <tt>value</tt> with <tt>UTF-8</tt> as character encoding.
+     *
+     * @param value the value to be encoded.
+     * @return a URL-encoded representation of value, using UTF-8 as character encoding.
+     */
+    @Nullable
+    public static String encode(@Nullable String value) {
+        if (Strings.isFilled(value)) {
+            return URLEncoder.encode(value, StandardCharsets.UTF_8);
+        }
+        return value;
+    }
+
+    /**
+     * Returns a URL-decoded representation of the given <tt>value</tt> with <tt>UTF-8</tt> as character encoding.
+     *
+     * @param value the value to be decoded.
+     * @return a URL-decoded representation of value, using UTF-8 as character encoding.
+     */
+    @Nullable
+    public static String decode(@Nullable String value) {
+        if (Strings.isFilled(value)) {
+            return URLDecoder.decode(value, StandardCharsets.UTF_8);
+        }
+        return value;
     }
 
     /**

--- a/src/main/java/sirius/kernel/nls/Formatter.java
+++ b/src/main/java/sirius/kernel/nls/Formatter.java
@@ -9,6 +9,7 @@
 package sirius.kernel.nls;
 
 import sirius.kernel.commons.Strings;
+import sirius.kernel.commons.Urls;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -233,7 +234,7 @@ public class Formatter {
         }
 
         if (urlEncode) {
-            replacement.put(property, Strings.urlEncode(value));
+            replacement.put(property, Urls.encode(value));
             return this;
         }
 

--- a/src/test/kotlin/sirius/kernel/commons/StringsTest.kt
+++ b/src/test/kotlin/sirius/kernel/commons/StringsTest.kt
@@ -9,8 +9,6 @@
 package sirius.kernel.commons
 
 import org.junit.jupiter.api.Test
-import org.junit.jupiter.params.ParameterizedTest
-import org.junit.jupiter.params.provider.CsvSource
 import java.util.*
 import java.util.function.UnaryOperator
 import java.util.regex.Pattern
@@ -121,56 +119,6 @@ class StringsTest {
         assertNull(Strings.firstFilled())
         assertNull(Strings.firstFilled(null as String?))
         assertNull(Strings.firstFilled(""))
-    }
-
-    @ParameterizedTest
-    @CsvSource(
-        "true, https://example.com",
-        "true, HTTPS://example.com",
-        "true, http://example.com",
-        "true, Http://example.com?foo=bar",
-        "true, http://user:password@server.com/path",
-        "true, http://user@server.com/path",
-        "true, https://example.com/my/sample/page",
-        "true, http://example.com:8080/my/sample/page?user=foo&password=bar",
-        "false, https:// ;%@@ lol whatever i don't care",
-        "false, HttpS",
-        "false, ",
-        "false, ''",
-        "false, For testing look at https://example.com"
-    )
-    fun isHttpUrl(isUrl: Boolean, url: String?) {
-        assertEquals(isUrl, Strings.isHttpUrl(url))
-    }
-
-    @ParameterizedTest
-    @CsvSource(
-        "true, https://example.com",
-        "true, HTTPS://example.com",
-        "false, http://example.com",
-        "false, Http://example.com?foo=bar",
-        "false, http://user:password@server.com/path",
-        "false, http://user@server.com/path",
-        "true, https://example.com/my/sample/page",
-        "false, http://example.com:8080/my/sample/page?user=foo&password=bar",
-        "false, https:// ;%@@ lol whatever i don't care",
-        "false, HttpS",
-        "false, ",
-        "false, ''",
-        "false, For testing look at https://example.com"
-    )
-    fun isHttpsUrl(isUrl: Boolean, url: String?) {
-        assertEquals(isUrl, Strings.isHttpsUrl(url))
-    }
-
-    @Test
-    fun urlEncode() {
-        assertEquals("A%3FTEST%26B%C3%84%C3%96%C3%9C", Strings.urlEncode("A?TEST&BÄÖÜ"))
-    }
-
-    @Test
-    fun urlDecode() {
-        assertEquals("A?TEST&BÄÖÜ", Strings.urlDecode("A%3FTEST%26B%C3%84%C3%96%C3%9C"))
     }
 
     @Test

--- a/src/test/kotlin/sirius/kernel/commons/UrlsTest.kt
+++ b/src/test/kotlin/sirius/kernel/commons/UrlsTest.kt
@@ -9,6 +9,8 @@
 package sirius.kernel.commons
 
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.CsvSource
 import kotlin.test.assertEquals
 
 /**
@@ -16,13 +18,69 @@ import kotlin.test.assertEquals
  */
 class UrlsTest {
 
+    @ParameterizedTest
+    @CsvSource(
+        "true, https://example.com",
+        "true, HTTPS://example.com",
+        "true, http://example.com",
+        "true, Http://example.com?foo=bar",
+        "true, http://user:password@server.com/path",
+        "true, http://user@server.com/path",
+        "true, https://example.com/my/sample/page",
+        "true, http://example.com:8080/my/sample/page?user=foo&password=bar",
+        "false, https:// ;%@@ lol whatever i don't care",
+        "false, HttpS",
+        "false, ",
+        "false, ''",
+        "false, For testing look at https://example.com"
+    )
+    fun isHttpUrl(isUrl: Boolean, url: String?) {
+        assertEquals(isUrl, Urls.isHttpUrl(url))
+    }
+
+    @ParameterizedTest
+    @CsvSource(
+        "true, https://example.com",
+        "true, HTTPS://example.com",
+        "false, http://example.com",
+        "false, Http://example.com?foo=bar",
+        "false, http://user:password@server.com/path",
+        "false, http://user@server.com/path",
+        "true, https://example.com/my/sample/page",
+        "false, http://example.com:8080/my/sample/page?user=foo&password=bar",
+        "false, https:// ;%@@ lol whatever i don't care",
+        "false, HttpS",
+        "false, ",
+        "false, ''",
+        "false, For testing look at https://example.com"
+    )
+    fun isHttpsUrl(isUrl: Boolean, url: String?) {
+        assertEquals(isUrl, Urls.isHttpsUrl(url))
+    }
+
+    @Test
+    fun encode() {
+        assertEquals("A%3FTEST%26B%C3%84%C3%96%C3%9C", Urls.encode("A?TEST&BÄÖÜ"))
+    }
+
+    @Test
+    fun decode() {
+        assertEquals("A?TEST&BÄÖÜ", Urls.decode("A%3FTEST%26B%C3%84%C3%96%C3%9C"))
+    }
+
     @Test
     fun quoteSpaces() {
         assertEquals("https://example.com/hello%20world", Urls.quoteSpaces("https://example.com/hello world"))
         assertEquals("https://example.com/hello%20world", Urls.quoteSpaces("https://example.com/hello%20world"))
         assertEquals("https://example.com/hello+world", Urls.quoteSpaces("https://example.com/hello+world"))
-        assertEquals("https://example.com/helloworld?test=a%20b", Urls.quoteSpaces("https://example.com/helloworld?test=a b"))
-        assertEquals("https://example.com/helloworld?test=a%20b", Urls.quoteSpaces("https://example.com/helloworld?test=a%20b"))
-        assertEquals("https://example.com/helloworld?test=a+b", Urls.quoteSpaces("https://example.com/helloworld?test=a+b"))
+        assertEquals(
+            "https://example.com/helloworld?test=a%20b", Urls.quoteSpaces("https://example.com/helloworld?test=a b")
+        )
+        assertEquals(
+            "https://example.com/helloworld?test=a%20b", Urls.quoteSpaces("https://example.com/helloworld?test=a%20b")
+        )
+        assertEquals(
+            "https://example.com/helloworld?test=a+b", Urls.quoteSpaces("https://example.com/helloworld?test=a+b")
+        )
     }
 }

--- a/src/test/kotlin/sirius/kernel/commons/UrlsTest.kt
+++ b/src/test/kotlin/sirius/kernel/commons/UrlsTest.kt
@@ -1,0 +1,28 @@
+/*
+ * Made with all the love in the world
+ * by scireum in Remshalden, Germany
+ *
+ * Copyright by scireum GmbH
+ * http://www.scireum.de - info@scireum.de
+ */
+
+package sirius.kernel.commons
+
+import org.junit.jupiter.api.Test
+import kotlin.test.assertEquals
+
+/**
+ * Tests the [Strings] class.
+ */
+class UrlsTest {
+
+    @Test
+    fun quoteSpaces() {
+        assertEquals("https://example.com/hello%20world", Urls.quoteSpaces("https://example.com/hello world"))
+        assertEquals("https://example.com/hello%20world", Urls.quoteSpaces("https://example.com/hello%20world"))
+        assertEquals("https://example.com/hello+world", Urls.quoteSpaces("https://example.com/hello+world"))
+        assertEquals("https://example.com/helloworld?test=a%20b", Urls.quoteSpaces("https://example.com/helloworld?test=a b"))
+        assertEquals("https://example.com/helloworld?test=a%20b", Urls.quoteSpaces("https://example.com/helloworld?test=a%20b"))
+        assertEquals("https://example.com/helloworld?test=a+b", Urls.quoteSpaces("https://example.com/helloworld?test=a+b"))
+    }
+}

--- a/src/test/kotlin/sirius/kernel/commons/UrlsTest.kt
+++ b/src/test/kotlin/sirius/kernel/commons/UrlsTest.kt
@@ -12,7 +12,7 @@ import org.junit.jupiter.api.Test
 import kotlin.test.assertEquals
 
 /**
- * Tests the [Strings] class.
+ * Tests the [Urls] class.
  */
 class UrlsTest {
 


### PR DESCRIPTION
### Description

We known that spaces in URLs are prohibited but in some cases they are provided as such in XML-files. This is necessary as the URI constructor that handles a full URL string does not do this automatically. Before the deprecation of the URL constructors we would use a workaround where we first create a URL and then pass all components of the URL in the specific URI constructor which would escape the path and query accordingly. With the deprecation that logic was switched back to the URI constructor and the functionality broke.

With this helper we now can explicitly force this behavior where necessary.

### Additional Notes

- This PR fixes or works on following ticket(s): [OX-11739](https://scireum.myjetbrains.com/youtrack/issue/OX-11739)

### Checklist

- [x] Code change has been tested and works locally
- [x] Code was formatted via IntelliJ and follows SonarLint & [best practices](https://scireum.myjetbrains.com/youtrack/articles/MISC-A-16/CodeStyle-JavaDoc)
- [ ] Patch Tasks: Is local execution of Patch Tasks necessary? If so, please also mark the PR with the tag.
