### PR TITLE
Upgrades commons lang3 version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -88,6 +88,12 @@
             <groupId>com.fasterxml.jackson.datatype</groupId>
             <artifactId>jackson-datatype-jsr310</artifactId>
         </dependency>
+        <!-- Changelog: https://commons.apache.org/proper/commons-lang/changes.html -->
+        <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-lang3</artifactId>
+            <version>3.18.0</version>
+        </dependency>
         <!-- Required, as the version provided by docker-compose-rule-core has security issues
              END: -->
     </dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -70,14 +70,15 @@
                 </exclusion>
             </exclusions>
         </dependency>
-        <!-- Required, as the version provided by docker-compose-rule-core has security issues -->
+
+        <!-- START:
+             Required, as the version provided by docker-compose-rule-core has security issues -->
         <!-- Changelog: https://github.com/apache/commons-io/blob/master/RELEASE-NOTES.txt -->
         <dependency>
             <groupId>commons-io</groupId>
             <artifactId>commons-io</artifactId>
             <version>2.19.0</version>
         </dependency>
-        <!-- Required, as the version provided by docker-compose-rule-core has security issues -->
         <!-- Changelog: https://github.com/FasterXML/jackson/wiki/Jackson-Releases -->
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
@@ -87,5 +88,7 @@
             <groupId>com.fasterxml.jackson.datatype</groupId>
             <artifactId>jackson-datatype-jsr310</artifactId>
         </dependency>
+        <!-- Required, as the version provided by docker-compose-rule-core has security issues
+             END: -->
     </dependencies>
 </project>


### PR DESCRIPTION
### Description
Includes current version of commons lang3 as transitive dependency from docker-compose-rule-core is outdated

### Additional Notes
- This PR fixes or works on following ticket(s): [SIRI-1072](https://scireum.myjetbrains.com/youtrack/issue/SIRI-1072)


### Checklist

- [x] Code change has been tested and works locally
- [x] Code was formatted via IntelliJ and follows SonarLint & [best practices](https://scireum.myjetbrains.com/youtrack/articles/MISC-A-16/CodeStyle-JavaDoc)
- [ ] Patch Tasks: Is local execution of Patch Tasks necessary? If so, please also mark the PR with the tag.
