### PR TITLE
Keeps a StructuredOutput's result as a JsonNode instead of writing it out

### DIFF
--- a/src/main/java/sirius/kernel/xml/JsonNodeStructuredOutput.java
+++ b/src/main/java/sirius/kernel/xml/JsonNodeStructuredOutput.java
@@ -1,0 +1,206 @@
+/*
+ * Made with all the love in the world
+ * by scireum in Remshalden, Germany
+ *
+ * Copyright by scireum GmbH
+ * http://www.scireum.de - info@scireum.de
+ */
+
+package sirius.kernel.xml;
+
+import sirius.kernel.commons.Amount;
+import sirius.kernel.commons.Json;
+import sirius.kernel.commons.NumberFormat;
+import sirius.kernel.commons.Strings;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.node.ArrayNode;
+import tools.jackson.databind.node.JsonNodeFactory;
+import tools.jackson.databind.node.ObjectNode;
+
+import java.math.BigDecimal;
+import java.util.ArrayDeque;
+import java.util.Deque;
+import java.util.function.Consumer;
+
+/**
+ * Assembles a {@link JsonNode} in memory instead of writing to a stream.
+ * <p>
+ * The implementations of {@link StructuredOutput} write their result somewhere as it is produced: into an XML document
+ * ({@link XMLStructuredOutput}) or into a response body (<tt>JSONStructuredOutput</tt> in <tt>sirius-web</tt>). This
+ * one keeps it, so that code written to describe a payload can also be used where the payload is needed as a
+ * <b>value</b> — embedded into a larger document, handed to a client library, compared against an expected result in a
+ * test, or post-processed before it is sent.
+ * <p>
+ * The point is that the description of the payload does not have to be written twice. A service which renders its
+ * result via a {@code StructuredOutput} can be handed one of these, and whatever it emits comes back as a node:
+ * <pre>{@code
+ * ObjectNode node = JsonNodeStructuredOutput.collect(output -> {
+ *     output.property("id", customer.getId());
+ *     output.property("name", customer.getName());
+ * });
+ * }</pre>
+ * <p>
+ * Values are rendered as the streaming JSON output renders them: a {@link JsonNode} is embedded as it is, an
+ * {@link Amount} becomes a number or {@code null}, booleans and numbers stay unquoted, and everything else goes
+ * through {@link #transformToStringRepresentation(Object)}, so dates and enums look the same on either.
+ */
+public class JsonNodeStructuredOutput extends AbstractStructuredOutput {
+
+    private static final JsonNodeFactory NODES = JsonNodeFactory.instance;
+
+    private final Deque<JsonNode> stack = new ArrayDeque<>();
+    private JsonNode root;
+
+    /**
+     * Collects what a writer emits into an object.
+     * <p>
+     * Wraps the whole life cycle — begin, write, end — around the given writer, which is what a caller interested in
+     * the resulting node rather than in the output itself is after.
+     *
+     * @param writer writes the payload, exactly as it would write it to any other output
+     * @return the assembled object
+     */
+    public static ObjectNode collect(Consumer<StructuredOutput> writer) {
+        JsonNodeStructuredOutput output = new JsonNodeStructuredOutput();
+        output.beginResult();
+        writer.accept(output);
+        output.endResult();
+        return (ObjectNode) output.getNode();
+    }
+
+    @Override
+    public StructuredOutput beginResult() {
+        beginObject("result");
+        return this;
+    }
+
+    @Override
+    public StructuredOutput beginResult(String name) {
+        // the name would become the root element in XML; a JSON document has no such element to name
+        return beginResult();
+    }
+
+    /**
+     * Closes the wrapping object and the output, mirroring how the streaming JSON output ends a response.
+     */
+    @Override
+    public void endResult() {
+        endObject();
+        super.endResult();
+    }
+
+    /**
+     * Returns the assembled payload once the output has been ended.
+     *
+     * @return the node which was written, or {@code null} if nothing was written at all
+     */
+    public JsonNode getNode() {
+        return root;
+    }
+
+    @Override
+    protected void startObject(String name, Attribute... attributes) {
+        ObjectNode node = Json.createObject();
+        attach(name, node);
+        stack.push(node);
+        if (attributes != null) {
+            for (Attribute attribute : attributes) {
+                property(attribute.getName(), attribute.getValue());
+            }
+        }
+    }
+
+    @Override
+    protected void endObject(String name) {
+        pop();
+    }
+
+    @Override
+    protected void startArray(String name) {
+        ArrayNode node = Json.createArray();
+        attach(name, node);
+        stack.push(node);
+    }
+
+    @Override
+    protected void endArray(String name) {
+        pop();
+    }
+
+    @Override
+    public void writeProperty(String name, Object data) {
+        if (data instanceof JsonNode node) {
+            put(name, node);
+            return;
+        }
+        if (data == null) {
+            put(name, NODES.nullNode());
+            return;
+        }
+        if (data instanceof Amount amount) {
+            put(name,
+                amount.isFilled() ? NODES.numberNode(new BigDecimal(amount.toMachineString())) : NODES.nullNode());
+            return;
+        }
+        if (data instanceof Boolean value) {
+            put(name, NODES.booleanNode(value));
+            return;
+        }
+        if (data instanceof Number value) {
+            put(name, NODES.numberNode(new BigDecimal(value.toString())));
+            return;
+        }
+        put(name, NODES.stringNode(transformToStringRepresentation(data)));
+    }
+
+    /**
+     * Writes an amount which {@link #amountProperty(String, Amount, NumberFormat, boolean)} has already formatted.
+     * <p>
+     * A machine-formatted amount becomes a number, as it does when the output is streamed. One formatted for a human
+     * ("1.234,50") cannot be, and is kept as a string rather than being rejected or written out as something a parser
+     * would refuse — a caller which asked for a localized format presumably means it.
+     */
+    @Override
+    protected void writeAmountProperty(String name, String formattedAmount) {
+        if (Strings.isEmpty(formattedAmount)) {
+            put(name, NODES.nullNode());
+            return;
+        }
+
+        try {
+            put(name, NODES.numberNode(new BigDecimal(formattedAmount)));
+        } catch (NumberFormatException exception) {
+            put(name, NODES.stringNode(formattedAmount));
+        }
+    }
+
+    /**
+     * Hangs a freshly opened container into its parent, or records it as the root when there is none.
+     */
+    private void attach(String name, JsonNode node) {
+        if (stack.isEmpty()) {
+            root = node;
+            return;
+        }
+        put(name, node);
+    }
+
+    /**
+     * Adds a value to the current container: named when it is an object, positional when it is an array.
+     */
+    private void put(String name, JsonNode value) {
+        JsonNode current = stack.peek();
+        if (current instanceof ArrayNode array) {
+            array.add(value);
+        } else if (current instanceof ObjectNode object) {
+            object.set(name, value);
+        }
+    }
+
+    private void pop() {
+        JsonNode finished = stack.pop();
+        if (stack.isEmpty()) {
+            root = finished;
+        }
+    }
+}

--- a/src/main/java/sirius/kernel/xml/README.md
+++ b/src/main/java/sirius/kernel/xml/README.md
@@ -25,6 +25,10 @@ by [sirius-web](https://github.com/scireum/sirius-web) which provides implementa
 to read and write JSON data. This way services can be created which are capable of reading and
 writing both.
 
+[JsonNodeStructuredOutput](JsonNodeStructuredOutput.java) implements the same interface but keeps the result
+in memory as a `JsonNode` instead of writing it out. Code which describes a payload via a **StructuredOutput**
+can therefore also be used where the payload is needed as a value rather than as a response.
+
 ## Webservices
 
 To call XML based REST services the [XMLCall](XMLCall.java) can be used which sends and/or

--- a/src/test/kotlin/sirius/kernel/xml/JsonNodeStructuredOutputTest.kt
+++ b/src/test/kotlin/sirius/kernel/xml/JsonNodeStructuredOutputTest.kt
@@ -1,0 +1,116 @@
+/*
+ * Made with all the love in the world
+ * by scireum in Remshalden, Germany
+ *
+ * Copyright by scireum GmbH
+ * http://www.scireum.de - info@scireum.de
+ */
+
+package sirius.kernel.xml
+
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import sirius.kernel.SiriusExtension
+import sirius.kernel.commons.Amount
+import sirius.kernel.commons.Json
+import sirius.kernel.commons.NumberFormat
+import java.time.LocalDate
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+/**
+ * Tests the [JsonNodeStructuredOutput] class.
+ */
+@ExtendWith(SiriusExtension::class)
+internal class JsonNodeStructuredOutputTest {
+
+    @Test
+    fun `Objects, arrays and nesting end up in the resulting node`() {
+        val node = JsonNodeStructuredOutput.collect { output ->
+            output.property("name", "Test")
+            output.beginObject("child")
+            output.property("name", "Child")
+            output.endObject()
+            output.beginArray("items")
+            output.beginObject("item")
+            output.property("pos", 1)
+            output.endObject()
+            output.beginObject("item")
+            output.property("pos", 2)
+            output.endObject()
+            output.endArray()
+        }
+
+        assertEquals("Test", node.path("name").asString())
+        assertEquals("Child", node.path("child").path("name").asString())
+        assertEquals(2, node.path("items").size())
+        assertEquals(2, node.path("items").path(1).path("pos").asInt())
+    }
+
+    @Test
+    fun `Numbers and booleans are written unquoted`() {
+        val node = JsonNodeStructuredOutput.collect { output ->
+            output.property("count", 42)
+            output.property("ratio", 1.5)
+            output.property("flag", true)
+            output.property("text", "42")
+        }
+
+        assertTrue(node.path("count").isNumber, "count is a number")
+        assertTrue(node.path("ratio").isNumber, "ratio is a number")
+        assertTrue(node.path("flag").isBoolean, "flag is a boolean")
+        assertTrue(node.path("text").isString, "a string which looks like a number stays a string")
+    }
+
+    @Test
+    fun `A null property becomes a null node rather than being left out`() {
+        val node = JsonNodeStructuredOutput.collect { output -> output.property("value", null) }
+
+        assertTrue(node.has("value"), "the property is present")
+        assertTrue(node.path("value").isNull, "and it is null")
+    }
+
+    @Test
+    fun `A node handed in is embedded as it is`() {
+        val embedded = Json.createObject().put("inner", "value")
+
+        val node = JsonNodeStructuredOutput.collect { output -> output.property("payload", embedded) }
+
+        assertEquals("value", node.path("payload").path("inner").asString())
+    }
+
+    @Test
+    fun `Values are rendered the way the streaming output renders them`() {
+        val node = JsonNodeStructuredOutput.collect { output ->
+            output.property("date", LocalDate.of(2026, 8, 4))
+            output.property("amount", Amount.of(12.5))
+            output.property("empty", Amount.NOTHING)
+        }
+
+        assertEquals("2026-08-04", node.path("date").asString())
+        assertTrue(node.path("amount").isNumber, "a filled amount is a number")
+        assertEquals(12.5, node.path("amount").asDouble())
+        assertTrue(node.path("empty").isNull, "an empty amount is null")
+    }
+
+    @Test
+    fun `A formatted amount is a number, unless it was formatted for a human`() {
+        // the streaming output writes the formatted value straight into the document, so a machine format is what
+        // callers are expected to ask for -- a localized one must not turn into something a parser would refuse
+        val node = JsonNodeStructuredOutput.collect { output ->
+            output.amountProperty("machine", Amount.of(1234.5), NumberFormat.MACHINE_TWO_DECIMAL_PLACES, false)
+            output.amountProperty("human", Amount.of(1234.5), NumberFormat.TWO_DECIMAL_PLACES, false)
+        }
+
+        assertTrue(node.path("machine").isNumber, "a machine-formatted amount is a number")
+        assertEquals(1234.5, node.path("machine").asDouble())
+        assertTrue(node.path("human").isString, "a localized amount is kept verbatim as a string")
+    }
+
+    @Test
+    fun `An output which was never written to yields nothing`() {
+        val output = JsonNodeStructuredOutput()
+
+        assertEquals(null, output.node)
+    }
+}


### PR DESCRIPTION
### Description

Adds `JsonNodeStructuredOutput`, an implementation of `StructuredOutput` which keeps its result in memory as a
`JsonNode` instead of writing it out.

Every implementation so far writes the result somewhere as it is produced — `XMLStructuredOutput` into a
document, sirius-web's `JSONStructuredOutput` into a response body. So code written to describe a payload can
only be used where that payload *is* the answer. Wanting the same payload as a **value** — to embed it into a
larger document, to hand it to a client library, to compare it against an expectation in a test, or to
post-process it before sending — meant describing it a second time, and two descriptions of one thing drift
apart without anybody noticing.

```java
ObjectNode node = JsonNodeStructuredOutput.collect(output -> {
    output.property("id", customer.getId());
    output.property("name", customer.getName());
});
```

Values render as the streaming JSON output renders them, so the two agree on dates, enums, amounts and what
stays unquoted.

**Amounts are the one place where they deliberately differ.** `JSONStructuredOutput` writes the formatted value
straight into the document, so an amount formatted with a localized `NumberFormat` ("1.234,50") produces
invalid JSON there. Here a machine-formatted amount becomes a number and anything else is kept verbatim as a
string, so no caller can produce a document a parser would refuse. Both directions are covered by a test.

No existing behaviour is touched: this only adds a class, its test and a paragraph in the package README.

### On the package, which is worth a word

The class lands in `sirius.kernel.xml`, and a JSON implementation in a package named `xml` reads oddly. That is
deliberate rather than careless, and I would rather point at it than let it look accidental:

- The package is where the format-neutral part of the abstraction already lives — `StructuredOutput`,
  `StructuredInput`, `AbstractStructuredOutput`, `Attribute` — so the implementation sits with the contract it
  implements.
- `sirius.kernel.commons`, next to `Json` and `CSVWriter`, would read better. But the class extends
  `AbstractStructuredOutput`, so putting it there would introduce the first `commons` → `xml` package
  dependency; today the arrow points only the other way.
- A neutral package would be the honest fix, but only if `StructuredOutput` and friends moved into it as well,
  and that breaks every import in every downstream product.

For the same reason it is worth noting where the sibling implementation is: `JSONStructuredOutput` lives in
`sirius.web.services`, although it depends on nothing from sirius-web — only on `sirius.kernel.*`, `java.io` and
Jackson. So one interface currently has implementations in three places, and this PR makes that three rather
than two.

If you would rather have it elsewhere, say where and I will move it — the naming is yours to decide, and none
of this is load-bearing for the change itself.

### Additional Notes

- No ticket — this came out of a downstream product that needed the same payload description for a response and
  for a value, and the gap is general enough to belong here rather than in the product.

### Checklist

- [x] Code change has been tested and works locally
- [ ] Code was formatted via IntelliJ and follows SonarLint & [best practices](https://scireum.myjetbrains.com/youtrack/articles/MISC-A-16/CodeStyle-JavaDoc)
- [x] Patch Tasks: Is local execution of Patch Tasks necessary? If so, please also mark the PR with the tag.
