### PR TITLE
Lets a caller of Strings.shorten choose the length and the indicator

### DIFF
--- a/src/main/java/sirius/kernel/commons/Strings.java
+++ b/src/main/java/sirius/kernel/commons/Strings.java
@@ -48,7 +48,7 @@ public class Strings {
     private static final String DEFAULT_OMISSION_INDICATOR = "...";
 
     /**
-     * Determines how many chars {@link #shorten(String, int)} may give up to reach a word boundary.
+     * Defines how many chars {@link #shorten(String, int)} may give up to reach a word boundary.
      */
     private static final int DEFAULT_MAX_CUTBACK = 10;
 

--- a/src/main/java/sirius/kernel/commons/Strings.java
+++ b/src/main/java/sirius/kernel/commons/Strings.java
@@ -43,6 +43,16 @@ public class Strings {
     private static final String ELLIPSIS = "…";
 
     /**
+     * Names the omission indicator used by {@link #shorten(String, int)}.
+     */
+    private static final String DEFAULT_OMISSION_INDICATOR = "...";
+
+    /**
+     * Determines how many chars {@link #shorten(String, int)} may give up to reach a word boundary.
+     */
+    private static final int DEFAULT_MAX_CUTBACK = 10;
+
+    /**
      * Contains the marker/signal which should be used to depict that the string has been truncated.
      */
     private static final String TRUNCATED_SIGNAL = ELLIPSIS + "[" + ELLIPSIS + "]" + ELLIPSIS;
@@ -682,29 +692,86 @@ public class Strings {
     }
 
     /**
-     * Shortens a string to the given number of chars,
-     * cutting of at most half of the string and adding ... if something has been cut of.
+     * Shortens a string which is longer than the given number of chars, cutting back to a word boundary if one is
+     * within reach and appending <tt>...</tt> to signal the omission.
+     * <p>
+     * Note that <tt>maxUnshortenedLength</tt> is the length up to which a string is returned unchanged, not the length
+     * of the result: a shortened string is cut one char short of it and then carries the three chars of the omission
+     * indicator, so the result may be two chars longer. Use
+     * {@link #shorten(String, int, int, String)} to give the result an upper bound instead.
      *
-     * @param string   string to be cut of
-     * @param numChars new maximum length of string
-     * @return the shortened string
+     * @param string               the string to shorten
+     * @param maxUnshortenedLength the length up to which the string is returned unchanged
+     * @return the given string if it is not longer than <tt>maxUnshortenedLength</tt>, otherwise a shortened one
+     * @see #shorten(String, int, int, String)
      * @see Strings#limit(Object, int)
      * @see Strings#limit(Object, int, boolean)
      */
-    public static String shorten(String string, int numChars) {
+    public static String shorten(String string, int maxUnshortenedLength) {
         if (isEmpty(string)) {
             return "";
         }
-        if (string.length() <= numChars) {
+        if (string.length() <= maxUnshortenedLength) {
             return string;
         }
-        int index = numChars - 1;
-        int maxCutoff = Math.min(string.length() / 2, 10);
-        while (numChars > 0 && Character.isLetterOrDigit(string.charAt(index)) && maxCutoff > 0) {
-            index--;
-            maxCutoff--;
+        if (maxUnshortenedLength <= 0) {
+            // nothing of the string can be kept, and computing the cut index would overflow for the smallest int
+            return DEFAULT_OMISSION_INDICATOR;
         }
-        return string.substring(0, index) + "...";
+
+        return cutBackToWordBoundary(string, maxUnshortenedLength - 1, DEFAULT_MAX_CUTBACK, DEFAULT_OMISSION_INDICATOR);
+    }
+
+    /**
+     * Shortens a string to at most the given number of chars, cutting back to a word boundary if one is within reach
+     * and appending the given indicator to signal the omission.
+     * <p>
+     * In contrast to {@link #shorten(String, int)}, the length of the indicator is reserved, so the result never
+     * exceeds <tt>maxLength</tt> -- unless <tt>maxLength</tt> leaves no room for the indicator at all, in which case
+     * the indicator alone is returned.
+     *
+     * @param string            the string to shorten
+     * @param maxLength         the maximum length of the result, including the omission indicator
+     * @param maxCutback        how many chars may be given up to reach a word boundary; never more than half of the
+     *                          string, and a longer word is cut through rather than dropped. Zero or less cuts
+     *                          wherever the length lands, without looking for a boundary at all
+     * @param omissionIndicator the string to append if something was left out, e.g. <tt>...</tt> or <tt>…</tt>
+     * @return the given string if it is not longer than <tt>maxLength</tt>, otherwise a shortened one
+     * @see #shorten(String, int)
+     */
+    public static String shorten(String string, int maxLength, int maxCutback, @Nonnull String omissionIndicator) {
+        if (isEmpty(string)) {
+            return "";
+        }
+        if (string.length() <= maxLength) {
+            return string;
+        }
+        if (maxLength <= omissionIndicator.length()) {
+            // there is no room for anything but the indicator, and the cut index would overflow for the smallest int
+            return omissionIndicator;
+        }
+
+        return cutBackToWordBoundary(string, maxLength - omissionIndicator.length(), maxCutback, omissionIndicator);
+    }
+
+    /**
+     * Cuts the given string at the given index, moving back to a word boundary if one is within reach.
+     *
+     * @param string            the string to cut
+     * @param cutIndex          the index to cut at, before looking for a word boundary
+     * @param maxCutback        how many chars may be given up to reach a word boundary
+     * @param omissionIndicator the string to append to signal the omission
+     * @return the cut string with the indicator appended
+     */
+    private static String cutBackToWordBoundary(String string, int cutIndex, int maxCutback, String omissionIndicator) {
+        int index = Math.max(0, cutIndex);
+        int remainingCutback = Math.min(string.length() / 2, maxCutback);
+        while (index > 0 && Character.isLetterOrDigit(string.charAt(index)) && remainingCutback > 0) {
+            index--;
+            remainingCutback--;
+        }
+
+        return string.substring(0, index) + omissionIndicator;
     }
 
     /**

--- a/src/test/kotlin/sirius/kernel/commons/StringsTest.kt
+++ b/src/test/kotlin/sirius/kernel/commons/StringsTest.kt
@@ -369,6 +369,84 @@ class StringsTest {
     }
 
     @Test
+    fun shorten() {
+        assertEquals("", Strings.shorten(null, 10))
+        assertEquals("", Strings.shorten("", 10))
+        assertEquals("ABCDE", Strings.shorten("ABCDE", 10))
+        assertEquals("ABCDE", Strings.shorten("ABCDE", 5))
+        // cuts back to the word boundary, which is within reach
+        assertEquals("Das ist ein Satz...", Strings.shorten("Das ist ein Satz mit Wortgrenzen", 20))
+        // no boundary within reach, so the word is cut through
+        assertEquals("Die Daten...", Strings.shorten("Die Datenbankarchitektur ist komplex", 20))
+    }
+
+    @Test
+    fun `shorten keeps its result two chars longer than the given length`() {
+        // the length is the one up to which a string is left alone, not the length of the result: callers rely on
+        // this, so it is pinned here rather than quietly corrected
+        val shortened = Strings.shorten("a b c d e f g h i j k l m n o p", 10)
+
+        assertEquals(12, shortened.length)
+        assertTrue { shortened.endsWith("...") }
+    }
+
+    @Test
+    fun `shorten survives a length shorter than the word it cuts`() {
+        // walking back to a boundary must not run off the start of the string
+        assertEquals("...", Strings.shorten("abcdef", 3))
+        assertEquals("...", Strings.shorten("abc", 0))
+        assertEquals("...", Strings.shorten("abc", -5))
+        // the smallest int makes the cut index overflow into a large positive one
+        assertEquals("...", Strings.shorten("abcdef", Int.MIN_VALUE))
+    }
+
+    @Test
+    fun `shorten with options never exceeds the given length`() {
+        assertEquals("", Strings.shorten(null, 10, 10, "…"))
+        assertEquals("", Strings.shorten("", 10, 10, "…"))
+        assertEquals("ABCDE", Strings.shorten("ABCDE", 10, 10, "…"))
+
+        val shortened = Strings.shorten("a b c d e f g h i j k l m n o p", 10, 10, "…")
+
+        assertEquals(10, shortened.length)
+        assertTrue { shortened.endsWith("…") }
+    }
+
+    @Test
+    fun `shorten with options honours the given omission indicator`() {
+        assertEquals("Das ist ein Satz…", Strings.shorten("Das ist ein Satz mit Wortgrenzen", 18, 10, "…"))
+        assertEquals(
+            "Das ist ein Satz [more]",
+            Strings.shorten("Das ist ein Satz mit Wortgrenzen", 23, 10, " [more]")
+        )
+    }
+
+    @Test
+    fun `shorten with options honours the given cutback`() {
+        // 'Wortgrenzen' is 11 chars, so it is only reached with a cutback allowing for it
+        assertEquals("Das ist ein Satz mit…", Strings.shorten("Das ist ein Satz mit Wortgrenzen hier", 28, 11, "…"))
+        assertEquals(
+            "Das ist ein Satz mit Wortgre…",
+            Strings.shorten("Das ist ein Satz mit Wortgrenzen hier", 29, 0, "…")
+        )
+    }
+
+    @Test
+    fun `shorten with options returns the indicator when there is no room for anything else`() {
+        assertEquals("…", Strings.shorten("abcdef", 1, 10, "…"))
+        assertEquals("...", Strings.shorten("abcdef", 1, 10, "..."))
+        assertEquals("…", Strings.shorten("abcdef", 0, 10, "…"))
+        // the smallest int makes the cut index overflow into a large positive one
+        assertEquals("…", Strings.shorten("abcdef", Int.MIN_VALUE, 10, "…"))
+    }
+
+    @Test
+    fun `shorten with options treats a cutback of zero or less as no cutback at all`() {
+        assertEquals("Das ist ein Satz mi…", Strings.shorten("Das ist ein Satz mit Wortgrenzen", 20, 0, "…"))
+        assertEquals("Das ist ein Satz mi…", Strings.shorten("Das ist ein Satz mit Wortgrenzen", 20, -5, "…"))
+    }
+
+    @Test
     fun truncateMiddle() {
         assertEquals("", Strings.truncateMiddle(null, 4, 4))
         assertEquals("", Strings.truncateMiddle(null, -4, 4))


### PR DESCRIPTION
### Description

`Strings.shorten` offered no say over the two things a caller most often wants to decide: how far back it may reach for a word boundary, and what marks the omission. The indicator was hard-coded to three dots — while the very same class reaches for the typographic `…` in `limit`.

```java
// existing — behaviour untouched, parameter renamed only
public static String shorten(String string, int maxUnshortenedLength)

// new — the result never exceeds maxLength, as the indicator's length is reserved
public static String shorten(String string, int maxLength, int maxCutback, String omissionIndicator)
```

Both now delegate to one private `cutBackToWordBoundary`, so there is a single implementation. The existing method passes cut position `maxUnshortenedLength - 1` and `"..."`; the new one passes `maxLength - omissionIndicator.length()`.

**No breaking change — deliberately.** The existing method keeps its exact semantics, including the quirk that its length is the one up to which a string is returned *unchanged*, so a shortened result runs two chars past it (cut at `length - 1`, then three chars of indicator). Callers may well depend on that, so it stays. The new overload gets the honest contract instead of inheriting the quirk.

**The parameter rename.** `numChars` becomes `maxUnshortenedLength`, because that is what the code actually tests (`string.length() <= numChars`), whereas the Javadoc called it *"new maximum length of string"* — which it never was. A parameter name binds neither the source nor the binary contract; its meaning does. So only the name moves, and the Javadoc now states the two-char overrun rather than denying it.

#### A crash, fixed

The loop guarded `numChars > 0` — which never changes inside the loop — where it meant `index > 0`. Two ways to fall off the start of the string:

- a length shorter than the word being cut through, so the backtrack walks `index` to `-1` and `charAt` throws
- a length of zero or negative, so `index` starts negative and `substring` throws before the loop is ever entered

`Strings.shorten("abcdef", 3)` and `Strings.shorten("abc", 0)` both threw `StringIndexOutOfBoundsException`.

#### Verified against the previous implementation

Rather than reason about equivalence, I ran the old implementation and the new one against 300k random inputs (lengths 0–40, limits −3 to 41):

```
compared=259175  identical=259175  mismatches=0  (legacy threw on 40825 inputs, now handled)
```

Identical on every input where it returned at all; the only difference is that it no longer throws.

#### Tests

`shorten` had **none** — which is presumably how both the wrong Javadoc and the crash survived. Seven cases added, following the existing style in `StringsTest`, including one that deliberately pins the two chars the existing length runs over, with a comment saying callers may rely on it, so it is not quietly "corrected" later.

Full suite: 463 tests, 0 failures.

#### Note

This is a public API addition to a foundational library, so the overload is permanent surface. The caller that motivated it (a link preview that wants a hard 300-character cap ending in `…` rather than `...`) lives in memoio and will follow in its own PR, once a release carries this.

### Additional Notes

- This PR fixes or works on following ticket(s): [MIO-6573](https://scireum.myjetbrains.com/youtrack/issue/MIO-6573) — no separate SIRI ticket; this came out of the memoio-side work on link previews.

### Checklist

- [x] Code change has been tested and works locally
- [ ] Code was formatted via IntelliJ and follows SonarLint & [best practices](https://scireum.myjetbrains.com/youtrack/articles/MISC-A-16/CodeStyle-JavaDoc) — **the IntelliJ formatter was run** on both changed files (both report *Formatted well*, and I checked the diff touches nothing outside the method and its Javadoc), but **SonarLint was not**: it cannot run headlessly, so *Analyze VCS Changed Files* still needs a pass in the IDE.
- [ ] Patch Tasks: none required.

🤖 Generated with [Claude Code](https://claude.com/claude-code)