### PR TITLE
Makes reoccuring blacklist logs skippable

### DIFF
--- a/src/main/java/sirius/kernel/io/IOExceptionSkipLog.java
+++ b/src/main/java/sirius/kernel/io/IOExceptionSkipLog.java
@@ -14,14 +14,18 @@ import java.io.IOException;
 import java.io.Serial;
 
 /**
- * This class gets used as an {@linkplain IOException#getCause() IOException's cause} to mark that this exception
+ * This class gets used as a special kind of {@linkplain IOException} to mark that a failed IO operation
  * should not be logged.
  * <p>
  * Possible, to be skipped log messages are those, that contain no information and only spoil the log file, like
  * error from requests that not get executed due to the blacklisting feature of {@linkplain Outcall outcall}.
  */
-public class IoSkipLogException extends Exception {
+public class IOExceptionSkipLog extends IOException {
 
     @Serial
     private static final long serialVersionUID = 4787224866678714833L;
+
+    public IOExceptionSkipLog(String message) {
+        super(message);
+    }
 }

--- a/src/main/java/sirius/kernel/io/IoSkipLogException.java
+++ b/src/main/java/sirius/kernel/io/IoSkipLogException.java
@@ -1,0 +1,27 @@
+/*
+ * Made with all the love in the world
+ * by scireum in Stuttgart, Germany
+ *
+ * Copyright by scireum GmbH
+ * https://www.scireum.de - info@scireum.de
+ */
+
+package sirius.kernel.io;
+
+import sirius.kernel.xml.Outcall;
+
+import java.io.IOException;
+import java.io.Serial;
+
+/**
+ * This class gets used as an {@linkplain IOException#getCause() IOException's cause} to mark that this exception
+ * should not be logged.
+ * <p>
+ * Possible, to be skipped log messages are those, that contain no information and only spoil the log file, like
+ * error from requests that not get executed due to the blacklisting feature of {@linkplain Outcall outcall}.
+ */
+public class IoSkipLogException extends Exception {
+
+    @Serial
+    private static final long serialVersionUID = 4787224866678714833L;
+}

--- a/src/main/java/sirius/kernel/xml/Outcall.java
+++ b/src/main/java/sirius/kernel/xml/Outcall.java
@@ -15,6 +15,7 @@ import sirius.kernel.commons.Explain;
 import sirius.kernel.commons.Monoflop;
 import sirius.kernel.commons.Streams;
 import sirius.kernel.commons.Strings;
+import sirius.kernel.commons.Tuple;
 import sirius.kernel.commons.Watch;
 import sirius.kernel.di.std.ConfigValue;
 import sirius.kernel.health.Average;
@@ -110,8 +111,11 @@ public class Outcall {
      * <p>
      * These hosts are blacklisted for a short amount of time ({@link #connectTimeoutBlacklistDuration}) to prevent
      * cascading failures.
+     * <p>
+     * We log a warning for each host which is blacklisted and is called again. To make sure this doesn't spam the logs,
+     * we only log once and then set the second value of the tuple to <tt>true</tt> to prevent further log messages.
      */
-    private static final Map<String, Long> timeoutBlacklist = new ConcurrentHashMap<>();
+    private static final Map<String, Tuple<Long, Boolean>> timeoutBlacklist = new ConcurrentHashMap<>();
 
     /**
      * If the {@link #timeoutBlacklist} contains more than the given number of entries, we remove all expired ones
@@ -494,15 +498,25 @@ public class Outcall {
             return;
         }
 
-        Long timeout = timeoutBlacklist.get(blacklistId);
-        if (timeout != null) {
-            if (timeout > System.currentTimeMillis()) {
+        Tuple<Long, Boolean> blacklistedHostInformation = timeoutBlacklist.get(blacklistId);
+        if(blacklistedHostInformation == null) {
+            return;
+        }
+
+        Long timeout = blacklistedHostInformation.getFirst();
+        if (timeout == null) {
+            return;
+        }
+
+        if (timeout > System.currentTimeMillis()) {
+            if (Boolean.FALSE.equals(blacklistedHostInformation.getSecond())) {
+                blacklistedHostInformation.setSecond(true);
                 throw new IOException(Strings.apply(
                         "Connections with blacklist identifier %s are currently rejected due to connectivity issues.",
                         blacklistId));
-            } else {
-                timeoutBlacklist.remove(blacklistId);
             }
+        } else {
+            timeoutBlacklist.remove(blacklistId);
         }
     }
 
@@ -512,11 +526,11 @@ public class Outcall {
         }
 
         long now = System.currentTimeMillis();
-        timeoutBlacklist.put(blacklistId, now + connectTimeoutBlacklistDuration.toMillis());
+        timeoutBlacklist.put(blacklistId, new Tuple<>(now + connectTimeoutBlacklistDuration.toMillis(), false));
         if (timeoutBlacklist.size() > TIMEOUT_BLACKLIST_HIGH_WATERMARK) {
             // We collected a bunch of hosts - try to some cleanup (remove all hosts for which the timeout expired)...
             timeoutBlacklist.forEach((id, timeout) -> {
-                if (timeout < now) {
+                if (timeout.getFirst() < now) {
                     timeoutBlacklist.remove(id);
                 }
             });

--- a/src/main/java/sirius/kernel/xml/Outcall.java
+++ b/src/main/java/sirius/kernel/xml/Outcall.java
@@ -21,6 +21,7 @@ import sirius.kernel.di.std.ConfigValue;
 import sirius.kernel.health.Average;
 import sirius.kernel.health.Exceptions;
 import sirius.kernel.health.Microtiming;
+import sirius.kernel.io.IoSkipLogException;
 import sirius.kernel.nls.NLS;
 import sirius.kernel.settings.Extension;
 
@@ -515,6 +516,9 @@ public class Outcall {
                         "Connections with blacklist identifier %s are currently rejected due to connectivity issues.",
                         blacklistId));
             }
+            throw new IOException(Strings.apply(
+                    "Connections with blacklist identifier %s are currently rejected due to connectivity issues.",
+                    blacklistId), new IoSkipLogException());
         } else {
             timeoutBlacklist.remove(blacklistId);
         }

--- a/src/main/java/sirius/kernel/xml/Outcall.java
+++ b/src/main/java/sirius/kernel/xml/Outcall.java
@@ -480,7 +480,7 @@ public class Outcall {
                 request = requestBuilder.build();
                 performRequest();
             }
-        } catch (InterruptedException exception) {
+        } catch (InterruptedException _) {
             Thread.currentThread().interrupt();
             throw new IOException("Thread was interrupted!");
         } catch (HttpTimeoutException | ConnectException | SocketTimeoutException exception) {

--- a/src/main/java/sirius/kernel/xml/Outcall.java
+++ b/src/main/java/sirius/kernel/xml/Outcall.java
@@ -499,7 +499,7 @@ public class Outcall {
         }
 
         Tuple<Long, Boolean> blacklistedHostInformation = timeoutBlacklist.get(blacklistId);
-        if(blacklistedHostInformation == null) {
+        if (blacklistedHostInformation == null) {
             return;
         }
 
@@ -526,7 +526,7 @@ public class Outcall {
         }
 
         long now = System.currentTimeMillis();
-        timeoutBlacklist.put(blacklistId, new Tuple<>(now + connectTimeoutBlacklistDuration.toMillis(), false));
+        timeoutBlacklist.put(blacklistId, Tuple.create(now + connectTimeoutBlacklistDuration.toMillis(), false));
         if (timeoutBlacklist.size() > TIMEOUT_BLACKLIST_HIGH_WATERMARK) {
             // We collected a bunch of hosts - try to some cleanup (remove all hosts for which the timeout expired)...
             timeoutBlacklist.forEach((id, timeout) -> {

--- a/src/main/java/sirius/kernel/xml/Outcall.java
+++ b/src/main/java/sirius/kernel/xml/Outcall.java
@@ -21,7 +21,7 @@ import sirius.kernel.di.std.ConfigValue;
 import sirius.kernel.health.Average;
 import sirius.kernel.health.Exceptions;
 import sirius.kernel.health.Microtiming;
-import sirius.kernel.io.IoSkipLogException;
+import sirius.kernel.io.IOExceptionSkipLog;
 import sirius.kernel.nls.NLS;
 import sirius.kernel.settings.Extension;
 
@@ -517,9 +517,9 @@ public class Outcall {
                         blacklistId,
                         LocalDateTime.ofEpochSecond(timeout / 1000, 0, ZoneOffset.UTC)));
             }
-            throw new IOException(Strings.apply(
+            throw new IOExceptionSkipLog(Strings.apply(
                     "Connections with blacklist identifier %s are currently rejected due to connectivity issues.",
-                    blacklistId), new IoSkipLogException());
+                    blacklistId));
         } else {
             timeoutBlacklist.remove(blacklistId);
         }

--- a/src/main/java/sirius/kernel/xml/Outcall.java
+++ b/src/main/java/sirius/kernel/xml/Outcall.java
@@ -513,8 +513,9 @@ public class Outcall {
             if (Boolean.FALSE.equals(blacklistedHostInformation.getSecond())) {
                 blacklistedHostInformation.setSecond(true);
                 throw new IOException(Strings.apply(
-                        "Connections with blacklist identifier %s are currently rejected due to connectivity issues.",
-                        blacklistId));
+                        "Connections with blacklist identifier %s get rejected until %s due to connectivity issues.",
+                        blacklistId,
+                        LocalDateTime.ofEpochSecond(timeout / 1000, 0, ZoneOffset.UTC)));
             }
             throw new IOException(Strings.apply(
                     "Connections with blacklist identifier %s are currently rejected due to connectivity issues.",

--- a/src/main/java/sirius/kernel/xml/SOAPClient.java
+++ b/src/main/java/sirius/kernel/xml/SOAPClient.java
@@ -15,7 +15,7 @@ import sirius.kernel.health.Average;
 import sirius.kernel.health.Exceptions;
 import sirius.kernel.health.HandledException;
 import sirius.kernel.health.Log;
-import sirius.kernel.io.IoSkipLogException;
+import sirius.kernel.io.IOExceptionSkipLog;
 
 import javax.annotation.CheckReturnValue;
 import javax.annotation.Nonnull;
@@ -363,8 +363,8 @@ public class SOAPClient {
             return handleResult(watch, action, effectiveEndpoint, result);
         } catch (SOAPFaultException | HandledException exception) {
             throw exception;
-        } catch (IOException exception) {
-            return handleIOException(watch, action, effectiveEndpoint, exception);
+        } catch (IOExceptionSkipLog exception) {
+            return handleIOExceptionSkipLog(watch, action, effectiveEndpoint, exception);
         } catch (Exception exception) {
             return handleGeneralFault(watch, action, effectiveEndpoint, exception);
         }
@@ -486,21 +486,18 @@ public class SOAPClient {
                                               .handle());
     }
 
-    private StructuredNode handleIOException(Watch watch,
-                                             String action,
-                                             URL effectiveEndpoint,
-                                             IOException ioException) {
-        if (ioException.getCause() instanceof IoSkipLogException) {
-            throw exceptionFilter.apply(Exceptions.createHandled()
-                                                  .to(LOG)
-                                                  .error(ioException)
-                                                  .withSystemErrorMessage(
-                                                          "An error occurred when executing '%s' against '%s': %s (%s)",
-                                                          action,
-                                                          effectiveEndpoint)
-                                                  .handle());
-        }
-        return handleGeneralFault(watch, action, effectiveEndpoint, ioException);
+    private StructuredNode handleIOExceptionSkipLog(Watch watch,
+                                                    String action,
+                                                    URL effectiveEndpoint,
+                                                    IOExceptionSkipLog exception) {
+        throw exceptionFilter.apply(Exceptions.createHandled()
+                                              .to(LOG)
+                                              .error(exception)
+                                              .withSystemErrorMessage(
+                                                      "An error occurred when executing '%s' against '%s': %s (%s)",
+                                                      action,
+                                                      effectiveEndpoint)
+                                              .handle());
     }
 
     /**

--- a/src/main/java/sirius/kernel/xml/SOAPClient.java
+++ b/src/main/java/sirius/kernel/xml/SOAPClient.java
@@ -15,6 +15,7 @@ import sirius.kernel.health.Average;
 import sirius.kernel.health.Exceptions;
 import sirius.kernel.health.HandledException;
 import sirius.kernel.health.Log;
+import sirius.kernel.io.IoSkipLogException;
 
 import javax.annotation.CheckReturnValue;
 import javax.annotation.Nonnull;
@@ -362,6 +363,8 @@ public class SOAPClient {
             return handleResult(watch, action, effectiveEndpoint, result);
         } catch (SOAPFaultException | HandledException exception) {
             throw exception;
+        } catch (IOException exception) {
+            return handleIOException(watch, action, effectiveEndpoint, exception);
         } catch (Exception exception) {
             return handleGeneralFault(watch, action, effectiveEndpoint, exception);
         }
@@ -481,6 +484,23 @@ public class SOAPClient {
                                                       action,
                                                       effectiveEndpoint)
                                               .handle());
+    }
+
+    private StructuredNode handleIOException(Watch watch,
+                                             String action,
+                                             URL effectiveEndpoint,
+                                             IOException ioException) {
+        if (ioException.getCause() instanceof IoSkipLogException) {
+            throw exceptionFilter.apply(Exceptions.createHandled()
+                                                  .to(LOG)
+                                                  .error(ioException)
+                                                  .withSystemErrorMessage(
+                                                          "An error occurred when executing '%s' against '%s': %s (%s)",
+                                                          action,
+                                                          effectiveEndpoint)
+                                                  .handle());
+        }
+        return handleGeneralFault(watch, action, effectiveEndpoint, ioException);
     }
 
     /**

--- a/src/test/kotlin/sirius/kernel/xml/SoapClientTest.kt
+++ b/src/test/kotlin/sirius/kernel/xml/SoapClientTest.kt
@@ -1,0 +1,51 @@
+/*
+ * Made with all the love in the world
+ * by scireum in Remshalden, Germany
+ *
+ * Copyright by scireum GmbH
+ * http://www.scireum.de - info@scireum.de
+ */
+
+package sirius.kernel.xml
+
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import org.junit.jupiter.api.extension.ExtendWith
+import sirius.kernel.SiriusExtension
+import sirius.kernel.health.HandledException
+import sirius.kernel.health.LogHelper
+import java.net.URI
+import java.util.logging.Level
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+/**
+ * Tests the [SOAPClient] class.
+ */
+@ExtendWith(SiriusExtension::class)
+internal class SOAPClientTest {
+
+    @Test
+    fun `Unsuccessful SOAPClient calls getting blacklisted get logged only once`() {
+        // Use a non-existing endpoint to provoke an exception
+        val soapClient = SOAPClient(URI.create("http://localhost:2345").toURL())
+
+        // First call with an expected, non blacklist exception
+        assertThrows<HandledException> { soapClient.call("action") {} }
+
+        // Second call, the first call being blacklisted with a blacklist message being logged
+        LogHelper.clearMessages()
+        assertThrows<HandledException> { soapClient.call("action") {} }
+        assertTrue { hasBlacklistLogMessage() }
+
+        // On follow-up calls, no blacklisting messages must be logged
+        LogHelper.clearMessages()
+        assertThrows<HandledException> { soapClient.call("action") {} }
+        assertFalse { hasBlacklistLogMessage() }
+    }
+
+    private fun hasBlacklistLogMessage(): Boolean {
+        return LogHelper.hasMessage(Level.SEVERE, SOAPClient.LOG, ".*blacklist identifier localhost.*")
+    }
+
+}


### PR DESCRIPTION
### Description
When calling unaccessible remote endpoints using Outcall, we might generate a lot of log files. Hereby we mark the exception thrown by the blacklist mechanism, so we can properly react on the not execution of the call and decide if the message should be logged. 

The first two commits bring back the implementation of https://github.com/scireum/sirius-kernel/pull/511 that was reverted by https://github.com/scireum/sirius-kernel/pull/571. The other commits fix it, so that follow up blacklisted call still throw an exception, but mark it as to be skipped. 

Also for SOAPClient we are able to provide the log message skip implementation in here. It can be used as an example on how to implement the skipping in other implementations using Outcall or it's xml and json aware convenience classes. 

### Additional Notes
- This PR fixes or works on following ticket(s): [SIRI-1118](https://scireum.myjetbrains.com/youtrack/issue/SIRI-1118)


### Checklist

- [x] Code change has been tested and works locally
- [x] Code was formatted via IntelliJ and follows SonarLint & [best practices](https://scireum.myjetbrains.com/youtrack/articles/MISC-A-16/CodeStyle-JavaDoc)
- [ ] Patch Tasks: Is local execution of Patch Tasks necessary? If so, please also mark the PR with the tag.
