### PR TITLE
Adds Dependabot cooldowns for Maven and GitHub Actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -14,6 +14,13 @@ updates:
     - scireum-mvn
   schedule:
     interval: daily
+  cooldown:
+    default-days: 2
+    semver-major-days: 14
+    semver-minor-days: 5
+    semver-patch-days: 2
+    exclude:
+      - "com.scireum:sirius-*"
   ignore:
     # ignore Maven APIs/SPIs
     - dependency-name: org.apache.maven:*
@@ -28,5 +35,7 @@ updates:
   directory: "/"
   schedule:
     interval: "daily"
+  cooldown:
+    default-days: 2
   labels:
     - "🛠️ Maintenance"


### PR DESCRIPTION
### Description

Dependabot now waits before opening update PRs so we get fewer same-day bumps when upstream releases land. Maven uses tiered cooldowns (14 days for major, 5 for minor, 2 for patch/default), with an exclude so our own sirius modules are excluded. GitHub Actions uses a 2-day default cooldown, as it does not support the SemVer syntax.

This is done for multiple reasons:
- Can help against supply chain attacks that increased in recent times
- We don't want to beta test major/breaking releases -> longer wait
- Bundling of upgrades of dependencies with high frequency of releases
