### PR TITLE
Improves json amount reading

### DIFF
--- a/src/main/java/sirius/kernel/commons/Json.java
+++ b/src/main/java/sirius/kernel/commons/Json.java
@@ -573,6 +573,9 @@ public class Json {
         if (node.isTextual()) {
             return Amount.ofMachineString(node.textValue());
         }
+        if (node.isPojo()) {
+            return tryGetFromPojoNode(node, Amount.class).orElse(Amount.NOTHING);
+        }
         return Amount.NOTHING;
     }
 
@@ -587,6 +590,9 @@ public class Json {
     @Nonnull
     public static Optional<LocalDate> tryValueDate(@Nonnull JsonNode jsonNode, String fieldName) {
         JsonNode node = jsonNode.get(fieldName);
+        if (node != null && node.isPojo()) {
+            return tryGetFromPojoNode(node, LocalDate.class);
+        }
         if (node == null || node.isNull() || !node.isTextual()) {
             return Optional.empty();
         }
@@ -609,6 +615,9 @@ public class Json {
     @Nonnull
     public static Optional<LocalDateTime> tryValueDateTime(@Nonnull JsonNode jsonNode, String fieldName) {
         JsonNode node = jsonNode.get(fieldName);
+        if (node != null && node.isPojo()) {
+            return tryGetFromPojoNode(node, LocalDateTime.class);
+        }
         if (node == null || node.isNull() || !node.isTextual()) {
             return Optional.empty();
         }
@@ -617,5 +626,13 @@ public class Json {
         } catch (DateTimeParseException exception) {
             return Optional.empty();
         }
+    }
+
+    private static <T> Optional<T> tryGetFromPojoNode(JsonNode node, Class<T> targetClass) {
+        if (node.isPojo() && node instanceof POJONode pojoNode && targetClass.isInstance(pojoNode.getPojo())) {
+            return Optional.of(targetClass.cast(pojoNode.getPojo()));
+        }
+
+        return Optional.empty();
     }
 }

--- a/src/main/java/sirius/kernel/commons/Json.java
+++ b/src/main/java/sirius/kernel/commons/Json.java
@@ -64,7 +64,8 @@ public class Json {
                               .registerModule(new JavaTimeModule());
 
     static {
-        MAPPER.getFactory().setStreamReadConstraints(StreamReadConstraints.builder().maxStringLength(25_000_000).build());
+        MAPPER.getFactory()
+              .setStreamReadConstraints(StreamReadConstraints.builder().maxStringLength(25_000_000).build());
     }
 
     private Json() {

--- a/src/test/kotlin/sirius/kernel/commons/JsonTest.kt
+++ b/src/test/kotlin/sirius/kernel/commons/JsonTest.kt
@@ -421,4 +421,28 @@ class JsonTest {
         assertEquals(inputAmount, parsedAmount)
     }
 
+    @Test
+    fun `Read Amount from POJONode`() {
+        val inputAmount = Amount.ofRounded(BigDecimal("1.23456789"))
+        val objectNode = Json.createObject().putPOJO("amount", inputAmount)
+        val amountFromPojo = Json.getValueAmount(objectNode, "amount")
+        assertEquals(inputAmount, amountFromPojo)
+    }
+
+    @Test
+    fun `Read LocalDate from POJONode`() {
+        val inputDate = LocalDate.now()
+        val objectNode = Json.createObject().putPOJO("localDate", inputDate)
+        val localDateFromPojo = Json.tryValueDate(objectNode, "localDate").orElse(null)
+        assertEquals(inputDate, localDateFromPojo)
+    }
+
+    @Test
+    fun `Read LocalDateTime from POJONode`() {
+        val inputDateTime = LocalDateTime.now()
+        val objectNode = Json.createObject().putPOJO("localDateTime", inputDateTime)
+        val localDateTimeFromPojo = Json.tryValueDateTime(objectNode, "localDateTime").orElse(null)
+        assertEquals(inputDateTime, localDateTimeFromPojo)
+    }
+
 }

--- a/src/test/kotlin/sirius/kernel/commons/JsonTest.kt
+++ b/src/test/kotlin/sirius/kernel/commons/JsonTest.kt
@@ -93,10 +93,10 @@ class JsonTest {
         val date = LocalDate.now()
         val time = LocalDateTime.now()
         val node = Json.createObject()
-                .put("foo", 123)
-                .put("bar", "baz")
-                .putPOJO("date", date)
-                .putPOJO("time", time)
+            .put("foo", 123)
+            .put("bar", "baz")
+            .putPOJO("date", date)
+            .putPOJO("time", time)
         val formattedTime = DateTimeFormatter.ISO_LOCAL_DATE_TIME.format(time)
         val json = Json.write(node)
         assertEquals("""{"foo":123,"bar":"baz","date":"$date","time":"$formattedTime"}""", json)
@@ -281,7 +281,7 @@ class JsonTest {
     @Test
     fun `tryGetArrayAt works with arrays as POJO Nodes`() {
         val node = Json.createObject()
-                .set<ObjectNode>("nested", Json.createObject().putPOJO("foo", listOf(1, 2, 3)).put("bar", 123))
+            .set<ObjectNode>("nested", Json.createObject().putPOJO("foo", listOf(1, 2, 3)).put("bar", 123))
 
         val presentArray: Optional<ArrayNode> = Json.tryGetArrayAt(node, Json.createPointer("nested/foo"))
         assertTrue(presentArray.isPresent)
@@ -346,7 +346,7 @@ class JsonTest {
     @Test
     fun `getValueAmount reads value from number and string`() {
         val json =
-                """{"number_1": 123,"number_2": -123,"number_3": 12.3,"number_4": 1.0E+2,"string": "123","null":null}"""
+            """{"number_1": 123,"number_2": -123,"number_3": 12.3,"number_4": 1.0E+2,"string": "123","null":null}"""
         val node = Json.parseObject(json)
 
         assertEquals(Amount.of(123L), Json.getValueAmount(node, "number_1"))
@@ -373,7 +373,7 @@ class JsonTest {
     @Test
     fun `tryValueString reads string value from string, number and boolean`() {
         val json =
-                """{ "number": 123, "string": "blablabla", "null": null, "bool": true, "obj": {"a": "b"}, "array": [] }"""
+            """{ "number": 123, "string": "blablabla", "null": null, "bool": true, "obj": {"a": "b"}, "array": [] }"""
         val node = Json.parseObject(json)
 
         assertEquals("123", Json.tryValueString(node, "number").get())


### PR DESCRIPTION
### Description
A json object in Java might not only be created from a serialized representation, but also using POJOs. Adapt our Json utility to read in specific types in some methods properly from Jackson POJONodes. 

### Additional Notes

- This PR fixes or works on following ticket(s): [SE-14628](https://scireum.myjetbrains.com/youtrack/issue/SE-14628)

### Checklist

- [ ] Code change has been tested and works locally
- [ ] Code was formatted via IntelliJ and follows SonarLint & [best practices](https://scireum.myjetbrains.com/youtrack/articles/MISC-A-16/CodeStyle-JavaDoc)
- [ ] Patch Tasks: Is local execution of Patch Tasks necessary? If so, please also mark the PR with the tag.
