### PR TITLE
Tests: Makes failing lifecycle participants break the build again

### DIFF
--- a/src/test/java/sirius/kernel/SiriusTestSessionListener.java
+++ b/src/test/java/sirius/kernel/SiriusTestSessionListener.java
@@ -1,0 +1,34 @@
+/*
+ * Made with all the love in the world
+ * by scireum in Stuttgart, Germany
+ *
+ * Copyright by scireum GmbH
+ * https://www.scireum.de - info@scireum.de
+ */
+
+package sirius.kernel;
+
+import org.junit.platform.launcher.LauncherSession;
+import org.junit.platform.launcher.LauncherSessionListener;
+
+/**
+ * Terminates the framework once all tests of a launcher session have been executed.
+ * <p>
+ * This is the counterpart of {@link SiriusExtension} which boots the framework for the first test requiring it.
+ * Performing the teardown here (instead of within a JVM shutdown hook) is essential: an exception thrown by a
+ * {@link TestLifecycleParticipant} escapes into the build tool and therefore actually fails the test run. Within a
+ * shutdown hook the very same exception would be swallowed, as the build result has already been determined by then.
+ * <p>
+ * This listener is registered via the {@link java.util.ServiceLoader} (see
+ * {@code META-INF/services/org.junit.platform.launcher.LauncherSessionListener}), so it is also picked up by
+ * downstream projects which use this test-jar.
+ */
+public class SiriusTestSessionListener implements LauncherSessionListener {
+
+    @Override
+    public void launcherSessionClosed(LauncherSession session) {
+        // Note that build tools may open additional sessions (e.g. to scan the classpath) which never start the
+        // framework at all. TestHelper.performTearDown() turns into a no-op for those.
+        TestHelper.performTearDown();
+    }
+}

--- a/src/test/java/sirius/kernel/TestHelper.java
+++ b/src/test/java/sirius/kernel/TestHelper.java
@@ -11,6 +11,9 @@ package sirius.kernel;
 import sirius.kernel.di.Injector;
 import sirius.kernel.nls.NLS;
 
+import java.util.ArrayList;
+import java.util.List;
+
 /**
  * Initializes and stops Sirius as part of the tests.
  */
@@ -40,7 +43,6 @@ public class TestHelper {
             Injector.context()
                     .getPriorizedParts(TestLifecycleParticipant.class)
                     .forEach(TestLifecycleParticipant::beforeTests);
-            Runtime.getRuntime().addShutdownHook(new Thread(() -> tearDown(testClass)));
         }
     }
 
@@ -58,14 +60,39 @@ public class TestHelper {
     /**
      * Performs the framework termination. This can be used from test extensions before a fresh framework instance
      * will to be started.
+     * <p>
+     * Note that this reports <b>all</b> failing {@link TestLifecycleParticipant participants} instead of stopping at
+     * the first one, as a single build usually wants to learn about every problem at once. The framework is stopped
+     * in any case, even if a participant fails.
+     *
+     * @throws RuntimeException if one or more {@link TestLifecycleParticipant participants} failed. Additional
+     *                          failures are attached as suppressed exceptions.
      */
     public static void performTearDown() {
-        Injector.context()
-                .getPriorizedParts(TestLifecycleParticipant.class)
-                .forEach(TestLifecycleParticipant::afterTests);
-        Sirius.stop();
+        if (frameworkStarter == null) {
+            // The framework was never started (e.g. a test run without any test requiring it)...
+            return;
+        }
 
-        frameworkStarter = null;
+        try {
+            List<RuntimeException> failures = new ArrayList<>();
+            for (TestLifecycleParticipant participant : Injector.context()
+                                                                .getPriorizedParts(TestLifecycleParticipant.class)) {
+                try {
+                    participant.afterTests();
+                } catch (RuntimeException failure) {
+                    failures.add(failure);
+                }
+            }
 
+            if (!failures.isEmpty()) {
+                RuntimeException firstFailure = failures.getFirst();
+                failures.stream().skip(1).forEach(firstFailure::addSuppressed);
+                throw firstFailure;
+            }
+        } finally {
+            Sirius.stop();
+            frameworkStarter = null;
+        }
     }
 }

--- a/src/test/java/sirius/kernel/TestHelper.java
+++ b/src/test/java/sirius/kernel/TestHelper.java
@@ -58,8 +58,9 @@ public class TestHelper {
     }
 
     /**
-     * Performs the framework termination. This can be used from test extensions before a fresh framework instance
-     * will to be started.
+     /**
+      * Performs the framework termination. This can be used from test extensions before a fresh framework instance
+      * will be started.
      * <p>
      * Note that this reports <b>all</b> failing {@link TestLifecycleParticipant participants} instead of stopping at
      * the first one, as a single build usually wants to learn about every problem at once. The framework is stopped

--- a/src/test/java/sirius/kernel/TestHelper.java
+++ b/src/test/java/sirius/kernel/TestHelper.java
@@ -36,8 +36,13 @@ public class TestHelper {
      */
     public static void setUp(Class<?> testClass) {
         if (frameworkStarter == null) {
-            frameworkStarter = testClass;
             Sirius.start(new Setup(Setup.Mode.TEST, Sirius.class.getClassLoader()));
+
+            // Only mark the framework as started once the startup actually succeeded. Otherwise a failed startup
+            // would leave a marker behind which makes performTearDown() run at the end of the launcher session and
+            // thus bury the original error under a misleading secondary failure...
+            frameworkStarter = testClass;
+
             NLS.setDefaultLanguage("de");
 
             Injector.context()

--- a/src/test/resources/META-INF/services/org.junit.platform.launcher.LauncherSessionListener
+++ b/src/test/resources/META-INF/services/org.junit.platform.launcher.LauncherSessionListener
@@ -1,0 +1,1 @@
+sirius.kernel.SiriusTestSessionListener


### PR DESCRIPTION
### Description

TestHelper registered the framework teardown as a JVM shutdown hook, which made TestLifecycleParticipant#afterTests() effectively dead code: the hook runs after Surefire has collected its results and written its reports, so an exception thrown there can neither influence the exit code nor reach the log. Both ReportBrokenTemplates and ReportBrokenStylesheets in sirius-web as well as ReportMissingTranslations therefore reported nothing at all, and broken templates and missing translations have been shipping unnoticed.

The hook was introduced when the tests were migrated to the JUnit 5 engines. Back then the JUnit 4 suites still invoked TestHelper.tearDown() explicitly and reported teardown failures to the RunNotifier, so the checks kept working. Removing TestSuite and later ScenarioSuite dropped those last callers and left the shutdown hook as the only remaining path.

The teardown now runs in a LauncherSessionListener registered via the ServiceLoader. Its launcherSessionClosed() callback is invoked while Surefire is still in control of the fork, hence an exception escapes into the build and fails it as intended. As the registration travels with the test-jar, downstream projects pick it up without any additional configuration.

Beside that, performTearDown() now stops the framework within a finally block and collects the failures of all participants instead of aborting at the first one. Previously a throwing participant skipped Sirius.stop() entirely, leaving the framework running.

Note that this re-arms checks which have been silently disabled for years, so downstream builds are expected to turn red until their templates, stylesheets and translations have been fixed.

### Checklist

- [x] Code change has been tested and works locally
- [x] Code was formatted via IntelliJ and follows SonarLint & [best practices](https://scireum.myjetbrains.com/youtrack/articles/MISC-A-16/CodeStyle-JavaDoc)
- [ ] Patch Tasks: Is local execution of Patch Tasks necessary? If so, please also mark the PR with the tag.
