### PR TITLE
Offers propertyIfFilled on every structured output 🕳️

### DIFF
--- a/src/main/java/sirius/kernel/xml/AbstractStructuredOutput.java
+++ b/src/main/java/sirius/kernel/xml/AbstractStructuredOutput.java
@@ -355,6 +355,14 @@ public abstract class AbstractStructuredOutput implements StructuredOutput {
     }
 
     @Override
+    public StructuredOutput propertyIfFilled(@Nonnull String name, @Nullable Object data) {
+        if (data != null) {
+            property(name, data);
+        }
+        return this;
+    }
+
+    @Override
     public StructuredOutput amountProperty(@Nonnull String name,
                                            @Nullable Amount amount,
                                            @Nonnull NumberFormat numberFormat,

--- a/src/main/java/sirius/kernel/xml/StructuredOutput.java
+++ b/src/main/java/sirius/kernel/xml/StructuredOutput.java
@@ -101,6 +101,22 @@ public interface StructuredOutput {
     StructuredOutput nullsafeProperty(@Nonnull String name, @Nullable Object data);
 
     /**
+     * Adds a property to the current object, unless there is no value for it.
+     * <p>
+     * This will create a property only if the specified data object is not null. Else no property is created.
+     * <p>
+     * In contrast to {@link #nullsafeProperty(String, Object)}, which represents a missing value as an empty string,
+     * this leaves the property out of the output altogether. That is the appropriate choice wherever an empty string is
+     * not a value the reader would accept - a field documented as an optional number or timestamp being the common
+     * case, as a consumer otherwise finds the field present and parses a number out of {@code ""}.
+     *
+     * @param name the name of the property
+     * @param data the value of the property, or <tt>null</tt> to omit the property entirely
+     * @return the output itself for fluent method calls
+     */
+    StructuredOutput propertyIfFilled(@Nonnull String name, @Nullable Object data);
+
+    /**
      * Starts an array with is added to the current object as "name".
      *
      * @param name the name of the array

--- a/src/main/java/sirius/kernel/xml/StructuredOutput.java
+++ b/src/main/java/sirius/kernel/xml/StructuredOutput.java
@@ -109,6 +109,12 @@ public interface StructuredOutput {
      * this leaves the property out of the output altogether. That is the appropriate choice wherever an empty string is
      * not a value the reader would accept - a field documented as an optional number or timestamp being the common
      * case, as a consumer otherwise finds the field present and parses a number out of {@code ""}.
+     * <p>
+     * Despite the name, the test is for <tt>null</tt> alone and <b>not</b>
+     * {@link sirius.kernel.commons.Strings#isFilled(Object)}: an empty string is a value here and is written out. A
+     * caller which wants those omitted too has to normalise them to <tt>null</tt> itself. Widening the test would
+     * silently drop elements from documents that existing callers already produce, which is why the narrower meaning
+     * is kept and stated here rather than inferred from the name.
      *
      * @param name the name of the property
      * @param data the value of the property, or <tt>null</tt> to omit the property entirely

--- a/src/main/java/sirius/kernel/xml/XMLStructuredOutput.java
+++ b/src/main/java/sirius/kernel/xml/XMLStructuredOutput.java
@@ -307,23 +307,6 @@ public class XMLStructuredOutput extends AbstractStructuredOutput {
     }
 
     /**
-     * Adds a property to the current object.
-     * <p>
-     * This will create a property only if the specified data object is not null.
-     * Else no property is created.
-     *
-     * @param name the name of the property
-     * @param data the value of the property
-     * @return the output itself for fluent method calls
-     */
-    public StructuredOutput propertyIfFilled(@Nonnull String name, @Nullable Object data) {
-        if (data != null) {
-            property(name, data);
-        }
-        return this;
-    }
-
-    /**
      * Adds a property containing attributes to the current object.
      *
      * @param name       the name of the property

--- a/src/test/kotlin/sirius/kernel/xml/JsonNodeStructuredOutputTest.kt
+++ b/src/test/kotlin/sirius/kernel/xml/JsonNodeStructuredOutputTest.kt
@@ -76,11 +76,14 @@ internal class JsonNodeStructuredOutputTest {
         val node = JsonNodeStructuredOutput.collect { output ->
             output.propertyIfFilled("kept", 42)
             output.propertyIfFilled("skipped", null)
+            output.propertyIfFilled("blank", "")
             output.nullsafeProperty("emptied", null)
         }
 
         assertEquals(42, node.path("kept").asInt())
         assertFalse(node.has("skipped"), "the property is absent rather than null")
+        // the test is for null alone, not Strings.isFilled -- an empty string is a value and is written out
+        assertTrue(node.has("blank"), "an empty string is kept")
         assertEquals("", node.path("emptied").asString(), "whereas nullsafeProperty writes an empty string")
     }
 

--- a/src/test/kotlin/sirius/kernel/xml/JsonNodeStructuredOutputTest.kt
+++ b/src/test/kotlin/sirius/kernel/xml/JsonNodeStructuredOutputTest.kt
@@ -16,6 +16,7 @@ import sirius.kernel.commons.Json
 import sirius.kernel.commons.NumberFormat
 import java.time.LocalDate
 import kotlin.test.assertEquals
+import kotlin.test.assertFalse
 import kotlin.test.assertTrue
 
 /**
@@ -68,6 +69,19 @@ internal class JsonNodeStructuredOutputTest {
 
         assertTrue(node.has("value"), "the property is present")
         assertTrue(node.path("value").isNull, "and it is null")
+    }
+
+    @Test
+    fun `A property which is not filled is left out entirely`() {
+        val node = JsonNodeStructuredOutput.collect { output ->
+            output.propertyIfFilled("kept", 42)
+            output.propertyIfFilled("skipped", null)
+            output.nullsafeProperty("emptied", null)
+        }
+
+        assertEquals(42, node.path("kept").asInt())
+        assertFalse(node.has("skipped"), "the property is absent rather than null")
+        assertEquals("", node.path("emptied").asString(), "whereas nullsafeProperty writes an empty string")
     }
 
     @Test

--- a/src/test/kotlin/sirius/kernel/xml/JsonNodeStructuredOutputTest.kt
+++ b/src/test/kotlin/sirius/kernel/xml/JsonNodeStructuredOutputTest.kt
@@ -84,7 +84,9 @@ internal class JsonNodeStructuredOutputTest {
         assertFalse(node.has("skipped"), "the property is absent rather than null")
         // the test is for null alone, not Strings.isFilled -- an empty string is a value and is written out
         assertTrue(node.has("blank"), "an empty string is kept")
-        assertEquals("", node.path("emptied").asString(), "whereas nullsafeProperty writes an empty string")
+        // has() first: a missing node answers asString() with "" as well, so the value alone proves nothing
+        assertTrue(node.has("emptied"), "whereas nullsafeProperty writes the property")
+        assertEquals("", node.path("emptied").asString(), "and writes it as an empty string")
     }
 
     @Test


### PR DESCRIPTION
### Description

`propertyIfFilled(String, Object)` has existed on `XMLStructuredOutput` for a long time, but only there — `StructuredOutput` never declared it. So the JSON outputs (`JSONStructuredOutput` in sirius-web, `JsonNodeStructuredOutput` here) had no way to leave a property out, and callers who needed that reached for `nullsafeProperty`, which writes an empty **string**, or wrote their own two-line helper.

This moves the declaration to `StructuredOutput` and the body to `AbstractStructuredOutput`. No new concept and no new name — just the method it already had, available where it was missing.

**Nothing else has to change.** `AbstractStructuredOutput` is the only direct implementor of the interface across sirius-kernel, -db, -web and -biz; `JsonNodeStructuredOutput`, `XMLStructuredOutput`, `XMLGenerator` and sirius-web's `JSONStructuredOutput` all extend it. `XMLStructuredOutput` keeps only its variant carrying `Attribute...`, since attributes are XML's alone, and loses the two-arg copy it now inherits.

Not a breaking change for anything in the stack. Strictly speaking a class outside these repos implementing `StructuredOutput` directly would now have to provide the method — a `default` method would avoid even that, but this interface has none, so I followed the pattern of `nullsafeProperty` instead. Say the word if you'd rather have the `default`.

### Why the test stays `!= null` rather than `Strings.isFilled`

The name invites the wider reading, so the contract is now spelled out in the javadoc instead of being inferred from it. Deliberately **not** widened:

- Every caller in the stack is an XML export — 155 of them, all in oxomi, none in sirius-kernel/-db/-web/-biz — and several feed external catalogue standards (ARGE DQR, BMEcat). Widening the test would drop their empty elements from documents already in circulation. That deserves its own ticket and an export regression pass, not a ride-along here.
- The heaviest group of callers (43 sites via `ArgeImportHelper.formatDate`/`formatDecimal`) already `return null` for a missing value, i.e. they were written against exactly this contract.
- A caller wanting the wider behaviour can normalise to `null` itself, which is what the javadoc now says.

The test pins both sides: a null value is left out, an empty string is kept.

The javadoc says why the two sit side by side: an empty string is a *value*, and on a field documented as an optional number or timestamp it is one the reader cannot make sense of — it finds the field present and parses a number out of `""`.

### Additional Notes

- No ticket — this came out of the review of scireum/oxomi#13191, where a local `omittableProperty` helper was written for exactly this and @sabieber rightly asked why it wasn't on `StructuredOutput`.
- This PR is related to PR: https://github.com/scireum/oxomi/pull/13191

### Checklist

- [x] Code change has been tested and works locally
- [ ] Code was formatted via IntelliJ and follows SonarLint & [best practices](https://scireum.myjetbrains.com/youtrack/articles/MISC-A-16/CodeStyle-JavaDoc)
- [x] Patch Tasks: Is local execution of Patch Tasks necessary? If so, please also mark the PR with the tag.

**On the checklist, precisely:** the three touched Java files were run through the IntelliJ formatter against `.idea/codeStyles/Project.xml` and report *"well formed"*. **SonarLint was not run** — there is no headless path for it — so that box is left unticked rather than ticked on half the claim; please run *Analyze VCS Changed Files* if it is required. No patch tasks are needed: the change adds a method and moves no data.

**Tests:** `JsonNodeStructuredOutputTest` gains one case covering all three behaviours side by side — a filled value written, a null one left out, and `nullsafeProperty` still writing `""`. Mutation-checked: flipping the null check to `if (true)` fails it. 16 tests green in `sirius.kernel.xml`.

🤖 Authored by an automated Claude Code session on @jakobvogel's machine, not written by @jakobvogel personally.
