### PR TITLE
Adds asStringList to a Value

### DIFF
--- a/src/main/java/sirius/kernel/commons/Value.java
+++ b/src/main/java/sirius/kernel/commons/Value.java
@@ -732,7 +732,7 @@ public class Value {
         if (data instanceof Collection<?> collection) {
             return collection.stream().map(Object::toString).toList();
         }
-        if (isEmptyString()) {
+        if (isNull()) {
             return List.of();
         }
         return List.of(asString());

--- a/src/main/java/sirius/kernel/commons/Value.java
+++ b/src/main/java/sirius/kernel/commons/Value.java
@@ -729,8 +729,8 @@ public class Value {
      */
     @Nonnull
     public List<String> asStringList() {
-        if (data instanceof Collection<?>) {
-            return ((Collection<?>) data).stream().map(Object::toString).toList();
+        if (data instanceof Collection<?> collection) {
+            return collection.stream().map(Object::toString).toList();
         }
         if (isEmptyString()) {
             return List.of();

--- a/src/main/java/sirius/kernel/commons/Value.java
+++ b/src/main/java/sirius/kernel/commons/Value.java
@@ -719,6 +719,26 @@ public class Value {
     }
 
     /**
+     * Returns the wrapped data as a list of strings.
+     * <p>
+     * If the wrapped data is a collection, each element will be converted to a string using
+     * {@link Object#toString()}. If the wrapped data is not a collection, a list containing
+     * a single element representing the string value of the wrapped data will be returned.
+     *
+     * @return a list of strings representing the wrapped data
+     */
+    @Nonnull
+    public List<String> asStringList() {
+        if (data instanceof Collection<?>) {
+            return ((Collection<?>) data).stream().map(Object::toString).toList();
+        }
+        if (isEmptyString()) {
+            return List.of();
+        }
+        return List.of(asString());
+    }
+
+    /**
      * Returns the unprocessed string representation of the wrapped value.
      * <p>
      * In contrast to {@link #getString()} this method <b>will not</b> trim the wrapped string value.


### PR DESCRIPTION
### Description

Until now, we could only retrieve data that is a list or a single value using the get() method, which is rather cumbersome and unattractive. This PR introduces a new method that directly ensures that we get a List<String> back.

### Additional Notes

- This PR fixes or works on following ticket(s): [SIRI-1174](https://scireum.myjetbrains.com/youtrack/issue/SIRI-1174)

### Checklist

- [x] Code change has been tested and works locally
- [x] Code was formatted via IntelliJ and follows SonarLint & [best practices](https://scireum.myjetbrains.com/youtrack/articles/MISC-A-16/CodeStyle-JavaDoc)
- [ ] Patch Tasks: Is local execution of Patch Tasks necessary? If so, please also mark the PR with the tag.
