### PR TITLE
Fixes HTML to plain text conversion... again

### DIFF
--- a/src/main/java/sirius/kernel/commons/StringCleanup.java
+++ b/src/main/java/sirius/kernel/commons/StringCleanup.java
@@ -182,7 +182,7 @@ public class StringCleanup {
                                                                       TAG_UL,
                                                                       TAG_LI);
 
-    private static final Pattern PATTERN_STRIP_XML = Pattern.compile(Strings.REGEX_DETECT_XML_TAGS);
+    private static final Pattern PATTERN_STRIP_XML = Pattern.compile("\\s*" + Strings.REGEX_DETECT_XML_TAGS + "\\s*");
     private static final Map<Integer, String> unicodeMapping = new TreeMap<>();
 
     static {

--- a/src/main/java/sirius/kernel/commons/StringCleanup.java
+++ b/src/main/java/sirius/kernel/commons/StringCleanup.java
@@ -572,7 +572,7 @@ public class StringCleanup {
 
                 // Remove any other tags, decode entities and trim
                 String normalizedLine = Strings.cleanup(lineText,
-                                                        StringCleanup::removeXml,
+                                                        StringCleanup::replaceXml,
                                                         StringCleanup::decodeHtmlEntities,
                                                         StringCleanup::reduceWhitespace,
                                                         StringCleanup::trim);

--- a/src/main/java/sirius/kernel/commons/StringCleanup.java
+++ b/src/main/java/sirius/kernel/commons/StringCleanup.java
@@ -574,6 +574,7 @@ public class StringCleanup {
                 String normalizedLine = Strings.cleanup(lineText,
                                                         StringCleanup::removeXml,
                                                         StringCleanup::decodeHtmlEntities,
+                                                        StringCleanup::reduceWhitespace,
                                                         StringCleanup::trim);
                 builder.append(normalizedLine);
                 firstLine.toggle();

--- a/src/main/java/sirius/kernel/commons/StringCleanup.java
+++ b/src/main/java/sirius/kernel/commons/StringCleanup.java
@@ -550,7 +550,7 @@ public class StringCleanup {
         if (PATTERN_STRIP_XML.matcher(input).find()) {
             // Start joining all lines. A browser does not recognize line breaks in the HTML source as these
             // are just whitespaces. Handling of actual HTML line breaks happens in the following lines.
-            String normalizedText = input.lines().collect(Collectors.joining());
+            String normalizedText = input.lines().collect(Collectors.joining(" "));
 
             // Replace br tags with line breaks
             normalizedText = PATTERN_BR_TAG.matcher(normalizedText).replaceAll("\n");

--- a/src/test/kotlin/sirius/kernel/commons/StringsTest.kt
+++ b/src/test/kotlin/sirius/kernel/commons/StringsTest.kt
@@ -445,5 +445,21 @@ class StringsTest {
                 StringCleanup::htmlToPlainText
             )
         )
+
+        assertEquals(
+            "Span 1 Span 2",
+            Strings.cleanup(
+                "<span>Span 1</span>\n<span>Span 2</span>",
+                StringCleanup::htmlToPlainText
+            )
+        )
+
+        assertEquals(
+            "\nLine 1 Line 2 Line 3",
+            Strings.cleanup(
+                "<p>Line 1\nLine 2\nLine 3</p>",
+                StringCleanup::htmlToPlainText
+            )
+        )
     }
 }

--- a/src/test/kotlin/sirius/kernel/commons/StringsTest.kt
+++ b/src/test/kotlin/sirius/kernel/commons/StringsTest.kt
@@ -432,5 +432,18 @@ class StringsTest {
                 StringCleanup::htmlToPlainText
             )
         )
+
+        assertEquals(
+            """
+                
+                
+                Hello
+                World
+            """.trimIndent(),
+            Strings.cleanup(
+                "<br />\n<br />\nHello<br />\n<i>World</i> ",
+                StringCleanup::htmlToPlainText
+            )
+        )
     }
 }

--- a/src/test/kotlin/sirius/kernel/commons/StringsTest.kt
+++ b/src/test/kotlin/sirius/kernel/commons/StringsTest.kt
@@ -438,10 +438,10 @@ class StringsTest {
                 
                 
                 Hello
-                World
+                World and the universe
             """.trimIndent(),
             Strings.cleanup(
-                "<br />\n<br />\nHello<br />\n<i>World</i> ",
+                "<br />\n<br />\nHello<br />\n<i>World</i>   and the universe",
                 StringCleanup::htmlToPlainText
             )
         )


### PR DESCRIPTION
### Description

**Note in advance:**
we should evaluate using **jsoup** or some lib to perform these kind of operations. But since that required an analysis (impact and feasibility), I just try to improve the current code. There is no real recognition of things like inline vs block elements.

The HTML code might contain line-breaks. These are not considered for display and the actual `br` and `p` tags must be use to really display a line-break.

In addition, HTML reduces spaces. A string like `"<b>Hello  </b>   world"` is displayed as "**Hello** world".

### Additional Notes

- This PR fixes or works on following ticket(s): [OX-12298](https://scireum.myjetbrains.com/youtrack/issue/OX-12298)
- This PR is related to PR: https://github.com/scireum/sirius-kernel/pull/592

### Checklist

- [x] Code change has been tested and works locally
- [x] Code was formatted via IntelliJ and follows SonarLint & [best practices](https://scireum.myjetbrains.com/youtrack/articles/MISC-A-16/CodeStyle-JavaDoc)
