### PR TITLE
Make Amount#hashCode return the same code for numerically equal values

### DIFF
--- a/src/main/java/sirius/kernel/commons/Amount.java
+++ b/src/main/java/sirius/kernel/commons/Amount.java
@@ -656,7 +656,8 @@ public class Amount extends Number implements Comparable<Amount> {
 
     @Override
     public int hashCode() {
-        return value != null ? value.hashCode() : 0;
+        BigDecimal valueWithoutTrailingZeros = fetchAmountWithoutTrailingZeros();
+        return valueWithoutTrailingZeros != null ? valueWithoutTrailingZeros.hashCode() : 0;
     }
 
     /// Compares this amount against the given amount and returns the one with the lower value.

--- a/src/test/kotlin/sirius/kernel/commons/AmountTest.kt
+++ b/src/test/kotlin/sirius/kernel/commons/AmountTest.kt
@@ -15,6 +15,7 @@ import org.junit.jupiter.params.converter.ConvertWith
 import org.junit.jupiter.params.provider.CsvSource
 import sirius.kernel.SiriusExtension
 import sirius.kernel.async.CallContext
+import java.math.BigDecimal
 import java.math.RoundingMode
 import kotlin.test.assertEquals
 import kotlin.test.assertTrue
@@ -389,5 +390,12 @@ class AmountTest {
         result: String,
     ) {
         assertEquals(result, a.fetchAmountWithoutTrailingZeros()?.toPlainString())
+    }
+
+    @Test
+    fun `hashCode() works as expected`() {
+        val a = Amount.of(1)
+        val b = Amount.ofRounded(BigDecimal(1))
+        assertEquals(b.hashCode(), a.hashCode())
     }
 }


### PR DESCRIPTION
### Description
The hashCode function until now internally just calls `BigDecimal#hashCode` which states:

> Two `BigDecimal` objects that are numerically equal but differ in scale (like 2.0 and 2.00) will generally **not** have the same hash code.

This might be okay for `BigDecimal`, which also doesn't treat those two values as equal.

However, `Amount#equals` checks for mathmatical equality. The `hashCode` function should behave the same.

### Additional Notes

- This PR fixes or works on following ticket(s): [SE-15356](https://scireum.myjetbrains.com/youtrack/issue/SE-15356)

### Checklist

- [x] Code change has been tested and works locally
- [x] Code was formatted via IntelliJ and follows SonarLint & [best practices](https://scireum.myjetbrains.com/youtrack/articles/MISC-A-16/CodeStyle-JavaDoc)
- [ ] Patch Tasks: Is local execution of Patch Tasks necessary? If so, please also mark the PR with the tag.
