### PR TITLE
Caffeine for Caching

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -53,6 +53,14 @@
             <version>2.0.17</version>
         </dependency>
 
+        <!-- More efficient caching library, a drop-in replacement for the (faulty?) Guava cache -->
+        <!-- Changelog: https://github.com/ben-manes/caffeine/releases -->
+        <dependency>
+            <groupId>com.github.ben-manes.caffeine</groupId>
+            <artifactId>caffeine</artifactId>
+            <version>3.2.3</version>
+        </dependency>
+
         <!-- Used to auto-start Docker environments. Excluding dependencies not required for docker-compose. -->
         <!-- Changelog: https://github.com/palantir/docker-compose-rule/releases -->
         <dependency>

--- a/src/main/java/sirius/kernel/cache/Cache.java
+++ b/src/main/java/sirius/kernel/cache/Cache.java
@@ -14,7 +14,7 @@ import sirius.kernel.commons.Tuple;
 import javax.annotation.CheckReturnValue;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
-import java.util.Date;
+import java.time.Instant;
 import java.util.Iterator;
 import java.util.List;
 import java.util.function.BiPredicate;
@@ -98,7 +98,7 @@ public interface Cache<K, V> {
      *
      * @return the timestamp of the last eviction
      */
-    Date getLastEvictionRun();
+    Instant getLastEvictionRun();
 
     /**
      * Clears the complete cache

--- a/src/main/java/sirius/kernel/cache/ManagedCache.java
+++ b/src/main/java/sirius/kernel/cache/ManagedCache.java
@@ -24,7 +24,6 @@ import javax.annotation.Nullable;
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Collections;
-import java.util.Date;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;

--- a/src/main/java/sirius/kernel/cache/ManagedCache.java
+++ b/src/main/java/sirius/kernel/cache/ManagedCache.java
@@ -362,7 +362,10 @@ class ManagedCache<K, V> implements Cache<K, V>, RemovalListener<Object, Object>
     public void onRemoval(@Nullable Object key, @Nullable Object value, RemovalCause cause) {
         if (removeListener != null) {
             try {
-                removeListener.invoke(Tuple.create((K) key, (V) value));
+                removeListener.invoke(Tuple.create((K) key,
+                                                   Optional.ofNullable((CacheEntry<K, V>) value)
+                                                           .map(CacheEntry::getValue)
+                                                           .orElse(null)));
             } catch (Exception exception) {
                 Exceptions.handle(exception);
             }

--- a/src/main/java/sirius/kernel/cache/ManagedCache.java
+++ b/src/main/java/sirius/kernel/cache/ManagedCache.java
@@ -38,7 +38,7 @@ import java.util.function.BiPredicate;
  * @param <K> the type of the keys used by this cache
  * @param <V> the type of the values supported by this cache
  */
-class ManagedCache<K, V> implements Cache<K, V>, RemovalListener<Object, Object> {
+class ManagedCache<K, V> implements Cache<K, V>, RemovalListener<K, CacheEntry<K, V>> {
 
     protected static final int MAX_HISTORY = 25;
     private static final double ONE_HUNDERT_PERCENT = 100d;
@@ -358,14 +358,11 @@ class ManagedCache<K, V> implements Cache<K, V>, RemovalListener<Object, Object>
     }
 
     @Override
-    @SuppressWarnings("unchecked")
-    public void onRemoval(@Nullable Object key, @Nullable Object value, RemovalCause cause) {
+    public void onRemoval(@Nullable K key, @Nullable CacheEntry<K, V> value, RemovalCause cause) {
         if (removeListener != null) {
             try {
-                removeListener.invoke(Tuple.create((K) key,
-                                                   Optional.ofNullable((CacheEntry<K, V>) value)
-                                                           .map(CacheEntry::getValue)
-                                                           .orElse(null)));
+                removeListener.invoke(Tuple.create(key,
+                                                   Optional.ofNullable(value).map(CacheEntry::getValue).orElse(null)));
             } catch (Exception exception) {
                 Exceptions.handle(exception);
             }

--- a/src/main/java/sirius/kernel/cache/ManagedCache.java
+++ b/src/main/java/sirius/kernel/cache/ManagedCache.java
@@ -21,6 +21,7 @@ import sirius.kernel.settings.Extension;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
+import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Date;
@@ -50,7 +51,7 @@ class ManagedCache<K, V> implements Cache<K, V>, RemovalListener<Object, Object>
     protected com.github.benmanes.caffeine.cache.Cache<K, CacheEntry<K, V>> data;
     protected Counter hits = new Counter();
     protected Counter misses = new Counter();
-    protected Date lastEvictionRun = null;
+    protected Instant lastEvictionRun = null;
     protected final String name;
     protected long timeToLive;
     protected final ValueVerifier<V> verifier;
@@ -132,8 +133,8 @@ class ManagedCache<K, V> implements Cache<K, V>, RemovalListener<Object, Object>
     }
 
     @Override
-    public Date getLastEvictionRun() {
-        return (Date) lastEvictionRun.clone();
+    public Instant getLastEvictionRun() {
+        return lastEvictionRun;
     }
 
     protected void runEviction() {
@@ -143,7 +144,7 @@ class ManagedCache<K, V> implements Cache<K, V>, RemovalListener<Object, Object>
         if (timeToLive <= 0) {
             return;
         }
-        lastEvictionRun = new Date();
+        lastEvictionRun = Instant.now();
         // Remove all outdated entries...
         long now = System.currentTimeMillis();
         int numEvicted = 0;
@@ -181,7 +182,7 @@ class ManagedCache<K, V> implements Cache<K, V>, RemovalListener<Object, Object>
         data.asMap().clear();
         misses.reset();
         hits.reset();
-        lastEvictionRun = new Date();
+        lastEvictionRun = Instant.now();
     }
 
     @Override

--- a/src/test/kotlin/sirius/kernel/cache/ManagedCacheTest.kt
+++ b/src/test/kotlin/sirius/kernel/cache/ManagedCacheTest.kt
@@ -165,7 +165,8 @@ class ManagedCacheTest {
         cache.put("key1", "value1")
         cache.remove("key1")
 
-        Wait.millis(1001)
+        // wait a bit so that the listener can be invoked before we check the invocation flag
+        Wait.millis(101)
         assert(invoked) { "The removal listener was not invoked!" }
     }
 }

--- a/src/test/kotlin/sirius/kernel/cache/ManagedCacheTest.kt
+++ b/src/test/kotlin/sirius/kernel/cache/ManagedCacheTest.kt
@@ -152,4 +152,20 @@ class ManagedCacheTest {
         assertNotEquals(null, cache.get("Key4"))
         assertNotEquals(null, cache.get("Key5"))
     }
+
+    @Test
+    fun `a removal listener is correctly invoked upon eviction`() {
+        var invoked = false
+        val cache: ManagedCache<String, String> = ManagedCache("test-cache", null, null)
+        cache.onRemove { keyValueTuple ->
+            assertEquals("key1", keyValueTuple.getFirst())
+            assertEquals("value1", keyValueTuple.getSecond())
+            invoked = true
+        }
+        cache.put("key1", "value1")
+        cache.remove("key1")
+
+        Wait.millis(1001)
+        assert(invoked) { "The removal listener was not invoked!" }
+    }
 }

--- a/src/test/kotlin/sirius/kernel/cache/ManagedCacheTest.kt
+++ b/src/test/kotlin/sirius/kernel/cache/ManagedCacheTest.kt
@@ -20,9 +20,8 @@ import kotlin.test.assertEquals
 import kotlin.test.assertNotEquals
 
 /**
- * Tests the [AdvancedDateParser] class.
+ * Tests the [ManagedCache] class.
  */
-
 @ExtendWith(SiriusExtension::class)
 @NightlyTest
 class ManagedCacheTest {


### PR DESCRIPTION
### Description

Replaces Guava Caches with Caffeine.

> [!CAUTION]
> After upgrading, the major breaking change is that `cache.getLastEvictionRun()` now returns an `Instant` rather than a `Date`. As `Date` should not be used anymore, the best solution is to upgrade the surrounding code to use the Java Time libraries as well. However, if that is not feasible, conversion to a `Date` as before can be done via `Date.from(cache.getLastEvictionRun())`.
>
> The new caching library should not have changed the behaviour of the cache. Still, increased attention should be given to performance of code known to use caching.

### Additional Notes

- This PR fixes or works on following ticket(s): [SIRI-1175](https://scireum.myjetbrains.com/youtrack/issue/SIRI-1175)

### Checklist

- [x] Code change has been tested and works locally
- [x] Code was formatted via IntelliJ and follows SonarLint & [best practices](https://scireum.myjetbrains.com/youtrack/articles/MISC-A-16/CodeStyle-JavaDoc)
