### PR TITLE
Clean up some long standing deprecations

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,18 +95,13 @@ To set up which customizations are enabled in what order specify an array for *s
 
 ## Testing
 
-Tests are based on **spock** and written in **Groovy**, a base specification providing a proper setup of the
-system can be found in [BaseSpecification](src/test/java/sirius/kernel/BaseSpecification.groovy).
+Tests are based on **jUnit** and written in **Kotlin**, using `kotlin.test.*` for assertions and `MockK` for mocking.
 
 Our **golden rule** for tests is:
-> _No matter if you start the whole test suite, a single specification or just
-as single test (method) - the tests have to function independently of their surroundings. Therefore, a test
+> _No matter if you start the whole test suite, a single test class/bundle or just
+a single test (method) - the tests have to function independently of their surroundings. Therefore, a test
 has to either succeed in all three scenarios or it must fail each time. Everything else indicates an invalid test
 setup._
-
-Each module and application should provide its own test suite as subclass of
-[ScenarioSuite](src/test/java/sirius/kernel/ScenarioSuite.java).
-See [TestSuite](src/test/java/TestSuite.java) as an example.
 
 For testing, we heavily rely on **Docker** (especially when external systems like databases are required).
 SIRIUS has a build-in helper to start and stop **docker-compose** setups.

--- a/docs/why.md
+++ b/docs/why.md
@@ -6,7 +6,7 @@
 SIRIUS not only supports *dependency injection* but it takes it to the next level. 
 It embraces a programming style called **Discovery Based Programming** which permits 
 to provide services that discover their users at runtime. Please refer to the
- [Dependency Injection Microkernel](../src/main/java/sirius/kernel/di) for further informaton.
+ [Dependency Injection Microkernel](../src/main/java/sirius/kernel/di) for further information.
 
 ## KISS
 Keep it simple and stupid: No classloader ticks. No magic implicit variables coming from god knows where. 
@@ -17,7 +17,7 @@ By providing loose coupling via IoC-Patterns (inversion of control) like discove
 SIRIUS permits to write modular, maintainable and testable software with clear responsibilities. 
     
 ## Use your IDE
-SIRIUS can be started in any IDE/Debugger just like any normal Java appplication 
+SIRIUS can be started in any IDE/Debugger just like any normal Java application 
 ([Setup](../src/main/java/sirius/kernel/Setup.java) is actually a valid main class). As no classloader or bytecode 
 magic is used, class reloading in the VM works a treat. To further save precious developer time, the framework starts 
 ultra fast. Having a server up and running in less than two seconds drives productivity above level 9000!

--- a/src/main/java/sirius/kernel/README.md
+++ b/src/main/java/sirius/kernel/README.md
@@ -10,11 +10,11 @@ if necessary (e.g. system tenants).
 * [Start](Startable.java)/[Stop](Stoppable.java) Facility\
 All startable tasks will be started on system startup. All stoppable tasks will be invoked
 on system shutdown. Once completed, all killable tasks will be invoked to *really* stop them
-if they didn't respont to their stop call.
+if they didn't respond to their stop call.
 
 * [Docker Facility](DockerHelper.java)\
 Starts/Stops docker containers. This is mainly used for test- and development systems and
-cann start required docker containers (databases, storage systems ..).\
+can start required docker containers (databases, storage systems ..).\
 Use **docker.file** to specify a *docker-compose* file which will be started. Specify
 a **docker.project** so that all containers keep their name (for dev environments).
 Otherwise each start will launch a new set of containers which is suitable for test runs.\

--- a/src/main/java/sirius/kernel/Setup.java
+++ b/src/main/java/sirius/kernel/Setup.java
@@ -434,7 +434,7 @@ public class Setup {
         try {
             return ConfigFactory.parseMap(System.getenv(), "Environment").withFallback(config);
         } catch (Exception exception) {
-            Sirius.LOG.WARN("An error occured while reading the environment: %s (%s)",
+            Sirius.LOG.WARN("An error occurred while reading the environment: %s (%s)",
                             exception.getMessage(),
                             exception.getClass().getName());
             return config;

--- a/src/main/java/sirius/kernel/Sirius.java
+++ b/src/main/java/sirius/kernel/Sirius.java
@@ -199,7 +199,7 @@ public class Sirius {
         }
         LOG.INFO("Enabled %d of %d frameworks...", numEnabled, total);
         // Although customizations are loaded in setupConfiguration, we output the status here,
-        // as this seems more intiutive for the customer (the poor guy reading the logs...)
+        // as this seems more intuitive for the customer (the poor guy reading the logs...)
         LOG.INFO("Active Customizations: %s", customizations);
 
         frameworks = frameworkStatus;

--- a/src/main/java/sirius/kernel/async/CallContext.java
+++ b/src/main/java/sirius/kernel/async/CallContext.java
@@ -322,22 +322,6 @@ public class CallContext {
      * @param contextType the type of the sub-context to be returned.
      * @param <C>         the type of the sub-context
      * @return an instance of the given type. If no instance was available, a new one is created
-     * @deprecated use {@link #getOrCreateSubContext(Class)} instead.
-     */
-    @Nonnull
-    @Deprecated(since = "2023-01-04", forRemoval = true)
-    public <C extends SubContext> C get(@Nonnull Class<C> contextType) {
-        return getOrCreateSubContext(contextType);
-    }
-
-    /**
-     * Returns or creates the sub context of the given type.
-     * <p>
-     * The class of the sub context must provide a no-args constructor, as it will be instantiated if non existed.
-     *
-     * @param contextType the type of the sub-context to be returned.
-     * @param <C>         the type of the sub-context
-     * @return an instance of the given type. If no instance was available, a new one is created
      */
     @Nonnull
     @SuppressWarnings("unchecked")
@@ -357,22 +341,6 @@ public class CallContext {
                                                     contextType.getName())
                             .handle();
         }
-    }
-
-    /**
-     * Installs the given sub context.
-     * <p>
-     * This should only be used if required (e.g. in test environments to replace/mock objects). Otherwise, a
-     * call to {@link #get(Class)} will initialize the requested sub context.
-     *
-     * @param contextType the type of the context to set
-     * @param instance    the instance to set
-     * @param <C>         the type of the sub-context
-     * @deprecated use {@link #setSubContext(Class, SubContext)} instead.
-     */
-    @Deprecated(since = "2023-01-04", forRemoval = true)
-    public <C extends SubContext> void set(@Nonnull Class<C> contextType, @Nonnull C instance) {
-        setSubContext(contextType, instance);
     }
 
     /**
@@ -440,17 +408,6 @@ public class CallContext {
         return language;
     }
 
-    /**
-     * Returns the current language determined for the current thread.
-     *
-     * @return a two-letter language code used for the current thread.
-     * @deprecated call {@link #getLanguage()} instead.
-     */
-    @Deprecated
-    public final String getLang() {
-        return getLanguage();
-    }
-
     private void invokeLazyLanguageInstaller() {
         // We obtain a local copy and set the field to null, to avoid a circular
         // execution in case the language installer itself accesses getLang...
@@ -479,18 +436,6 @@ public class CallContext {
     }
 
     /**
-     * Returns the current fallback language determined for the current thread.
-     *
-     * @return a two-letter language code used for the current thread.
-     * @deprecated call {@link #getFallbackLang()} instead.
-     */
-    @Nullable
-    @Deprecated
-    public final String getFallbackLang() {
-        return getFallbackLanguage();
-    }
-
-    /**
      * Sets the current language for the current thread.
      * <p>
      * If <tt>null</tt> or an empty string is passed in, the language will not be changed.
@@ -506,20 +451,6 @@ public class CallContext {
     }
 
     /**
-     * Sets the current language for the current thread.
-     * <p>
-     * If <tt>null</tt> or an empty string is passed in, the language will not be changed.
-     * </p>
-     *
-     * @param language the two-letter language code for this thread.
-     * @deprecated call {@link #setLanguage(String)} instead.
-     */
-    @Deprecated
-    public final void setLang(@Nullable String language) {
-        setLanguage(language);
-    }
-
-    /**
      * Sets the current language for the current thread, only if no other language has been set already.
      * <p>
      * If <tt>null</tt> or an empty string is passed in, the language will not be changed.
@@ -531,20 +462,6 @@ public class CallContext {
         if (Strings.isEmpty(this.language)) {
             setLanguage(language);
         }
-    }
-
-    /**
-     * Sets the current language for the current thread, only if no other language has been set already.
-     * <p>
-     * If <tt>null</tt> or an empty string is passed in, the language will not be changed.
-     * </p>
-     *
-     * @param language the two-letter language code for this thread.
-     * @deprecated call {@link #setLanguageIfEmpty(String)} instead.
-     */
-    @Deprecated
-    public final void setLangIfEmpty(@Nullable String language) {
-        setLanguageIfEmpty(language);
     }
 
     /**
@@ -567,26 +484,6 @@ public class CallContext {
     }
 
     /**
-     * Adds a language supplier.
-     * <p>
-     * In certain circumstances the current language might be influenced by something which is hard to compute.
-     * For example a web request in <b>sirius-web</b> might either provide a user with a language attached via
-     * its session, or it might contain a language header which itself isn't quite easy to parse.
-     * <p>
-     * Worst of all, in many cases, the current language might not be used at all.
-     * <p>
-     * Therefore, we permit lazy computations which are only evaluated as required.
-     *
-     * @param languageInstaller a callback which installs the appropriate language into the given call context
-     *                          (is passed again to support {@link #fork() forking}).
-     * @deprecated call {@link #deferredSetLanguage(Consumer)} instead.
-     */
-    @Deprecated
-    public final void deferredSetLang(@Nonnull Consumer<CallContext> languageInstaller) {
-        deferredSetLanguage(languageInstaller);
-    }
-
-    /**
      * Sets the language back to <tt>null</tt>.
      * <p>
      * This method should only be used to re-initialize the language. Use {@link #setLanguage(String)} to specify a new language.
@@ -596,35 +493,12 @@ public class CallContext {
     }
 
     /**
-     * Sets the lang back to <tt>null</tt>.
-     * <p>
-     * This method should only be used to re-initialize the language. Use {@link #setLanguage(String)} to specify a new language.
-     *
-     * @deprecated call {@link #resetLanguage()} instead.
-     */
-    @Deprecated
-    public final void resetLang() {
-        resetLanguage();
-    }
-
-    /**
      * Sets the current fallback language for the current thread.
      *
      * @param fallbackLanguage the two-letter language code for this thread.
      */
     public void setFallbackLanguage(@Nullable String fallbackLanguage) {
         this.fallbackLanguage = fallbackLanguage;
-    }
-
-    /**
-     * Sets the current fallback language for the current thread.
-     *
-     * @param fallbackLanguage the two-letter language code for this thread.
-     * @deprecated call {@link #setFallbackLanguage(String)} instead.
-     */
-    @Deprecated
-    public final void setFallbackLang(@Nullable String fallbackLanguage) {
-        setFallbackLanguage(fallbackLanguage);
     }
 
     @Override

--- a/src/main/java/sirius/kernel/async/CallContext.java
+++ b/src/main/java/sirius/kernel/async/CallContext.java
@@ -410,7 +410,7 @@ public class CallContext {
 
     private void invokeLazyLanguageInstaller() {
         // We obtain a local copy and set the field to null, to avoid a circular
-        // execution in case the language installer itself accesses getLang...
+        // execution in case the language installer itself accesses getLanguage...
         Consumer<CallContext> localCopy = this.lazyLanguageInstaller;
         if (localCopy != null) {
             this.lazyLanguageInstaller = null;

--- a/src/main/java/sirius/kernel/async/Promise.java
+++ b/src/main/java/sirius/kernel/async/Promise.java
@@ -224,7 +224,7 @@ public class Promise<V> {
     /**
      * Returns the failure which was the reason for this promise to have failed.
      *
-     * @return the error which made this promise fail, or <tt>null</tt>  if the promnise is still running or not
+     * @return the error which made this promise fail, or <tt>null</tt>  if the promise is still running or not
      * completed yet.
      */
     public Throwable getFailure() {

--- a/src/main/java/sirius/kernel/async/Promise.java
+++ b/src/main/java/sirius/kernel/async/Promise.java
@@ -320,19 +320,6 @@ public class Promise<V> {
     }
 
     /**
-     * Returns this promise as a future.
-     *
-     * @return this promise as future
-     * @deprecated Usage of this method is discouraged. Wrap and use {@link CombinedFuture#asFuture()}} instead.
-     */
-    @Deprecated(forRemoval = true)
-    public Future asFuture() {
-        CombinedFuture result = new CombinedFuture();
-        result.add(this);
-        return result.asFuture();
-    }
-
-    /**
      * Chains this promise to the given one, by transforming the result value of this promise using the given mapper.
      *
      * @param promise the promise to be used as completion handler for this.

--- a/src/main/java/sirius/kernel/async/TaskContext.java
+++ b/src/main/java/sirius/kernel/async/TaskContext.java
@@ -169,7 +169,7 @@ public class TaskContext implements SubContext {
     /**
      * Increments the given performance counter by one and supplies a loop duration in milliseconds.
      * <p>
-     * The avarage value will be computed for the given counter and gives the user a rough estimate what the current
+     * The average value will be computed for the given counter and gives the user a rough estimate what the current
      * task is doing.
      * <p>
      * Note that the default implementation will simply ignore the provided timings.
@@ -184,7 +184,7 @@ public class TaskContext implements SubContext {
     /**
      * Increments the given performance counter by one and supplies a loop duration in milliseconds.
      * <p>
-     * The avarage value will be computed for the given counter and gives the user a rough estimate what the current
+     * The average value will be computed for the given counter and gives the user a rough estimate what the current
      * task is doing.
      * <p>
      * Note that the default implementation will simply ignore the provided timings.

--- a/src/main/java/sirius/kernel/cache/CacheCoherence.java
+++ b/src/main/java/sirius/kernel/cache/CacheCoherence.java
@@ -9,10 +9,10 @@
 package sirius.kernel.cache;
 
 /**
- * Permits to implement a cache coherence protocol.
+ * Permits implementing a cache coherence protocol.
  * <p>
  * {@link CoherentCache Coherent caches} created using {@link CacheManager#createCoherentCache(String)} will notify
- * an instace which is {@link sirius.kernel.di.std.Register registered} for this interface once a key needs to be
+ * an instance which is {@link sirius.kernel.di.std.Register registered} for this interface once a key needs to be
  * removed or if the cache is entirely cleared.
  * <p>
  * The coherence implementation must broadcast this information to all nodes of a cluster and call

--- a/src/main/java/sirius/kernel/cache/CacheManager.java
+++ b/src/main/java/sirius/kernel/cache/CacheManager.java
@@ -223,8 +223,8 @@ public class CacheManager {
      */
     public static void clearCoherentCacheLocally(String cacheName) {
         ManagedCache<?, ?> cache = caches.get(cacheName);
-        if (cache instanceof CoherentCache) {
-            ((CoherentCache<?>) cache).clearLocal();
+        if (cache instanceof CoherentCache<?> coherentCache) {
+            coherentCache.clearLocal();
         }
     }
 
@@ -250,8 +250,8 @@ public class CacheManager {
      */
     public static void removeCoherentCacheKeyLocally(String cacheName, String key) {
         ManagedCache<?, ?> cache = caches.get(cacheName);
-        if (cache instanceof CoherentCache) {
-            ((CoherentCache<?>) cache).removeLocal(key);
+        if (cache instanceof CoherentCache<?> coherentCache) {
+            coherentCache.removeLocal(key);
         }
     }
 
@@ -282,8 +282,8 @@ public class CacheManager {
      */
     public static void coherentCacheRemoveAllLocally(String cacheName, String discriminator, String testInput) {
         ManagedCache<?, ?> cache = caches.get(cacheName);
-        if (cache instanceof CoherentCache) {
-            ((CoherentCache<?>) cache).removeAllLocal(discriminator, testInput);
+        if (cache instanceof CoherentCache<?> coherentCache) {
+            coherentCache.removeAllLocal(discriminator, testInput);
         }
     }
 

--- a/src/main/java/sirius/kernel/commons/CSVReader.java
+++ b/src/main/java/sirius/kernel/commons/CSVReader.java
@@ -18,17 +18,17 @@ import java.util.List;
 import java.util.function.Consumer;
 
 /**
- * Provides a simple reader which parses given CSV (comma separated values) data into rows.
+ * Provides a simple reader which parses given CSV (comma-separated values) data into rows.
  * <p>
  * By default <tt>;</tt> is used to separate columns and a line break (either Windows or Unix) is used
  * to separate rows. Also columns can be enclosed in quotations, especially if line breaks occur within
- * a value. The default character used to signal quaotation is <tt>&quot;</tt>. Note that the quotation symbol has to
+ * a value. The default character used to signal quotation is <tt>&quot;</tt>. Note that the quotation symbol has to
  * be
  * the first non-whitespace character in the column to be detected as such (or the very first character if
- * {@link #notIgnoringWhitespaces()} was called during initialisation).
+ * {@link #notIgnoringWhitespaces()} was called during initialization).
  * <p>
- * Furthermore escaping can be used to embed a column separator or a quotation character in a column value.
- * By default <tt>\</tt> is used as escape character.
+ * Furthermore, escaping can be used to embed a column separator or a quotation character in a column value.
+ * By default <tt>\</tt> is used as an escape character.
  * <p>
  * Empty columns will be represented as empty strings. Values will not be trimmed, as this can be easily achieved
  * using the {@link Values} which is used to represent a parsed row.
@@ -36,7 +36,7 @@ import java.util.function.Consumer;
  * An example use case would be:
  * {@code new CSVReader(someInput).execute(row -&gt; doSomethingSmartPerRow(row)); }
  * <p>
- * Note that this class checks the {@link TaskContext} during execution. Therefore if the underlying task is cancelled,
+ * Note that this class checks the {@link TaskContext} during execution. Therefore if the underlying task is canceled,
  * the parser will stop after the current row has been processed.
  */
 public class CSVReader {
@@ -156,7 +156,7 @@ public class CSVReader {
         }
     }
 
-    /*
+    /**
      * Consumes a windows or unix style line break.
      */
     private void consumeNewLine() throws IOException {
@@ -168,16 +168,16 @@ public class CSVReader {
         }
     }
 
-    /*
+    /**
      * Fills the internal buffer by reading from the stream.
      */
     private void read() throws IOException {
         buffer = input.read();
     }
 
-    /*
+    /**
      * Reads a single row from the stream. This might be multiple lines from the
-     * input as quotet columns may contain line breaks.
+     * input as quoted columns may contain line breaks.
      */
     private void readRow() throws IOException {
         List<String> row = new ArrayList<>();
@@ -193,7 +193,7 @@ public class CSVReader {
         }
     }
 
-    /*
+    /**
      * Reads a single column.
      */
     private String readField() throws IOException {
@@ -246,7 +246,7 @@ public class CSVReader {
         }
     }
 
-    /*
+    /**
      * Determines if the current buffer value should be added to the field (column) content.
      */
     private boolean shouldContinueField(boolean inQuote) throws IOException {
@@ -265,14 +265,14 @@ public class CSVReader {
         }
     }
 
-    /*
+    /**
      * Determines if the current buffer indicates a line break.
      */
     private boolean isAtNewline() {
         return buffer == '\r' || buffer == '\n';
     }
 
-    /*
+    /**
      * Determines if we reached the end of the steam / reader.
      */
     public boolean isEOF() {

--- a/src/main/java/sirius/kernel/commons/Files.java
+++ b/src/main/java/sirius/kernel/commons/Files.java
@@ -23,7 +23,7 @@ import java.util.Optional;
 import java.util.regex.Pattern;
 
 /**
- * Helperclass for handling files in Java 8.
+ * Provides helpers for handling files in Java 8.
  */
 public class Files {
 
@@ -143,7 +143,7 @@ public class Files {
      *
      * @param path the path to a file to parse
      * @return the filename without extension or <tt>null</tt> if the given path is empty, <tt>null</tt> or does not
-     * have a filename (ends with a sepratator).
+     * have a filename (ends with a separator).
      */
     @Nullable
     @SuppressWarnings("java:S2259")

--- a/src/main/java/sirius/kernel/commons/Strings.java
+++ b/src/main/java/sirius/kernel/commons/Strings.java
@@ -280,56 +280,6 @@ public class Strings {
     }
 
     /**
-     * Returns if the given string is an HTTP(S) URL.
-     *
-     * @param value the string to check
-     * @return <tt>true</tt> if the given string is an HTTP(S) URL, <tt>false</tt> otherwise
-     * @deprecated use {@link Urls#isHttpUrl(String)} instead.
-     */
-    @Deprecated(since = "2025-06-11", forRemoval = true)
-    public static boolean isHttpUrl(@Nullable String value) {
-        return Urls.isHttpUrl(value);
-    }
-
-    /**
-     * Returns if the given string is an HTTPS URL, explicitly excluding unencrypted HTTP URLs.
-     *
-     * @param value the string to check
-     * @return <tt>true</tt> if the given string is an HTTPS URL, <tt>false</tt> otherwise
-     * @deprecated use {@link Urls#isHttpsUrl(String)} instead.
-     */
-    @Deprecated(since = "2025-06-11", forRemoval = true)
-    public static boolean isHttpsUrl(@Nullable String value) {
-        return Urls.isHttpsUrl(value);
-    }
-
-    /**
-     * Returns a url encoded representation of the given <tt>value</tt> with <tt>UTF-8</tt> as character encoding.
-     *
-     * @param value the value to be encoded.
-     * @return a url encoded representation of value, using UTF-8 as character encoding.
-     * @deprecated use {@link Urls#encode(String)} instead.
-     */
-    @Nullable
-    @Deprecated(since = "2025-06-11", forRemoval = true)
-    public static String urlEncode(@Nullable String value) {
-        return Urls.encode(value);
-    }
-
-    /**
-     * Returns a url decoded representation of the given <tt>value</tt> with <tt>UTF-8</tt> as character encoding.
-     *
-     * @param value the value to be decoded.
-     * @return a url decoded representation of value, using UTF-8 as character encoding.
-     * @deprecated use {@link Urls#decode(String)} instead.
-     */
-    @Nullable
-    @Deprecated(since = "2025-06-11", forRemoval = true)
-    public static String urlDecode(@Nullable String value) {
-        return Urls.decode(value);
-    }
-
-    /**
      * Splits the given string at the first occurrence of the separator.
      * <p>
      * If the given input is empty, a tuple with <tt>null</tt> as first and second component will be returned.

--- a/src/main/java/sirius/kernel/commons/Strings.java
+++ b/src/main/java/sirius/kernel/commons/Strings.java
@@ -805,7 +805,7 @@ public class Strings {
             sb.append(input);
         }
 
-        sb.append(padding.repeat(numberOfPaddings));
+        sb.repeat(padding, numberOfPaddings);
 
         if (left && input != null) {
             sb.append(input);

--- a/src/main/java/sirius/kernel/commons/URLBuilder.java
+++ b/src/main/java/sirius/kernel/commons/URLBuilder.java
@@ -124,40 +124,6 @@ public class URLBuilder {
     }
 
     /**
-     * Adds a path part to the URL.
-     * <p>
-     * Once the first parameter has been added, the path can no longer be modified. Also, the part itself can (but
-     * shouldn't) contain parameters, usually led by an initial question mark.
-     *
-     * @param uriPartsToAdd the URI part to add. This should not contain a leading '/' as it is added automatically. If
-     *                      an array (vararg) is given, all components are appended to the internal {@link
-     *                      StringBuilder} without any additional characters. If this contains a '?' to add parameters,
-     *                      no more parts can be added.
-     * @return the builder itself for fluent method calls
-     * @deprecated use {@link #addSafePart(String)} or {@link #addSafeParts(String...)} instead.
-     */
-    @Deprecated(forRemoval = true)
-    public URLBuilder addPart(@Nonnull String... uriPartsToAdd) {
-        url.append(PATH_SEPARATOR);
-        for (String uriPart : uriPartsToAdd) {
-            if (Strings.isFilled(uriPart)) {
-                if (questionMark.isToggled()) {
-                    throw new IllegalStateException(Strings.apply(
-                            "Cannot add '%s'! Parameters were already added to: '%s'.",
-                            uriPart,
-                            url));
-                }
-                if (uriPart.contains(QUERY_SEPARATOR)) {
-                    questionMark.toggle();
-                }
-                url.append(uriPart);
-            }
-        }
-
-        return this;
-    }
-
-    /**
      * Adds a parameter to the URL.
      *
      * @param key   the name of the parameter

--- a/src/main/java/sirius/kernel/di/Injector.java
+++ b/src/main/java/sirius/kernel/di/Injector.java
@@ -96,7 +96,7 @@ public class Injector {
     private static void loadClass(Matcher matcher) {
         String relativePath = matcher.group();
         String className = relativePath.substring(0, relativePath.length() - 6).replace("/", ".");
-        if (!shoudLoadClass(className)) {
+        if (!shouldLoadClass(className)) {
             return;
         }
         try {
@@ -156,7 +156,7 @@ public class Injector {
         }
     }
 
-    private static boolean shoudLoadClass(String className) {
+    private static boolean shouldLoadClass(String className) {
         if (packageFilter.isEmpty()) {
             return true;
         }

--- a/src/main/java/sirius/kernel/di/transformers/AutoTransformLoadAction.java
+++ b/src/main/java/sirius/kernel/di/transformers/AutoTransformLoadAction.java
@@ -100,7 +100,7 @@ public class AutoTransformLoadAction implements ClassLoadAction {
                 throw Exceptions.handle()
                                 .to(Log.SYSTEM)
                                 .error(exception.getCause())
-                                .withSystemErrorMessage("Failed to transform %s (%s) to %s - An error occured when"
+                                .withSystemErrorMessage("Failed to transform %s (%s) to %s - An error occurred when"
                                                         + " invoking the constructor: %s (%s)",
                                                         source,
                                                         sourceType,
@@ -110,7 +110,7 @@ public class AutoTransformLoadAction implements ClassLoadAction {
                 throw Exceptions.handle()
                                 .to(Log.SYSTEM)
                                 .error(exception)
-                                .withSystemErrorMessage("Failed to transform %s (%s) to %s - An error occured when"
+                                .withSystemErrorMessage("Failed to transform %s (%s) to %s - An error occurred when"
                                                         + " invoking the constructor: %s (%s)",
                                                         source,
                                                         sourceType,

--- a/src/main/java/sirius/kernel/health/Average.java
+++ b/src/main/java/sirius/kernel/health/Average.java
@@ -15,7 +15,7 @@ import java.util.concurrent.atomic.AtomicLong;
 /**
  * Represents an average value over a given set of values.
  * <p>
- * Using the <tt>maxSamples</tt> can be used to implement something like a sliding avarage as the value is
+ * Using the <tt>maxSamples</tt> can be used to implement something like a sliding average as the value is
  * reset (computed) once the counter hits <tt>maxSamples</tt>.
  */
 public class Average {
@@ -28,7 +28,7 @@ public class Average {
 
     /**
      * Creates a new average which averages up to {@link #DEFAULT_MAX_SAMPLES} and then computes the effective
-     * avarage and resets the counter to 1 using that value.
+     * average and resets the counter to 1 using that value.
      */
     public Average() {
         this(DEFAULT_MAX_SAMPLES);
@@ -36,7 +36,7 @@ public class Average {
 
     /**
      * Creates a new average which averages up to <tt>maxSamples</tt> and then computes the effective
-     * avarage and resets the counter to 1 using that value.
+     * average and resets the counter to 1 using that value.
      *
      * @param maxSamples the max number of samples to use in order to build the average
      */

--- a/src/main/java/sirius/kernel/info/Module.java
+++ b/src/main/java/sirius/kernel/info/Module.java
@@ -93,9 +93,9 @@ public class Module {
     }
 
     /**
-     * Creates a string which is unqiue for each released version (based on its commit hash and build number).
+     * Creates a string which is unique for each released version (based on its commit hash and build number).
      * <p>
-     * For development and test systems which have neigther of both, a random string is created for each
+     * For development and test systems which have neither of both, a random string is created for each
      * running instance.
      *
      * @return a unique version string per release or instance

--- a/src/main/java/sirius/kernel/nls/NLS.java
+++ b/src/main/java/sirius/kernel/nls/NLS.java
@@ -119,19 +119,6 @@ public class NLS {
     }
 
     /**
-     * Returns the currently active language as two-letter code.
-     *
-     * @return a two-letter code of the currently active language, as defined in
-     * {@link sirius.kernel.async.CallContext#getLanguage()}
-     * @deprecated call {@link #getCurrentLanguage()} instead.
-     */
-    @Nonnull
-    @Deprecated
-    public static String getCurrentLang() {
-        return getCurrentLanguage();
-    }
-
-    /**
      * Returns the two-letter code of the default language. Provided via the config in {@code nls.defaultLanguage}
      * <p>
      * If this is set to "auto" the default language will be the system language.
@@ -1370,34 +1357,6 @@ public class NLS {
      */
     public static String convertDuration(Duration duration) {
         return convertDuration(duration, true, true);
-    }
-
-    /**
-     * Converts a given time range in milliseconds to a human-readable format using the current language
-     *
-     * @param duration       the duration in milliseconds
-     * @param includeSeconds determines whether to include seconds or to ignore everything below minutes
-     * @param includeMillis  determines whether to include milliseconds or to ignore everything below seconds
-     * @return a string representation of the given duration in days, hours, minutes and,
-     * if enabled, seconds and milliseconds
-     */
-    @Deprecated(forRemoval = true)
-    public static String convertDuration(long duration, boolean includeSeconds, boolean includeMillis) {
-        return convertDuration(Duration.ofMillis(duration), includeSeconds, includeMillis);
-    }
-
-    /**
-     * Converts the given duration to a human-readable format including seconds and milliseconds using the current language
-     * <p>
-     * This is a boilerplate method for {@link #convertDuration(long, boolean, boolean)} with
-     * <tt>includeSeconds</tt> and <tt>includeMillis</tt> set to <tt>true</tt>.
-     *
-     * @param duration the duration in milliseconds
-     * @return a string representation of the given duration in days, hours, minutes, seconds and milliseconds
-     */
-    @Deprecated(forRemoval = true)
-    public static String convertDuration(long duration) {
-        return convertDuration(Duration.ofMillis(duration));
     }
 
     private static void appendDurationValue(StringBuilder result, String key, long value) {

--- a/src/main/java/sirius/kernel/settings/ExtendedSettings.java
+++ b/src/main/java/sirius/kernel/settings/ExtendedSettings.java
@@ -77,7 +77,7 @@ public class ExtendedSettings extends Settings {
      * Creates a new settings object based on the given config.
      *
      * @param config the config to wrap
-     * @param strict determines if the config is strict. A strict config will log an error if an unkown path is
+     * @param strict determines if the config is strict. A strict config will log an error if an unknown path is
      *               requested
      */
     public ExtendedSettings(Config config, boolean strict) {

--- a/src/main/java/sirius/kernel/timer/EndOfDayTask.java
+++ b/src/main/java/sirius/kernel/timer/EndOfDayTask.java
@@ -36,7 +36,7 @@ public interface EndOfDayTask {
     /**
      * Returns a short name which is used for logging.
      * <p>
-     * Note that the name shoudln't contain any whitespace so that the task can be started out of schedule by
+     * Note that the name shouldn't contain any whitespace so that the task can be started out of schedule by
      * invoking the {@link sirius.kernel.health.console.EndOfDayCommand eod command} in the console.
      *
      * @return the name of the task

--- a/src/main/java/sirius/kernel/timer/Timers.java
+++ b/src/main/java/sirius/kernel/timer/Timers.java
@@ -317,7 +317,7 @@ public class Timers implements Startable, Stoppable {
      * Executes all daily timers (implementing <tt>EveryDay</tt>) if applicable, or if outOfASchedule is <tt>true</tt>.
      *
      * @param currentHour determines the current hour. Most probably this will be wall-clock time. However, for
-     *                    out-of-schedule eecution, this can be set to any value.
+     *                    out-of-schedule execution, this can be set to any value.
      * @param forced      if <b>true</b>, the task will be executed even if it is not scheduled according to
      *                    {@link Orchestration#shouldRunDailyTask(String)}
      */

--- a/src/main/java/sirius/kernel/tokenizer/ParseException.java
+++ b/src/main/java/sirius/kernel/tokenizer/ParseException.java
@@ -40,11 +40,11 @@ public class ParseException extends Exception {
         if (errors.size() == 1) {
             return new ParseException(errors.getFirst().getMessage(), errors);
         } else if (errors.size() > 1) {
-            return new ParseException(String.format("%d errors occured. First: %s",
+            return new ParseException(String.format("%d errors occurred. First: %s",
                                                     errors.size(),
                                                     errors.getFirst().getMessage()), errors);
         } else {
-            return new ParseException("An unknown error occured", errors);
+            return new ParseException("An unknown error occurred", errors);
         }
     }
 

--- a/src/main/java/sirius/kernel/tokenizer/Tokenizer.java
+++ b/src/main/java/sirius/kernel/tokenizer/Tokenizer.java
@@ -491,7 +491,7 @@ public class Tokenizer extends Lookahead<Token> {
     /**
      * Determines if the given Char is a symbol character.
      * <p>
-     * By default these are all non-control characters, which don't match any other class (letter, digit, whitepsace)
+     * By default, these are all non-control characters, which don't match any other class (letter, digit, whitespace)
      *
      * @param ch the character to check
      * @return <tt>true</tt> if the given character is a valid symbol character, <tt>false</tt> otherwise
@@ -793,7 +793,7 @@ public class Tokenizer extends Lookahead<Token> {
     /**
      * Specifies if pipes are treat as brackets.
      *
-     * @param treatSinglePipeAsBracket <tt>true</tt> to treat pipes as bracked, <tt>false</tt> otherwise
+     * @param treatSinglePipeAsBracket <tt>true</tt> to treat pipes as bracket, <tt>false</tt> otherwise
      */
     public void setTreatSinglePipeAsBracket(boolean treatSinglePipeAsBracket) {
         this.treatSinglePipeAsBracket = treatSinglePipeAsBracket;

--- a/src/main/java/sirius/kernel/xml/README.md
+++ b/src/main/java/sirius/kernel/xml/README.md
@@ -6,7 +6,7 @@ Provides ways of reading and writing XML data.
 
 The [XMLReader](XMLReader.java) provides a convenient way for processing large XML files. A set of handlers can
 be registered on node names. The reader will then parse given data using a memory efficient SAX parser. Once a
-node with a regisered handler is found, the sub DOM is parsed and sent to the handler as [StructuredNode](StructuredNode.java).
+node with a registered handler is found, the sub DOM is parsed and sent to the handler as [StructuredNode](StructuredNode.java).
 
 Using this approach, very large XML files can be processed with almost constant memory overhead.
 

--- a/src/test/kotlin/sirius/kernel/testutil/Reflections.kt
+++ b/src/test/kotlin/sirius/kernel/testutil/Reflections.kt
@@ -22,7 +22,7 @@ class Reflections {
          * @param functionName of the function which is about to be called
          * @param args the arguments used to call the function. No argument may be null!
          * @return the result of the called function
-         * @throws any execption which may be called by the given function
+         * @throws any exception which may be called by the given function
          */
         fun <T : Any> callPrivateMethod(instance: T, functionName: String, vararg args: Any): Any? {
             try {


### PR DESCRIPTION
## BREAKING CHANGES

**Removed Deprecated APIs:**

- `CallContext.get(Class)` -> `getOrCreateSubContext(Class)`
- `CallContext.set(Class, C)` -> `setSubContext(Class, SubContext)`
- `CallContext.getLang()` -> `getLanguage()`
- `CallContext.getFallbackLang()` -> `getFallbackLanguage()`
- `CallContext.setLang(String)` -> `setLanguage(String)`
- `CallContext.setLangIfEmpty(String)` -> `setLanguageIfEmpty(String)`
- `CallContext.deferredSetLang(Consumer)` -> `deferredSetLanguage(Consumer)`
- `CallContext.resetLang()` -> `resetLanguage()`
- `CallContext.setFallbackLang(String)` -> `setFallbackLanguage(String)`
- `Promise.asFuture()` -> use `CombinedFuture#asFuture()`
- `Strings.isHttpUrl(String)` -> `Urls.isHttpUrl(String)`
- `Strings.isHttpsUrl(String)` -> `Urls.isHttpsUrl(String)`
- `Strings.urlEncode(String)` -> `Urls.encode(String)`
- `Strings.urlDecode(String)` -> `Urls.decode(String)`
- `URLBuilder.addPart(String...)` -> `addSafePart(String)` / `addSafeParts(String...)`
- `NLS.getCurrentLang()` -> `getCurrentLanguage()`
- `NLS.convertDuration(long, boolean, boolean)` -> `convertDuration(Duration, boolean, boolean)`
- `NLS.convertDuration(long)` -> `convertDuration(Duration)`

### Additional Notes

- This PR fixes or works on following ticket(s): [SIRI-1220](https://scireum.myjetbrains.com/youtrack/issue/SIRI-1220)

### Checklist

- [x] Code change has been tested and works locally
- [x] Code was formatted via IntelliJ and follows SonarLint & [best practices](https://scireum.myjetbrains.com/youtrack/articles/MISC-A-16/CodeStyle-JavaDoc)
- [ ] Patch Tasks: Is local execution of Patch Tasks necessary? If so, please also mark the PR with the tag.
