### PR TITLE
Fixes HTML to plain text conversion

### DIFF
--- a/src/main/java/sirius/kernel/commons/StringCleanup.java
+++ b/src/main/java/sirius/kernel/commons/StringCleanup.java
@@ -563,8 +563,8 @@ public class StringCleanup {
             // Iterates the lines to clean them up properly, preserving the line breaks converted above,
             // as the RegEx used by removeXml would detect and clean them.
             StringBuilder builder = new StringBuilder();
-            Strings.iterateLines(normalizedText, (lineNumber, lineText) -> {
-                if (lineNumber > 1) {
+            normalizedText.lines().forEach(lineText -> {
+                if (!builder.isEmpty()) {
                     builder.append("\n");
                 }
 

--- a/src/main/java/sirius/kernel/commons/StringCleanup.java
+++ b/src/main/java/sirius/kernel/commons/StringCleanup.java
@@ -559,10 +559,22 @@ public class StringCleanup {
             // Replace p tags with line breaks
             normalizedText = PATTERN_PP_TAG.matcher(normalizedText).replaceAll("\n");
             normalizedText = PATTERN_P_TAG.matcher(normalizedText).replaceAll("\n");
-            // Remove any other tags
-            normalizedText = Strings.cleanup(normalizedText, StringCleanup::removeXml);
-            // Decode entities
-            normalizedText = Strings.cleanup(normalizedText, StringCleanup::decodeHtmlEntities);
+
+            // Iterates the lines to clean them up properly, preserving the line breaks converted above,
+            // as the RegEx used by removeXml would detect and clean them.
+            StringBuilder builder = new StringBuilder();
+            Strings.iterateLines(normalizedText, (lineNumber, lineText) -> {
+                if (lineNumber > 1) {
+                    builder.append("\n");
+                }
+
+                // Remove any other tags
+                String normalizedLine = Strings.cleanup(lineText, StringCleanup::removeXml);
+                // Decode entities
+                normalizedLine = Strings.cleanup(normalizedLine, StringCleanup::decodeHtmlEntities);
+                builder.append(normalizedLine);
+            });
+            return builder.toString();
         }
 
         return normalizedText;

--- a/src/main/java/sirius/kernel/commons/Strings.java
+++ b/src/main/java/sirius/kernel/commons/Strings.java
@@ -306,10 +306,10 @@ public class Strings {
     }
 
     /**
-     * Returns an url encoded representation of the given <tt>value</tt> with <tt>UTF-8</tt> as character encoding.
+     * Returns a url encoded representation of the given <tt>value</tt> with <tt>UTF-8</tt> as character encoding.
      *
      * @param value the value to be encoded.
-     * @return an url encoded representation of value, using UTF-8 as character encoding.
+     * @return a url encoded representation of value, using UTF-8 as character encoding.
      * @deprecated use {@link Urls#encode(String)} instead.
      */
     @Nullable
@@ -319,10 +319,10 @@ public class Strings {
     }
 
     /**
-     * Returns an url decoded representation of the given <tt>value</tt> with <tt>UTF-8</tt> as character encoding.
+     * Returns a url decoded representation of the given <tt>value</tt> with <tt>UTF-8</tt> as character encoding.
      *
      * @param value the value to be decoded.
-     * @return an url decoded representation of value, using UTF-8 as character encoding.
+     * @return a url decoded representation of value, using UTF-8 as character encoding.
      * @deprecated use {@link Urls#decode(String)} instead.
      */
     @Nullable
@@ -499,7 +499,7 @@ public class Strings {
     /**
      * Returns a string representation of the given map.
      * <p>
-     * Keys and values are separated by a colon (:) and entries by a new line.
+     * Keys and values are separated by a colon {@code :} and entries by a new line.
      *
      * @param source to map to be converted to a string
      * @return a string representation of the given map, or "" if the map was null
@@ -633,7 +633,7 @@ public class Strings {
      * <p>
      * Note that empty/<tt>null</tt> inputs will always result in an empty string.
      *
-     * @param inputString the string to clean-up
+     * @param inputString the string to clean up
      * @param cleanups    the operations to perform, most probably some from {@link StringCleanup}
      * @return the cleaned up string
      * @see StringCleanup
@@ -658,7 +658,7 @@ public class Strings {
      * <p>
      * Note that empty/<tt>null</tt> inputs will always result in an empty string.
      *
-     * @param inputString the string to clean-up
+     * @param inputString the string to clean up
      * @param cleanups    the operations to perform, most probably some from {@link StringCleanup}
      * @return the cleaned up string
      * @see StringCleanup
@@ -753,7 +753,9 @@ public class Strings {
      * the replacement function.
      * <p>
      * To replace all occurrences of {@code #{X}} by {@code NLS.get("X")} one could use:
-     * {@code Strings.replaceAll(Pattern.compile("#\\{([^\\}]+)\\}"), someText, NLS::get)}
+     * <code>
+     * Strings.replaceAll(Pattern.compile("#\\{([^\\}]+)\\}"}, someText, NLS::get)
+     * </code>
      *
      * @param regEx       the regular expression to replace in the given input
      * @param input       the input to scan

--- a/src/main/java/sirius/kernel/commons/Strings.java
+++ b/src/main/java/sirius/kernel/commons/Strings.java
@@ -18,6 +18,8 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Scanner;
+import java.util.function.BiConsumer;
 import java.util.function.UnaryOperator;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -860,5 +862,22 @@ public class Strings {
         }
 
         return sb.toString();
+    }
+
+    /**
+     * Iterates over all lines of the given text and applies the given consumer for each line.
+     * <p>
+     * This method works independent on the end-of-line characters used in the given text.
+     *
+     * @param text         the text to iterate over
+     * @param lineConsumer the consumer to be applied for each line. The first parameter is the line number (starting at 1),
+     */
+    public static void iterateLines(String text, BiConsumer<Integer, String> lineConsumer) {
+        try (Scanner scanner = new Scanner(text)) {
+            int lineNumber = 0;
+            while (scanner.hasNextLine()) {
+                lineConsumer.accept(++lineNumber, scanner.nextLine());
+            }
+        }
     }
 }

--- a/src/main/java/sirius/kernel/commons/Strings.java
+++ b/src/main/java/sirius/kernel/commons/Strings.java
@@ -872,7 +872,7 @@ public class Strings {
      * This method works independent on the end-of-line characters used in the given text.
      *
      * @param text         the text to iterate over
-     * @param lineConsumer the consumer to be applied for each line. The first parameter is the line number (starting at 1),
+     * @param lineConsumer the consumer to be applied for each line. The first parameter is the line number (starting at 1), the second is the corresponding line text.
      */
     public static void iterateLines(String text, BiConsumer<Integer, String> lineConsumer) {
         try (Scanner scanner = new Scanner(text)) {

--- a/src/main/java/sirius/kernel/commons/Strings.java
+++ b/src/main/java/sirius/kernel/commons/Strings.java
@@ -18,7 +18,7 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
-import java.util.Scanner;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.BiConsumer;
 import java.util.function.UnaryOperator;
 import java.util.regex.Matcher;
@@ -875,11 +875,12 @@ public class Strings {
      * @param lineConsumer the consumer to be applied for each line. The first parameter is the line number (starting at 1), the second is the corresponding line text.
      */
     public static void iterateLines(String text, BiConsumer<Integer, String> lineConsumer) {
-        try (Scanner scanner = new Scanner(text)) {
-            int lineNumber = 0;
-            while (scanner.hasNextLine()) {
-                lineConsumer.accept(++lineNumber, scanner.nextLine());
-            }
+        if (isEmpty(text)) {
+            return;
         }
+        AtomicInteger lineNumber = new AtomicInteger(0);
+        text.lines().forEach(line -> {
+            lineConsumer.accept(lineNumber.incrementAndGet(), line);
+        });
     }
 }

--- a/src/main/java/sirius/kernel/commons/Strings.java
+++ b/src/main/java/sirius/kernel/commons/Strings.java
@@ -18,8 +18,6 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
-import java.util.concurrent.atomic.AtomicInteger;
-import java.util.function.BiConsumer;
 import java.util.function.UnaryOperator;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -864,23 +862,5 @@ public class Strings {
         }
 
         return sb.toString();
-    }
-
-    /**
-     * Iterates over all lines of the given text and applies the given consumer for each line.
-     * <p>
-     * This method works independent on the end-of-line characters used in the given text.
-     *
-     * @param text         the text to iterate over
-     * @param lineConsumer the consumer to be applied for each line. The first parameter is the line number (starting at 1), the second is the corresponding line text.
-     */
-    public static void iterateLines(String text, BiConsumer<Integer, String> lineConsumer) {
-        if (isEmpty(text)) {
-            return;
-        }
-        AtomicInteger lineNumber = new AtomicInteger(0);
-        text.lines().forEach(line -> {
-            lineConsumer.accept(lineNumber.incrementAndGet(), line);
-        });
     }
 }

--- a/src/test/kotlin/sirius/kernel/commons/StringsTest.kt
+++ b/src/test/kotlin/sirius/kernel/commons/StringsTest.kt
@@ -425,5 +425,12 @@ class StringsTest {
             )
         )
 
+        assertEquals(
+            "bold\nmove",
+            Strings.cleanup(
+                "<strong>bold</strong><br />move",
+                StringCleanup::htmlToPlainText
+            )
+        )
     }
 }


### PR DESCRIPTION
### Description

`StringCleanup#htmlToPlainText` is expected to convert `p` and `br` tags to line breaks.
This works if these tags were not followed by other tags. For example:

➡️ Input: `Hello<br />World`
✅ Output:
```
Hello
World
```
but
➡️ Input: `<strong>Hello</strong><br />World`
🚫 Output: `HelloWorld`

This happens because `StringCleanup.PATTERN_STRIP_XML` will look for white-spaces leading or trailing a tag, effectively replacing `</strong>\n` in the example above by an empty string.

To not disrupt this pattern, and possible cause a breaking change/behavioral change, which is used in several other places, we iterate and clean each line.

### Additional Notes

- This PR fixes or works on following ticket(s): [OX-12298](https://scireum.myjetbrains.com/youtrack/issue/OX-12298)

### Checklist

- [x] Code change has been tested and works locally
- [x] Code was formatted via IntelliJ and follows SonarLint & [best practices](https://scireum.myjetbrains.com/youtrack/articles/MISC-A-16/CodeStyle-JavaDoc)
