### PR TITLE
Testing Improvements

### DIFF
--- a/src/main/java/sirius/kernel/nls/NLS.java
+++ b/src/main/java/sirius/kernel/nls/NLS.java
@@ -721,12 +721,12 @@ public class NLS {
     private static DateTimeFormatter safeGetDateTimeFormat(String language,
                                                            Map<String, DateTimeFormatter> formatters,
                                                            String nlsProperty) {
-        if (Strings.isEmpty(language)) {
-            return formatters.computeIfAbsent(getCurrentLanguage(),
-                                              effectiveLanguage -> DateTimeFormatter.ofPattern(get(nlsProperty,
+        String givenOrCurrentLanguage = Strings.isEmpty(language) ? getCurrentLanguage() : language;
+        return formatters.computeIfAbsent(givenOrCurrentLanguage,
+                                          effectiveLanguage -> DateTimeFormatter.ofPattern(get(nlsProperty,
+                                                                                               effectiveLanguage),
+                                                                                           Locale.forLanguageTag(
                                                                                                    effectiveLanguage)));
-        }
-        return formatters.computeIfAbsent(language, ignored -> DateTimeFormatter.ofPattern(get(nlsProperty, language)));
     }
 
     /**

--- a/src/test/java/sirius/kernel/SiriusExtension.java
+++ b/src/test/java/sirius/kernel/SiriusExtension.java
@@ -23,6 +23,10 @@ public class SiriusExtension implements BeforeAllCallback, BeforeEachCallback {
 
     @Override
     public void beforeAll(ExtensionContext context) {
+        // Allow setting restricted HTTP headers, like `Origin:` … Only very few tests actually need this, but it is
+        // required to set the property before any HttpURLConnection is created, so we do it here globally
+        System.setProperty("sun.net.http.allowRestrictedHeaders", "true");
+
         TestHelper.setUp(SiriusExtension.class);
     }
 

--- a/src/test/java/sirius/kernel/SiriusExtension.java
+++ b/src/test/java/sirius/kernel/SiriusExtension.java
@@ -24,8 +24,11 @@ public class SiriusExtension implements BeforeAllCallback, BeforeEachCallback {
     @Override
     public void beforeAll(ExtensionContext context) {
         // Allow setting restricted HTTP headers, like `Origin:` … Only very few tests actually need this, but it is
-        // required to set the property before any HttpURLConnection is created, so we do it here globally
-        System.setProperty("sun.net.http.allowRestrictedHeaders", "true");
+        // required to set the property before any HttpURLConnection is created, so we do it here globally unless
+        // the JVM was already configured explicitly.
+        if (System.getProperty("sun.net.http.allowRestrictedHeaders") == null) {
+            System.setProperty("sun.net.http.allowRestrictedHeaders", "true");
+        }
 
         TestHelper.setUp(SiriusExtension.class);
     }

--- a/src/test/java/sirius/kernel/SiriusExtension.java
+++ b/src/test/java/sirius/kernel/SiriusExtension.java
@@ -14,7 +14,7 @@ import org.junit.jupiter.api.extension.ExtensionContext;
 import sirius.kernel.async.CallContext;
 
 /**
- * JUnit 5 extension to support Sirius framework lifecycle. Annotated test classes will be provisioned with
+ * JUnit 5 extension to support the Sirius framework lifecycle. Annotated test classes will be provisioned with
  * a running framework and a cleared {@link CallContext} before each test.
  * <p>
  * Note: This currently does not support {@link sirius.kernel.Scenario scenarios}.


### PR DESCRIPTION
### Description

This PR improves test infrastructure and fixes locale-dependent time formatting.

Date and time formatters in `NLS` now use the requested NLS language as their `Locale` instead of relying on the JVM default locale. This prevents English time formatting from unexpectedly producing lower-case `am`/`pm` on systems with defaults like `en_GB`.

The shared Sirius JUnit extension also enables restricted HTTP headers before tests initialize HTTP connections, so tests can set headers such as `Origin`.

No breaking changes expected.

### Additional Notes
- This PR has no ticket.
- Tested locally with: `mvn -Dtest=sirius.kernel.nls.NLSTest test`

### Checklist
- [x] Code change has been tested and works locally
- [x] Code was formatted via IntelliJ and follows SonarLint & [best practices](https://scireum.myjetbrains.com/youtrack/articles/MISC-A-16/CodeStyle-JavaDoc)
